### PR TITLE
Rename Raw keyrings to be inline with specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ SRCS = \
 	   src/SDK/CMM/DefaultCMM.dfy \
 	   src/SDK/CMM/Defs.dfy \
 	   src/SDK/Deserialize.dfy \
-	   src/SDK/Keyring/AESKeyring.dfy \
+	   src/SDK/Keyring/RawAESKeyring.dfy \
 	   src/SDK/Keyring/Defs.dfy \
-	   src/SDK/Keyring/RSAKeyring.dfy \
+	   src/SDK/Keyring/RawRSAKeyring.dfy \
 	   src/SDK/Materials.dfy \
 	   src/SDK/MessageHeader.dfy \
 	   src/SDK/Serialize.dfy \

--- a/src/Main.dfy
+++ b/src/Main.dfy
@@ -1,6 +1,6 @@
 include "SDK/ToyClient.dfy"
-//include "SDK/Keyring/AESKeyring.dfy"
-include "SDK/Keyring/RSAKeyring.dfy"
+//include "SDK/Keyring/RawAESKeyring.dfy"
+include "SDK/Keyring/RawRSAKeyring.dfy"
 //include "SDK/Keyring/MultiKeyring.dfy"
 //include "SDK/Keyring/Defs.dfy"
 include "SDK/Materials.dfy"
@@ -17,11 +17,11 @@ module Main {
   import DefaultCMMDef
   import Client = ToyClientDef
   import RSA = RSAEncryption
-  import RSAKeyringDef
+  import RawRSAKeyringDef
   import Materials
   //import AES = AESEncryption
   //import opened Cipher
-  //import opened AESKeyringDef
+  //import opened RawAESKeyringDef
   //import K = KeyringDefs
   //import opened MultiKeyringDef
   //import opened SDKDefs
@@ -31,9 +31,9 @@ module Main {
   /*
   method RunToyClient() {
     var ek, dk := RSA.RSA.RSAKeygen(2048, RSA.PKCS1);
-    var rsa_kr := new RSAKeyring(byteseq_of_string("namespace"), byteseq_of_string("name"), RSA.PKCS1, 2048, Some(ek), Some(dk));
+    var rsa_kr := new RawRSAKeyring(byteseq_of_string("namespace"), byteseq_of_string("name"), RSA.PKCS1, 2048, Some(ek), Some(dk));
     var k2 := AES.AES.AESKeygen(AES_GCM_256);
-    var aes_kr := new AESKeyring(byteseq_of_string("namespace"), byteseq_of_string("name2"), k2, AES_GCM_256);
+    var aes_kr := new RawAESKeyring(byteseq_of_string("namespace"), byteseq_of_string("name2"), k2, AES_GCM_256);
     var kr_children := new K.Keyring[1](_ => rsa_kr);
     var kr := new MultiKeyring(aes_kr, kr_children);
     var cmm := new DefaultCMM.OfKeyring(kr);
@@ -82,7 +82,7 @@ module Main {
     var namespace := StringToByteSeq("namespace");
     var name := StringToByteSeq("MyKeyring");
     var ek, dk := RSA.RSA.RSAKeygen(2048, RSA.PKCS1);
-    var keyring := new RSAKeyringDef.RSAKeyring(namespace, name, RSA.RSAPaddingMode.PKCS1, 2048, Some(ek), Some(dk));
+    var keyring := new RawRSAKeyringDef.RawRSAKeyring(namespace, name, RSA.RSAPaddingMode.PKCS1, 2048, Some(ek), Some(dk));
     var cmm := new DefaultCMMDef.DefaultCMM.OfKeyring(keyring);
     var client := new Client.Client.OfCMM(cmm);
 

--- a/src/SDK/Keyring/RawAESKeyring.dfy
+++ b/src/SDK/Keyring/RawAESKeyring.dfy
@@ -7,7 +7,7 @@ include "../../Crypto/Random.dfy"
 include "../../Crypto/AESEncryption.dfy"
 include "../Materials.dfy"
 
-module AESKeyring{
+module RawAESKeyring{
   import opened StandardLibrary
   import opened UInt = StandardLibrary.UInt
   import AESEncryption
@@ -21,7 +21,7 @@ module AESKeyring{
   const IV_LEN_LEN       := 4;
   const VALID_ALGORITHMS := {EncryptionSuites.AES_GCM_128, EncryptionSuites.AES_GCM_192, EncryptionSuites.AES_GCM_256}
 
-  class AESKeyring extends KeyringDefs.Keyring {
+  class RawAESKeyring extends KeyringDefs.Keyring {
     const keyNamespace: string
     const keyName: string
     const wrappingKey: seq<uint8>

--- a/src/SDK/Keyring/RawRSAKeyring.dfy
+++ b/src/SDK/Keyring/RawRSAKeyring.dfy
@@ -6,7 +6,7 @@ include "../AlgorithmSuite.dfy"
 include "../../Crypto/Random.dfy"
 include "../../Crypto/RSAEncryption.dfy"
 
-module RSAKeyringDef {
+module RawRSAKeyringDef {
   import opened StandardLibrary
   import opened UInt = StandardLibrary.UInt
   import KeyringDefs
@@ -15,7 +15,7 @@ module RSAKeyringDef {
   import Materials
   import Random
 
-  class RSAKeyring extends KeyringDefs.Keyring {
+  class RawRSAKeyring extends KeyringDefs.Keyring {
     const keyNamespace: seq<uint8>
     const keyName: seq<uint8>
     const paddingMode: RSA.RSAPaddingMode


### PR DESCRIPTION
*Issue #, if available:* #71

*Description of changes:* Add Raw to keyring names where applicable. 
```
perl -pi -w -e 's/AESKeyring/RawAESKeyring/g;' src/**/*
perl -pi -w -e 's/RSAKeyring/RawRSAKeyring/g;' src/**/*
```

*Testing:* `make verify && make build`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
