### PR TITLE
Make strength and padding ghost in RSA Private/Public key constructors

### DIFF
--- a/src/Crypto/RSAEncryption.dfy
+++ b/src/Crypto/RSAEncryption.dfy
@@ -36,7 +36,7 @@ module {:extern "RSAEncryption"} RSAEncryption {
 
   // PrivateKey represents an extension of Key for RSA private keys to aid with type safety
   class PrivateKey extends Key {
-    constructor(pem: seq<uint8>, strength: StrengthBits, padding: PaddingMode)
+    constructor(pem: seq<uint8>, ghost strength: StrengthBits, ghost padding: PaddingMode)
     requires |pem| > 0
     requires GetBytes(strength) >= MinStrengthBytes(padding)
     requires PEMGeneratedWithStrength(pem, strength)
@@ -55,7 +55,7 @@ module {:extern "RSAEncryption"} RSAEncryption {
 
   // PublicKey represents an extension of Key for RSA public keys to aid with type safety
   class PublicKey extends Key {
-    constructor(pem: seq<uint8>, strength: StrengthBits, padding: PaddingMode)
+    constructor(pem: seq<uint8>, ghost strength: StrengthBits, ghost padding: PaddingMode)
     requires |pem| > 0
     requires GetBytes(strength) >= MinStrengthBytes(padding)
     requires PEMGeneratedWithStrength(pem, strength)


### PR DESCRIPTION
*Description of changes:*
This fixes an issue where ghost variables for Dafny in RSA Public/private keys are not ghost in the constructor and therefore are generated in the compiled code (despite never being used).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
