### PR TITLE
feat: Upgrade to dafny.msbuild 0.2.0

### DIFF
--- a/src/AWSEncryptionSDK.csproj
+++ b/src/AWSEncryptionSDK.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="dafny.msbuild" Version="0.1.1" />
+    <PackageReference Include="dafny.msbuild" Version="0.2.0" />
     <PackageReference Include="AWSSDK.Core" Version="3.3.104.1" />
     <PackageReference Include="AWSSDK.KeyManagementService" Version="3.3.103" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5.2" />

--- a/test/AWSEncryptionSDKTests.csproj
+++ b/test/AWSEncryptionSDKTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dafny.msbuild" Version="0.1.1" />
+    <PackageReference Include="dafny.msbuild" Version="0.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
This makes the new -p:VerifyDafnyJobs=X parameter available, for explicitly setting the verification parallelism.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
