### PR TITLE
Make Signature.ECDSA.Verify module-level in Dafny

### DIFF
--- a/src/Crypto/Signature.dfy
+++ b/src/Crypto/Signature.dfy
@@ -40,13 +40,6 @@ module {:extern "Signature"} Signature {
             ensures res.Some? ==> IsSignKeypair(s, res.get.1, res.get.0)
 //            ensures VKOfSK(s, sk) == vk
 
-
-      // TODO: This function should be moved out to the module level, like method "Sign". But apparently :extern in Dafny doesn't yet do this for functions.
-      // See https://github.com/dafny-lang/dafny/issues/423
-      static function method {:extern "Verify"} Verify(s: ECDSAParams, key: seq<uint8>, msg: seq<uint8>, sig: seq<uint8>): bool
-        // requires ECDSA.WfVK(s, key)
-        // requires MaxMsgLen(s).Some? ==> |msg| <= MaxMsgLen(s).get
-        // requires WfSig(s, sig)
     }
 
     method {:extern "Signature.ECDSA", "Sign"} Sign(s: ECDSAParams, key: seq<uint8>, digest: seq<uint8>) returns (sig: Option<seq<uint8>>)
@@ -54,6 +47,11 @@ module {:extern "Signature"} Signature {
       ensures sig.Some? ==> |sig.get| == s.SignatureLength() as int
       // ensures sig.Some? ==> WfSig(s, sig.get)
       // ensures sig.Some? ==> forall vk :: WfVK(s, vk) ==> IsSignKeypair(s, sk, vk) ==> Verify(s, vk, m, sig.get) == true
+
+    function method {:extern "Signature.ECDSA", "Verify"} Verify(s: ECDSAParams, key: seq<uint8>, msg: seq<uint8>, sig: seq<uint8>): bool
+      // requires ECDSA.WfVK(s, key)
+      // requires MaxMsgLen(s).Some? ==> |msg| <= MaxMsgLen(s).get
+      // requires WfSig(s, sig)
 
     method {:extern "Signature.ECDSA", "Digest"} Digest(s: ECDSAParams, msg: seq<uint8>) returns (digest: seq<uint8>)
 }

--- a/src/SDK/Client.dfy
+++ b/src/SDK/Client.dfy
@@ -164,7 +164,7 @@ module ESDKClient {
         var sig :- rd.ReadExact(signatureLength as nat);
         // verify signature
         var digest := Signature.Digest(ecdsaParams, msg);
-        var signatureVerified := Signature.ECDSA.Verify(ecdsaParams, decMat.verificationKey.get, digest, sig);
+        var signatureVerified := Signature.Verify(ecdsaParams, decMat.verificationKey.get, digest, sig);
         if !signatureVerified {
           return Failure("signature not verified");
         }


### PR DESCRIPTION
*Description of changes:*

Now that https://github.com/dafny-lang/dafny/issues/423 has been fixed in Dafny, the
`Verify` method can be moved to be a sibling of `Sign`, that is, it can be moved from
inside the Dafny `ECDSA` class to become a module-level function in module `Signature`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
