### PR TITLE
Replace deprecated xbuild with msbuild in buildspec.yml

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,7 +11,7 @@ phases:
       # Get Boogie
       - git clone https://github.com/boogie-org/boogie.git
       - nuget restore boogie/Source/Boogie.sln
-      - xbuild boogie/Source/Boogie.sln
+      - msbuild boogie/Source/Boogie.sln
       # Get Dafny
       - git clone https://github.com/microsoft/dafny.git
       - msbuild dafny/Source/Dafny.sln


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* We were using `xbuild` to build Boogie. `xbuild` has been deprecated, and no longer works with `xbuild`. Moved to `msbuild` per guidance.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
