### PR TITLE
fix: Add missing build step to restore Dafny packages

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,6 +15,7 @@ phases:
       - msbuild boogie/Source/Boogie.sln
       # Get Dafny
       - git clone https://github.com/microsoft/dafny.git
+      - nuget restore dafny/Source/Dafny.sln
       - msbuild dafny/Source/Dafny.sln
       - export PATH="$PWD/dafny/Binaries:$PATH"
       # Get Z3


### PR DESCRIPTION
I added this dependency in a recent Dafny change: https://github.com/dafny-lang/dafny/pull/464

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
