### PR TITLE
fix: Add JS build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/.DS_Store
 build/*
 test/**/Output/*
+/package-lock.json
+/node_modules

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ build/%.dfy.verified: src/%.dfy
 build/Main.exe: $(SRCS) $(DEPS)
 	$(DAFNY) /out:build/Main $(SRCS) $(DEPS) /compile:2 /noVerify /noIncludes && cp $(BCDLL) build/
 
+buildjs: $(SRCS)
+	$(DAFNY) /out:build/Main $(SRCS) /compile:2 /noVerify /noIncludes /compileTarget:js /spillTargetCode:1
+
 buildcs: build/Main.cs
 	csc /r:System.Numerics.dll /r:$(BCDLL) /target:exe /debug /nowarn:0164 /nowarn:0219 /nowarn:1717 /nowarn:0162 /nowarn:0168 build/Main.cs $(DEPS_CS) /out:build/Main.exe
 


### PR DESCRIPTION
Add the build target for Javascript,
and update .gitignore for Javascript.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
