### PR TITLE
WIP: Use Dafny's improved :-

### DIFF
--- a/test/Crypto/Signature.dfy
+++ b/test/Crypto/Signature.dfy
@@ -7,25 +7,25 @@ module TestSignature {
   import opened UInt = StandardLibrary.UInt
   import Signature
 
-  method YCompression(s: Signature.ECDSAParams, fieldSize: nat) returns (r: Result<()>) {
+  method YCompression(s: Signature.ECDSAParams, fieldSize: nat) returns (r: TestResult) {
     var res := Signature.ECDSA.KeyGen(s);
     if res == None {
-      return Failure("KeyGen failed");
+      return TestFailure("KeyGen failed");
     }
     var (public, secret) := res.get;
     // This is the declared postcondition of the natively implemented KenGen method, plus a condition
     // about zero-padding:
-    var _ :- Require(0 < |secret|);
-    var _ :- Require(|public| == 1 + (fieldSize + 7) / 8);  // 1 byte for y; x zero-padded up to the field size
-    var _ :- Require(public[0] == 2 || public[0] == 3);  // public key uses y compression
-    return Success(());
+    :- Require(0 < |secret|);
+    :- Require(|public| == 1 + (fieldSize + 7) / 8);  // 1 byte for y; x zero-padded up to the field size
+    :- Require(public[0] == 2 || public[0] == 3);  // public key uses y compression
+    return TestSuccess;
   }
 
-  method {:test} YCompression384() returns (r: Result<()>) {
+  method {:test} YCompression384() returns (r: TestResult) {
     r := YCompression(Signature.ECDSA_P384, 384);
   }
 
-  method {:test} YCompression256() returns (r: Result<()>) {
+  method {:test} YCompression256() returns (r: TestResult) {
     r := YCompression(Signature.ECDSA_P256, 256);
   }
 }

--- a/test/KMS/Integration.dfy
+++ b/test/KMS/Integration.dfy
@@ -63,11 +63,11 @@ module IntegTestKMS {
     }
   }
 
-  method {:test} TestEndToEnd() returns (r: Result<()>) {
+  method {:test} TestEndToEnd() returns (r: TestResult) {
     var namespace :- UTF8.Encode("namespace");
     var name :- UTF8.Encode("MyKeyring");
     var generatorStr := SHARED_TEST_KEY_ARN;
-    var _ :- Require(KMSUtils.ValidFormatCMK(generatorStr));
+    :- Require(KMSUtils.ValidFormatCMK(generatorStr));
     var generator: KMSUtils.CustomerMasterKey := generatorStr;
     var clientSupplier := new KMSUtils.DefaultClientSupplier();
     var keyring := new KMSKeyringDef.KMSKeyring(clientSupplier, [], Some(generator), []);

--- a/test/Keyring/KMSKeyring.dfy
+++ b/test/Keyring/KMSKeyring.dfy
@@ -10,33 +10,33 @@ module TestKMSKeyring {
   import opened UInt = StandardLibrary.UInt
   import KMSKeyringDef
   import KMSUtils
-  method {:test} TestRegionParseValidInput() returns (r: Result<()>) {
+  method {:test} TestRegionParseValidInput() returns (r: TestResult) {
     var cmk := "arn:aws:kms:us-west-1:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f";
-    var _ :- Require(KMSUtils.ValidFormatCMK(cmk));
+    :- Require(KMSUtils.ValidFormatCMK(cmk));
     var res :- KMSKeyringDef.RegionFromKMSKeyARN(cmk);
     r := RequireEqual("us-west-1", res);
   }
-  method {:test} TestRegionParseValidInputWildPartition() returns (r: Result<()>) {
+  method {:test} TestRegionParseValidInputWildPartition() returns (r: TestResult) {
     var cmk := "arn:xxx:kms:us-west-1:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f";
-    var _ :- Require(KMSUtils.ValidFormatCMK(cmk));
+    :- Require(KMSUtils.ValidFormatCMK(cmk));
     var res :- KMSKeyringDef.RegionFromKMSKeyARN(cmk);
     r := RequireEqual("us-west-1", res);
   }
-  method {:test} TestRegionParseValidInputNoPartition() returns (r: Result<()>) {
+  method {:test} TestRegionParseValidInputNoPartition() returns (r: TestResult) {
     var cmk := "arn::kms:us-west-1:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f";
-    var _ :- Require(KMSUtils.ValidFormatCMK(cmk));
+    :- Require(KMSUtils.ValidFormatCMK(cmk));
     var res :- KMSKeyringDef.RegionFromKMSKeyARN(cmk);
     r := RequireEqual("us-west-1", res);
   }
-  method {:test} TestRegionParseValidInputAliasArn() returns (r: Result<()>) {
+  method {:test} TestRegionParseValidInputAliasArn() returns (r: TestResult) {
     var cmk := "arn:aws:kms:us-west-1:658956600833:alias/EncryptDecrypt";
-    var _ :- Require(KMSUtils.ValidFormatCMK(cmk));
+    :- Require(KMSUtils.ValidFormatCMK(cmk));
     var res :- KMSKeyringDef.RegionFromKMSKeyARN(cmk);
     r := RequireEqual("us-west-1", res);
   }
-  method {:test} TestRegionParseBadInputAlias() returns (r: Result<()>) {
+  method {:test} TestRegionParseBadInputAlias() returns (r: TestResult) {
     var cmk := "alias/EncryptDecrypt";
-    var _ :- Require(KMSUtils.ValidFormatCMK(cmk));
+    :- Require(KMSUtils.ValidFormatCMK(cmk));
     var res := KMSKeyringDef.RegionFromKMSKeyARN(cmk);
     r := Require(res.Failure? && res.error == "Malformed ARN");
   }

--- a/test/SDK/Client.dfy
+++ b/test/SDK/Client.dfy
@@ -23,7 +23,7 @@ module {:extern "TestClient"} TestClient {
   import UTF8
   import Base64
 
-  method EncryptDecryptTest(cmm: CMMDefs.CMM) returns (r: Result<()>)
+  method EncryptDecryptTest(cmm: CMMDefs.CMM) returns (r: TestResult)
     requires cmm.Valid()
   {
     var msg :- UTF8.Encode("hello");
@@ -48,7 +48,7 @@ module {:extern "TestClient"} TestClient {
     r := RequireEqual(msg, d);
   }
 
-  method {:test} HappyPath() returns (r: Result<()>) {
+  method {:test} HappyPath() returns (r: TestResult) {
     var namespace :- UTF8.Encode("namespace");
     var name :- UTF8.Encode("MyKeyring");
 

--- a/test/SDK/Keyring/MultiKeyring.dfy
+++ b/test/SDK/Keyring/MultiKeyring.dfy
@@ -15,7 +15,7 @@ module TestMultiKeying {
   import AlgorithmSuite
   import UTF8
 
-  method {:test} TestOnEncryptOnDecryptWithGenerator() returns (r: Result<()>) {
+  method {:test} TestOnEncryptOnDecryptWithGenerator() returns (r: TestResult) {
     // TODO: mock children keyrings
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
@@ -32,9 +32,9 @@ module TestMultiKeying {
     // Encryption
     var onEncryptResult :- multiKeyring.OnEncrypt(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryptionContext, None);
     // Check EDK list is as expected
-    var _ :- Require(onEncryptResult.Some? && |onEncryptResult.get.encryptedDataKeys| == 2);
+    :- Require(onEncryptResult.Some? && |onEncryptResult.get.encryptedDataKeys| == 2);
     // Check keyringTrace is as expected
-    var _ :- Require(
+    :- Require(
        && |onEncryptResult.get.keyringTrace| == 3
        && onEncryptResult.get.keyringTrace[0] == child1Keyring.GenerateTraceEntry()
        && onEncryptResult.get.keyringTrace[1] == child1Keyring.EncryptTraceEntry()
@@ -48,9 +48,9 @@ module TestMultiKeying {
     // First edk decryption
     var onDecryptResult :- multiKeyring.OnDecrypt(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryptionContext, [edk1]);
     // Check plaintextDataKey is as expected
-    var _ :- Require(onDecryptResult.Some? && onDecryptResult.get.plaintextDataKey == pdk);
+    :- Require(onDecryptResult.Some? && onDecryptResult.get.plaintextDataKey == pdk);
     // Check keyringTrace is as expected
-    var _ :- Require(
+    :- Require(
        && |onDecryptResult.get.keyringTrace| == 1
        && onDecryptResult.get.keyringTrace[0] == child1Keyring.DecryptTraceEntry()
     );
@@ -58,7 +58,7 @@ module TestMultiKeying {
     // Second edk decryption
     onDecryptResult :- multiKeyring.OnDecrypt(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryptionContext, [edk2]);
     // Check plaintextDataKey is as expected
-    var _ :- Require(onDecryptResult.Some? && onDecryptResult.get.plaintextDataKey == pdk);
+    :- Require(onDecryptResult.Some? && onDecryptResult.get.plaintextDataKey == pdk);
     // Check keyringTrace is as expected
     r := Require(
        && |onDecryptResult.get.keyringTrace| == 1
@@ -66,7 +66,7 @@ module TestMultiKeying {
     );
   }
 
-  method {:test} TestOnEncryptOnDecryptWithoutGenerator() returns (r: Result<()>) {
+  method {:test} TestOnEncryptOnDecryptWithoutGenerator() returns (r: TestResult) {
     // TODO: mock children keyrings and move encrypt <-> decrypt test into new test
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
@@ -85,9 +85,9 @@ module TestMultiKeying {
     // Encryption
     var onEncryptResult :- multiKeyring.OnEncrypt(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryptionContext, Some(pdk));
     // Check plaintextDataKey is as expected
-    var _ :- Require(onEncryptResult.Some? && onEncryptResult.get.plaintextDataKey == pdk);
+    :- Require(onEncryptResult.Some? && onEncryptResult.get.plaintextDataKey == pdk);
     // Check keyringTrace is as expected
-    var _ :- Require(
+    :- Require(
        && |onEncryptResult.get.keyringTrace| == 2
        && onEncryptResult.get.keyringTrace[0] == child1Keyring.EncryptTraceEntry()
        && onEncryptResult.get.keyringTrace[1] == child2Keyring.EncryptTraceEntry()
@@ -99,9 +99,9 @@ module TestMultiKeying {
     // First EDK decryption
     var onDecryptResult :- multiKeyring.OnDecrypt(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryptionContext, [edk1]);
     // Check plaintextDataKey is as expected
-    var _ :- Require(onDecryptResult.Some? && onDecryptResult.get.plaintextDataKey == pdk);
+    :- Require(onDecryptResult.Some? && onDecryptResult.get.plaintextDataKey == pdk);
     // Check keyringTrace is as expected
-    var _ :- Require(
+    :- Require(
        && |onDecryptResult.get.keyringTrace| == 1
        && onDecryptResult.get.keyringTrace[0] == child1Keyring.DecryptTraceEntry()
     );
@@ -109,7 +109,7 @@ module TestMultiKeying {
     // Second EDK decryption
     onDecryptResult :- multiKeyring.OnDecrypt(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryptionContext, [edk2]);
     // Check plaintextDataKey is as expected
-    var _ :- Require(onDecryptResult.Some? && onDecryptResult.get.plaintextDataKey == pdk);
+    :- Require(onDecryptResult.Some? && onDecryptResult.get.plaintextDataKey == pdk);
     // Check keyringTrace is as expected
     r := Require(
       && |onDecryptResult.get.keyringTrace| == 1

--- a/test/SDK/Keyring/RawAESKeyring.dfy
+++ b/test/SDK/Keyring/RawAESKeyring.dfy
@@ -21,7 +21,7 @@ module TestAESKeyring {
   import UTF8
   import TestUtils
 
-  method {:test} TestOnEncryptOnDecryptGenerateDataKey() returns (r: Result<()>)
+  method {:test} TestOnEncryptOnDecryptGenerateDataKey() returns (r: TestResult)
   {
     var name :- UTF8.Encode("test Name");
     var namespace :- UTF8.Encode("test Namespace");
@@ -30,12 +30,12 @@ module TestAESKeyring {
     var valA :- UTF8.Encode("valA");
     var encryptionContext := [(keyA, valA)];
     var isValidAAD := MessageHeader.ComputeValidAAD(encryptionContext);
-    var _ :- Require(isValidAAD);
+    :- Require(isValidAAD);
 
     var wrappingAlgorithmID := AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384;
 
     var onEncryptResult :- rawAESKeyring.OnEncrypt(wrappingAlgorithmID, encryptionContext, None);
-    var _ :- Require(onEncryptResult.Some? && |onEncryptResult.get.encryptedDataKeys| == 1);
+    :- Require(onEncryptResult.Some? && |onEncryptResult.get.encryptedDataKeys| == 1);
 
     var pdk := onEncryptResult.get.plaintextDataKey;
     var edk := onEncryptResult.get.encryptedDataKeys[0];
@@ -44,7 +44,7 @@ module TestAESKeyring {
     r := Require(res.Some? && res.get.plaintextDataKey == pdk);
   }
 
-  method {:test} TestOnEncryptOnDecryptSuppliedDataKey() returns (r: Result<()>)
+  method {:test} TestOnEncryptOnDecryptSuppliedDataKey() returns (r: TestResult)
   {
     var name :- UTF8.Encode("test Name");
     var namespace :- UTF8.Encode("test Namespace");
@@ -53,14 +53,14 @@ module TestAESKeyring {
     var valA :- UTF8.Encode("valA");
     var encryptionContext := [(keyA, valA)];
     var isValidAAD := MessageHeader.ComputeValidAAD(encryptionContext);
-    var _ :- Require(isValidAAD);
+    :- Require(isValidAAD);
 
     var pdk := seq(32, i => 0);
 
     var wrappingAlgorithmID := AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384;
 
     var onEncryptResult :- rawAESKeyring.OnEncrypt(wrappingAlgorithmID, encryptionContext, Some(pdk));
-    var _ :- Require(onEncryptResult.Some? && |onEncryptResult.get.encryptedDataKeys| == 1);
+    :- Require(onEncryptResult.Some? && |onEncryptResult.get.encryptedDataKeys| == 1);
 
     var edk := onEncryptResult.get.encryptedDataKeys[0];
 
@@ -68,7 +68,7 @@ module TestAESKeyring {
     r := Require(res.Some? && res.get.plaintextDataKey == pdk);
   }
 
-  method {:test} TestOnDecryptNoEDKs() returns (r: Result<()>)
+  method {:test} TestOnDecryptNoEDKs() returns (r: TestResult)
   {
     var name :- UTF8.Encode("test Name");
     var namespace :- UTF8.Encode("test Namespace");
@@ -82,7 +82,7 @@ module TestAESKeyring {
     r := Require(res.None?);
   }
 
-  method {:test} TestOnEncryptUnserializableEC() returns (r: Result<()>)
+  method {:test} TestOnEncryptUnserializableEC() returns (r: TestResult)
   {
     var name :- UTF8.Encode("test Name");
     var namespace :- UTF8.Encode("test Namespace");
@@ -90,14 +90,14 @@ module TestAESKeyring {
     var keyA :- UTF8.Encode("keyA");
     var unserializableEncryptionContext := generateUnserializableEncryptionContext(keyA);
     var isValidAAD := MessageHeader.ComputeValidAAD(unserializableEncryptionContext);
-    var _ :- Require(!isValidAAD);
+    :- Require(!isValidAAD);
 
     var wrappingAlgorithmID := AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384;
     var onEncryptResult := rawAESKeyring.OnEncrypt(wrappingAlgorithmID, unserializableEncryptionContext, None);
     r := Require(onEncryptResult.Failure?);
   }
 
-  method {:test} TestOnDecryptUnserializableEC() returns (r: Result<()>)
+  method {:test} TestOnDecryptUnserializableEC() returns (r: TestResult)
   {
     // Set up valid EDK for decryption
     var name :- UTF8.Encode("test Name");
@@ -108,30 +108,30 @@ module TestAESKeyring {
     var encryptionContext := [(keyA, valA)];
     var wrappingAlgorithmID := AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384;
     var onEncryptResult :- rawAESKeyring.OnEncrypt(wrappingAlgorithmID, encryptionContext, None);
-    var _ :- Require(onEncryptResult.Some?);
-    var _ :- Require(|onEncryptResult.get.encryptedDataKeys| == 1);
+    :- Require(onEncryptResult.Some?);
+    :- Require(|onEncryptResult.get.encryptedDataKeys| == 1);
     var edk := onEncryptResult.get.encryptedDataKeys[0];
 
     // Set up EC that can't be serialized
     var unserializableEncryptionContext := generateUnserializableEncryptionContext(keyA);
     var isValidAAD := MessageHeader.ComputeValidAAD(unserializableEncryptionContext);
-    var _ :- Require(!isValidAAD);
+    :- Require(!isValidAAD);
 
     var onDecryptResult := rawAESKeyring.OnDecrypt(wrappingAlgorithmID, unserializableEncryptionContext, [edk]);
     r := Require(onDecryptResult.Failure?);
   }
 
-  method {:test} TestDeserializeEDKCiphertext() returns (r: Result<()>) {
+  method {:test} TestDeserializeEDKCiphertext() returns (r: TestResult) {
     var ciphertext := [0, 1, 2, 3];
     var authTag := [4, 5, 6, 7];
     var serializedEDKCiphertext := ciphertext + authTag;
     var encOutput := RawAESKeyringDef.DeserializeEDKCiphertext(serializedEDKCiphertext, |authTag|);
 
-    var _ :- RequireEqual(encOutput.cipherText, ciphertext);
+    :- RequireEqual(encOutput.cipherText, ciphertext);
     r := RequireEqual(encOutput.authTag, authTag);
   }
 
-  method {:test} TestSerializeEDKCiphertext() returns (r: Result<()>) {
+  method {:test} TestSerializeEDKCiphertext() returns (r: TestResult) {
     var ciphertext := [0, 1, 2, 3];
     var authTag := [4, 5, 6, 7];
     var encOutput := AESEncryption.EncryptionOutput(ciphertext, authTag);

--- a/test/SDK/Keyring/RawRSAKeyring.dfy
+++ b/test/SDK/Keyring/RawRSAKeyring.dfy
@@ -15,7 +15,7 @@ module TestRSAKeyring {
 
   const allPaddingModes := {RSA.PKCS1, RSA.OAEP_SHA1, RSA.OAEP_SHA256, RSA.OAEP_SHA384, RSA.OAEP_SHA512}
 
-  method {:test} TestOnEncryptOnDecryptGenerateDataKey() returns (r: Result<()>)
+  method {:test} TestOnEncryptOnDecryptGenerateDataKey() returns (r: TestResult)
   {
     var remainingPaddingModes := allPaddingModes;
     var name :- UTF8.Encode("test Name");
@@ -34,7 +34,7 @@ module TestRSAKeyring {
       var valA :- UTF8.Encode("valA");
       var encryptionContext := [(keyA, valA)];
       var onEncryptResult :- rawRSAKeyring.OnEncrypt(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryptionContext, None);
-      var _ :- Require(onEncryptResult.Some? &&
+      :- Require(onEncryptResult.Some? &&
         |onEncryptResult.get.encryptedDataKeys| == 1 &&
         |onEncryptResult.get.keyringTrace| == 2);
       var plaintextDataKey := onEncryptResult.get.plaintextDataKey;
@@ -42,12 +42,12 @@ module TestRSAKeyring {
 
       // Verify decoding
       var res :- rawRSAKeyring.OnDecrypt(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryptionContext, [encryptedDataKey]);
-      var _ :- Require(res.Some? && res.get.plaintextDataKey == plaintextDataKey);
+      :- Require(res.Some? && res.get.plaintextDataKey == plaintextDataKey);
     }
-    return Success(());
+    return TestSuccess;
   }
 
-  method {:test} TestOnEncryptOnDecryptSuppliedDataKey() returns (r: Result<()>)
+  method {:test} TestOnEncryptOnDecryptSuppliedDataKey() returns (r: TestResult)
   {
     var remainingPaddingModes := allPaddingModes;
     var name :- UTF8.Encode("test Name");
@@ -67,7 +67,7 @@ module TestRSAKeyring {
       var encryptionContext := [(keyA, valA)];
       var plaintextDataKey := seq(32, i => 0);
       var onEncryptResult :- rawRSAKeyring.OnEncrypt(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryptionContext, Some(plaintextDataKey));
-      var _ :- Require(onEncryptResult.Some? &&
+      :- Require(onEncryptResult.Some? &&
         |onEncryptResult.get.encryptedDataKeys| == 1 &&
         onEncryptResult.get.plaintextDataKey == plaintextDataKey &&
         |onEncryptResult.get.keyringTrace| == 1);

--- a/test/SDK/Materials.dfy
+++ b/test/SDK/Materials.dfy
@@ -8,7 +8,7 @@ module {:extern "TestMaterials"} TestMaterials {
   import opened Materials
   import AlgorithmSuite
 
-  method {:test} TestEncryptionContextGetHappy() returns (res: Result<()>)
+  method {:test} TestEncryptionContextGetHappy() returns (res: TestResult)
   {
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
@@ -18,13 +18,13 @@ module {:extern "TestMaterials"} TestMaterials {
     var encCtx := [(keyA, valA), (keyB, valB)];
 
     var val :- EncryptionContextGet(encCtx, keyA);
-    var _ :- RequireEqual(val, valA);
+    :- RequireEqual(val, valA);
 
     val :- EncryptionContextGet(encCtx, keyB);
     res := RequireEqual(val, valB);
   }
 
-  method {:test} TestEncryptionContextGetSad() returns (res: Result<()>)
+  method {:test} TestEncryptionContextGetSad() returns (res: TestResult)
   {
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
@@ -39,7 +39,7 @@ module {:extern "TestMaterials"} TestMaterials {
     res := RequireFailure(methodCall);
   }
 
-  method {:test} TestEncryptionContextGetLarge() returns (res: Result<()>)
+  method {:test} TestEncryptionContextGetLarge() returns (res: TestResult)
   {
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
@@ -55,7 +55,7 @@ module {:extern "TestMaterials"} TestMaterials {
     res := RequireEqual(valB, val);
   }
 
-  method {:test} TestConcatDataKeyMaterialsHappy() returns (res: Result<()>)
+  method {:test} TestConcatDataKeyMaterialsHappy() returns (res: TestResult)
   {
     var edk1 := EncryptedDataKey([], [1], [1]);
     var pdk := seq(32, i => 0);
@@ -68,9 +68,9 @@ module {:extern "TestMaterials"} TestMaterials {
 
     var concatenated := ConcatDataKeyMaterials(datakeyMat1, datakeyMat2);
 
-    var _ :- Require(pdk == datakeyMat1.plaintextDataKey == datakeyMat2.plaintextDataKey == concatenated.plaintextDataKey);
-    var _ :- Require(datakeyMat1.algorithmSuiteID == datakeyMat2.algorithmSuiteID == concatenated.algorithmSuiteID);
-    var _ :- RequireEqual(datakeyMat1.encryptedDataKeys + datakeyMat2.encryptedDataKeys, concatenated.encryptedDataKeys);
+    :- Require(pdk == datakeyMat1.plaintextDataKey == datakeyMat2.plaintextDataKey == concatenated.plaintextDataKey);
+    :- Require(datakeyMat1.algorithmSuiteID == datakeyMat2.algorithmSuiteID == concatenated.algorithmSuiteID);
+    :- RequireEqual(datakeyMat1.encryptedDataKeys + datakeyMat2.encryptedDataKeys, concatenated.encryptedDataKeys);
     res :=  RequireEqual(datakeyMat1.keyringTrace + datakeyMat2.keyringTrace, concatenated.keyringTrace);
   }
 }

--- a/test/SDK/MessageHeader.dfy
+++ b/test/SDK/MessageHeader.dfy
@@ -14,13 +14,13 @@ module TestMessageHeader {
   import MessageHeader
   import TestUtils
   
-  method {:test} TestComputeValidAADEmpty() returns (r: Result<()>) {
+  method {:test} TestComputeValidAADEmpty() returns (r: TestResult) {
     var kvPairs := [];
     var valid := MessageHeader.ComputeValidAAD(kvPairs);
     r := Require(valid);
   }
 
-  method {:test} TestComputeValidAADOnePair() returns (r: Result<()>) {
+  method {:test} TestComputeValidAADOnePair() returns (r: TestResult) {
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
     var kvPairs := [(keyA, valA)];
@@ -28,7 +28,7 @@ module TestMessageHeader {
     r := Require(valid);
   }
 
-  method {:test} TestComputeValidAADOnePairMaxSize() returns (r: Result<()>) {
+  method {:test} TestComputeValidAADOnePairMaxSize() returns (r: TestResult) {
     var keyA :- UTF8.Encode("A");
     // (2^16 - 1) - 2 => 65533 what we want the size of the key value pair to fill
     // 65533 - 2 - 1 - 2 => 65528 is the size that we want the value to fill
@@ -39,7 +39,7 @@ module TestMessageHeader {
     r := Require(valid);
   }
 
-  method {:test} TestComputeValidAADMaxPairs() returns (r: Result<()>) {
+  method {:test} TestComputeValidAADMaxPairs() returns (r: TestResult) {
     var keyA :- UTF8.Encode("A");
     var valA :- UTF8.Encode("A");
     // (2^16 - 1) / (minimum kvPair size) => (2^16 - 1) / 6 => 10922 is the max
@@ -49,7 +49,7 @@ module TestMessageHeader {
     r := Require(valid);
   }
 
-  method {:test} TestComputeValidAADTooManyEntries() returns (r: Result<()>) {
+  method {:test} TestComputeValidAADTooManyEntries() returns (r: TestResult) {
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
     var kvPairs := seq(0x1_0000, _ => (keyA, valA));
@@ -57,7 +57,7 @@ module TestMessageHeader {
     r := Require(!valid);
   }
 
-  method {:test} TestComputeValidAADTooLarge() returns (r: Result<()>) {
+  method {:test} TestComputeValidAADTooLarge() returns (r: TestResult) {
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
     var kvPairs := seq(0x1_FFFF, _ => (keyA, valA));
@@ -65,7 +65,7 @@ module TestMessageHeader {
     r := Require(!valid);
   }
 
-  method {:test} TestComputeValidAADPairTooBig() returns (r: Result<()>) {
+  method {:test} TestComputeValidAADPairTooBig() returns (r: TestResult) {
     var keyA :- UTF8.Encode("keyA");
     var invalidVal := seq(0x1_0000, _ => 0);
     var kvPairs :=[(keyA, invalidVal)];
@@ -74,7 +74,7 @@ module TestMessageHeader {
     r := Require(!valid);
   }
 
-  method {:test} TestComputeValidAADUnsorted() returns (r: Result<()>) {
+  method {:test} TestComputeValidAADUnsorted() returns (r: TestResult) {
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
     var keyB :- UTF8.Encode("keyB");
@@ -84,14 +84,14 @@ module TestMessageHeader {
     r := Require(!valid);
   }
 
-  method {:test} TestComputeKVPairsLengthEmpty() returns (r: Result<()>) {
+  method {:test} TestComputeKVPairsLengthEmpty() returns (r: TestResult) {
     var kvPairs := [];
 
     var len := MessageHeader.ComputeKVPairsLength(kvPairs);
     r := RequireEqual(len as int, 0);
   }
 
-  method {:test} TestComputeKVPairsLengthOnePair() returns (r: Result<()>) {
+  method {:test} TestComputeKVPairsLengthOnePair() returns (r: TestResult) {
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
     var kvPairs := [(keyA, valA)];
@@ -101,7 +101,7 @@ module TestMessageHeader {
     r := RequireEqual(len as int, |expectedSerialization|);
   }
 
-  method {:test} TestComputeKVPairsLengthLong() returns (r: Result<()>) {
+  method {:test} TestComputeKVPairsLengthLong() returns (r: TestResult) {
     var keyA :- UTF8.Encode("A");
     var largeVal := seq(0x1_0000, _ => 0);
     TestUtils.AssumeLongSeqIsValidUTF8(largeVal);

--- a/test/SDK/Serialize.dfy
+++ b/test/SDK/Serialize.dfy
@@ -8,7 +8,7 @@ module TestSerialize {
   import UTF8
   import MessageHeader
 
-  method {:test} TestSerializeAAD() returns (ret: Result<()>) {
+  method {:test} TestSerializeAAD() returns (ret: TestResult) {
     var wr := new Streams.ByteWriter();
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
@@ -21,7 +21,7 @@ module TestSerialize {
     ret := RequireEqual(wr.GetDataWritten(), expectedSerializedAAD);
   }
 
-  method {:test} TestSerializeAADEmpty() returns (ret: Result<()>) {
+  method {:test} TestSerializeAADEmpty() returns (ret: TestResult) {
     reveal MessageHeader.ValidAAD();
     var wr := new Streams.ByteWriter();
     var encryptionContext := [];
@@ -32,7 +32,7 @@ module TestSerialize {
     ret := RequireEqual(wr.GetDataWritten(), expectedSerializedAAD);
   }
 
-  method {:test} TestSerializeKVPairs() returns (ret: Result<()>) {
+  method {:test} TestSerializeKVPairs() returns (ret: TestResult) {
     var wr := new Streams.ByteWriter();
     var keyA :- UTF8.Encode("keyA");
     var valA :- UTF8.Encode("valA");
@@ -45,7 +45,7 @@ module TestSerialize {
     ret := RequireEqual(wr.GetDataWritten(), expectedSerializedAAD);
   }
 
-  method {:test} TestSerializeKVPairsEmpty() returns (ret: Result<()>) {
+  method {:test} TestSerializeKVPairsEmpty() returns (ret: TestResult) {
     reveal MessageHeader.ValidAAD();
     var wr := new Streams.ByteWriter();
     var encryptionContext := [];

--- a/test/StandardLibrary/Base64.dfy
+++ b/test/StandardLibrary/Base64.dfy
@@ -23,253 +23,253 @@ module TestBase64 {
     ensures forall i :: 0 <= i < |BASE64_TEST_VECTORS_ENCODED| ==> IsBase64String(BASE64_TEST_VECTORS_ENCODED[i])
   {}
 
-  method {:test} TestIsBase64CharSuccess() returns (r: Result<()>) {
+  method {:test} TestIsBase64CharSuccess() returns (r: TestResult) {
     r := Require(forall c :: c in BASE64_CHARS ==> IsBase64Char(c));
   }
 
-  method {:test} TestIsBase64CharFailure() returns (r: Result<()>) {
+  method {:test} TestIsBase64CharFailure() returns (r: TestResult) {
     r := Require(forall c :: c !in BASE64_CHARS ==> !IsBase64Char(c));
   }
 
-  method {:test} TestIsUnpaddedBase64StringSuccess() returns (r: Result<()>) {
+  method {:test} TestIsUnpaddedBase64StringSuccess() returns (r: TestResult) {
     r := Require(IsUnpaddedBase64String("VGVz"));
   }
 
-  method {:test} TestIsUnpaddedBase64StringTooShort() returns (r: Result<()>) {
+  method {:test} TestIsUnpaddedBase64StringTooShort() returns (r: TestResult) {
     r := Require(!IsUnpaddedBase64String("VGV"));
   }
 
-  method {:test} TestIsUnpaddedBase64StringNotBase64() returns (r: Result<()>) {
+  method {:test} TestIsUnpaddedBase64StringNotBase64() returns (r: TestResult) {
     r := Require(!IsUnpaddedBase64String("VGV$"));
   }
 
-  method {:test} TestIndexToChar63() returns (r: Result<()>) {
+  method {:test} TestIndexToChar63() returns (r: TestResult) {
     r := RequireEqual(IndexToChar(63), '/');
   }
 
-  method {:test} TestIndexToChar62() returns (r: Result<()>) {
+  method {:test} TestIndexToChar62() returns (r: TestResult) {
     r := RequireEqual(IndexToChar(62), '+');
   }
 
-  method {:test} TestIndexToCharDigits() returns (r: Result<()>) {
+  method {:test} TestIndexToCharDigits() returns (r: TestResult) {
     var digits := "0123456789";
     r := Require(forall i :: 52 <= i <= 61 ==> IndexToChar(i) in digits);
   }
 
-  method {:test} TestIndexToCharLowercase() returns (r: Result<()>) {
+  method {:test} TestIndexToCharLowercase() returns (r: TestResult) {
     var lowercase := "abcdefghijklmnopqrstuvwxyz";
     r := Require(forall i :: 26 <= i <= 51 ==> IndexToChar(i) in lowercase);
   }
 
-  method {:test} TestIndexToCharUppercase() returns (r: Result<()>) {
+  method {:test} TestIndexToCharUppercase() returns (r: TestResult) {
     var uppercase := "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     r := Require(forall i :: 0 <= i <= 25 ==> IndexToChar(i) in uppercase);
   }
 
-  method {:test} TestCharToIndex63() returns (r: Result<()>) {
+  method {:test} TestCharToIndex63() returns (r: TestResult) {
     r := RequireEqual(CharToIndex('/'), 63);
   }
 
-  method {:test} TestCharToIndex62() returns (r: Result<()>) {
+  method {:test} TestCharToIndex62() returns (r: TestResult) {
     r := RequireEqual(CharToIndex('+'), 62);
   }
 
-  method {:test} TestCharToIndexDigits() returns (r: Result<()>) {
+  method {:test} TestCharToIndexDigits() returns (r: TestResult) {
     var digits := "0123456789";
     r := Require(forall i :: 0 <= i < |digits| ==> CharToIndex(digits[i]) == ((i + 52) as index));
   }
 
-  method {:test} TestCharToIndexLowercase() returns (r: Result<()>) {
+  method {:test} TestCharToIndexLowercase() returns (r: TestResult) {
     var lowercase := "abcdefghijklmnopqrstuvwxyz";
     r := Require(forall i :: 0 <= i < |lowercase| ==> CharToIndex(lowercase[i]) == ((i + 26) as index));
   }
 
-  method {:test} TestCharToIndexUppercase() returns (r: Result<()>) {
+  method {:test} TestCharToIndexUppercase() returns (r: TestResult) {
     var uppercase := "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     r := Require(forall i :: 0 <= i < |uppercase| ==> CharToIndex(uppercase[i]) == (i as index));
   }
 
-  method {:test} TestUInt24ToSeq() returns (r: Result<()>) {
+  method {:test} TestUInt24ToSeq() returns (r: TestResult) {
     var input: uint24 := 0x100101;
     var output := [0x10, 0x01, 0x01];
     r := RequireEqual(output, UInt24ToSeq(input));
   }
 
-  method {:test} TestSeqToUInt24() returns (r: Result<()>) {
+  method {:test} TestSeqToUInt24() returns (r: TestResult) {
     var input := [0x10, 0x01, 0x01];
     var output: uint24 := 0x100101;
     r := RequireEqual(output, SeqToUInt24(input));
   }
 
-  method {:test} TestUInt24ToIndexSeq() returns (r: Result<()>) {
+  method {:test} TestUInt24ToIndexSeq() returns (r: TestResult) {
     var input: uint24 := 0x100101;
     var output := [0x04, 0x00, 0x04, 0x01];
     r := RequireEqual(output, UInt24ToIndexSeq(input));
   }
 
-  method {:test} TestIndexSeqToUInt24() returns (r: Result<()>) {
+  method {:test} TestIndexSeqToUInt24() returns (r: TestResult) {
     var input := [0x04, 0x00, 0x04, 0x01];
     var output: uint24 := 0x100101;
     r := RequireEqual(output, IndexSeqToUInt24(input));
   }
 
-  method {:test} TestDecodeBlock() returns (r: Result<()>) {
+  method {:test} TestDecodeBlock() returns (r: TestResult) {
     var input := [0x04, 0x00, 0x04, 0x01];
     var output := [0x10, 0x01, 0x01];
     r := RequireEqual(output, DecodeBlock(input));
   }
 
-  method {:test} TestEncodeBlock() returns (r: Result<()>) {
+  method {:test} TestEncodeBlock() returns (r: TestResult) {
     var input := [0x10, 0x01, 0x01];
     var output := [0x04, 0x00, 0x04, 0x01];
     r := RequireEqual(output, EncodeBlock(input));
   }
 
-  method {:test} TestDecodeRecursively() returns (r: Result<()>) {
+  method {:test} TestDecodeRecursively() returns (r: TestResult) {
     var input := [0x04, 0x00, 0x04, 0x01, 0x04, 0x00, 0x04, 0x01];
     var output := [0x10, 0x01, 0x01, 0x10, 0x01, 0x01];
     r := RequireEqual(output, DecodeRecursively(input));
   }
 
-  method {:test} TestEncodeRecursively() returns (r: Result<()>) {
+  method {:test} TestEncodeRecursively() returns (r: TestResult) {
     var input := [0x10, 0x01, 0x01, 0x10, 0x01, 0x01];
     var output := [0x04, 0x00, 0x04, 0x01, 0x04, 0x00, 0x04, 0x01];
     r := RequireEqual(output, EncodeRecursively(input));
   }
 
-  method {:test} TestFromCharsToIndices() returns (r: Result<()>) {
+  method {:test} TestFromCharsToIndices() returns (r: TestResult) {
     var input := "aA1+/";
     var output := [0x1A, 0x00, 0x35, 0x3E, 0x3F];
     r := RequireEqual(output, FromCharsToIndices(input));
   }
 
-  method {:test} TestFromIndicesToChars() returns (r: Result<()>) {
+  method {:test} TestFromIndicesToChars() returns (r: TestResult) {
     var input := [0x1A, 0x00, 0x35, 0x3E, 0x3F];
     var output := "aA1+/";
     r := RequireEqual(output, FromIndicesToChars(input));
   }
 
-  method {:test} TestDecodeUnpadded() returns (r: Result<()>) {
+  method {:test} TestDecodeUnpadded() returns (r: TestResult) {
     var input := "VGVzdGluZysx";
     var output := [0x54, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67, 0x2B, 0x31];
     r := RequireEqual(output, DecodeUnpadded(input));
   }
 
-  method {:test} TestEncodeUnpadded() returns (r: Result<()>) {
+  method {:test} TestEncodeUnpadded() returns (r: TestResult) {
     var input := [0x54, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67, 0x2B, 0x31];
     var output := "VGVzdGluZysx";
     r := RequireEqual(output, EncodeUnpadded(input));
   }
 
-  method {:test} TestDecodeUnpaddedEmpty() returns (r: Result<()>) {
+  method {:test} TestDecodeUnpaddedEmpty() returns (r: TestResult) {
     r := RequireEqual([], DecodeUnpadded([]));
   }
 
-  method {:test} TestEncodeUnpaddedEmpty() returns (r: Result<()>) {
+  method {:test} TestEncodeUnpaddedEmpty() returns (r: TestResult) {
     r := RequireEqual([], EncodeUnpadded([]));
   }
 
-  method {:test} TestIs1PaddingSuccess() returns (r: Result<()>) {
+  method {:test} TestIs1PaddingSuccess() returns (r: TestResult) {
     r := Require(Is1Padding("VGU="));
   }
 
-  method {:test} TestIs1PaddingTooShort() returns (r: Result<()>) {
+  method {:test} TestIs1PaddingTooShort() returns (r: TestResult) {
     r := Require(!Is1Padding("VG="));
   }
 
-  method {:test} TestIs1PaddingTooLong() returns (r: Result<()>) {
+  method {:test} TestIs1PaddingTooLong() returns (r: TestResult) {
     r := Require(!Is1Padding("VGUU="));
   }
 
-  method {:test} TestIs1PaddingInvalidChar0() returns (r: Result<()>) {
+  method {:test} TestIs1PaddingInvalidChar0() returns (r: TestResult) {
     r := Require(!Is1Padding("$GU="));
   }
 
-  method {:test} TestIs1PaddingInvalidChar1() returns (r: Result<()>) {
+  method {:test} TestIs1PaddingInvalidChar1() returns (r: TestResult) {
     r := Require(!Is1Padding("V$U="));
   }
 
-  method {:test} TestIs1PaddingInvalidChar2() returns (r: Result<()>) {
+  method {:test} TestIs1PaddingInvalidChar2() returns (r: TestResult) {
     r := Require(!Is1Padding("VG$="));
   }
 
-  method {:test} TestIs1PaddingInvalidChar3() returns (r: Result<()>) {
+  method {:test} TestIs1PaddingInvalidChar3() returns (r: TestResult) {
     r := Require(!Is1Padding("VGVz"));
   }
 
-  method {:test} TestIs1PaddingInvalidChar2Modulus() returns (r: Result<()>) {
+  method {:test} TestIs1PaddingInvalidChar2Modulus() returns (r: TestResult) {
     r := Require(!Is1Padding("VGV="));
   }
 
-  method {:test} TestDecode1Padding() returns (r: Result<()>) {
+  method {:test} TestDecode1Padding() returns (r: TestResult) {
     var input := "VGU=";
     var output := [0x54, 0x65];
     r := RequireEqual(output, Decode1Padding(input));
   }
 
-  method {:test} TestEncode1Padding() returns (r: Result<()>) {
+  method {:test} TestEncode1Padding() returns (r: TestResult) {
     var input := [0x54, 0x65];
     var output := "VGU=";
     r := RequireEqual(output, Encode1Padding(input));
   }
 
-  method {:test} TestIs2PaddingSuccess() returns (r: Result<()>) {
+  method {:test} TestIs2PaddingSuccess() returns (r: TestResult) {
     r := Require(Is2Padding("VA=="));
   }
 
-  method {:test} TestIs2PaddingTooShort() returns (r: Result<()>) {
+  method {:test} TestIs2PaddingTooShort() returns (r: TestResult) {
     r := Require(!Is2Padding("VA="));
   }
 
-  method {:test} TestIs2PaddingTooLong() returns (r: Result<()>) {
+  method {:test} TestIs2PaddingTooLong() returns (r: TestResult) {
     r := Require(!Is2Padding("VAA=="));
   }
 
-  method {:test} TestIs2PaddingInvalidChar0() returns (r: Result<()>) {
+  method {:test} TestIs2PaddingInvalidChar0() returns (r: TestResult) {
     r := Require(!Is2Padding("$A=="));
   }
 
-  method {:test} TestIs2PaddingInvalidChar1() returns (r: Result<()>) {
+  method {:test} TestIs2PaddingInvalidChar1() returns (r: TestResult) {
     r := Require(!Is2Padding("V$=="));
   }
 
-  method {:test} TestIs2PaddingInvalidChar2() returns (r: Result<()>) {
+  method {:test} TestIs2PaddingInvalidChar2() returns (r: TestResult) {
     r := Require(!Is2Padding("VAA="));
   }
 
-  method {:test} TestIs2PaddingInvalidChar3() returns (r: Result<()>) {
+  method {:test} TestIs2PaddingInvalidChar3() returns (r: TestResult) {
     r := Require(!Is2Padding("VA=A"));
   }
 
-  method {:test} TestIs2PaddingInvalidChar1Modulus() returns (r: Result<()>) {
+  method {:test} TestIs2PaddingInvalidChar1Modulus() returns (r: TestResult) {
     r := Require(!Is2Padding("VB=="));
   }
 
-  method {:test} TestDecode2Padding() returns (r: Result<()>) {
+  method {:test} TestDecode2Padding() returns (r: TestResult) {
     var input := "VA==";
     var output := [0x54];
     r := RequireEqual(output, Decode2Padding(input));
   }
 
-  method {:test} TestEncode2Padding() returns (r: Result<()>) {
+  method {:test} TestEncode2Padding() returns (r: TestResult) {
     var input := [0x54];
     var output := "VA==";
     r := RequireEqual(output, Encode2Padding(input));
   }
 
-  method {:test} TestIsBase64StringTestVectors() returns (r: Result<()>) {
+  method {:test} TestIsBase64StringTestVectors() returns (r: TestResult) {
     r := Require(forall i :: i in BASE64_TEST_VECTORS_ENCODED ==> IsBase64String(i) == true);
   }
 
-  method {:test} TestIsBase64StringBadLength() returns (r: Result<()>) {
+  method {:test} TestIsBase64StringBadLength() returns (r: TestResult) {
     r := Require(!IsBase64String("VG="));
   }
 
-  method {:test} TestIsBase64StringBadString() returns (r: Result<()>) {
+  method {:test} TestIsBase64StringBadString() returns (r: TestResult) {
     r := Require(!IsBase64String("VC=="));
   }
 
-  method {:test} TestSanityCheckDecodedTestVectors() returns (r: Result<()>) {
+  method {:test} TestSanityCheckDecodedTestVectors() returns (r: TestResult) {
 
     var testVectorIndex := 0;
     while testVectorIndex < |BASE64_TEST_VECTORS_DECODED|
@@ -284,37 +284,37 @@ module TestBase64 {
         uint8Message := uint8Message + [strMessage[msgIndex] as uint8];
         msgIndex := msgIndex + 1;
       }
-      var _ :- RequireEqual(BASE64_TEST_VECTORS_DECODED_UINT8[testVectorIndex], uint8Message);
+      :- RequireEqual(BASE64_TEST_VECTORS_DECODED_UINT8[testVectorIndex], uint8Message);
       testVectorIndex := testVectorIndex + 1;
     }
-    return Success(());
+    return TestSuccess;
   }
 
-  method {:test} TestDecodeValidTestVectors() returns (r: Result<()>) {
+  method {:test} TestDecodeValidTestVectors() returns (r: TestResult) {
     r := Require(forall i :: 0 <= i < |BASE64_TEST_VECTORS_ENCODED| ==>
       DecodeValid(BASE64_TEST_VECTORS_ENCODED[i]) == BASE64_TEST_VECTORS_DECODED_UINT8[i]);
   }
 
-  method {:test} TestDecodeTestVectors() returns (r: Result<()>) {
+  method {:test} TestDecodeTestVectors() returns (r: TestResult) {
     r := Require(forall i :: 0 <= i < |BASE64_TEST_VECTORS_ENCODED| ==>
       Decode(BASE64_TEST_VECTORS_ENCODED[i]) == Success(BASE64_TEST_VECTORS_DECODED_UINT8[i]));
   }
 
-  method {:test} TestDecodeFailure() returns (r: Result<()>) {
+  method {:test} TestDecodeFailure() returns (r: TestResult) {
     r := RequireEqual(Failure("The encoding is malformed"), Decode("$"));
   }
 
-  method {:test} TestEncode() returns (r: Result<()>) {
+  method {:test} TestEncode() returns (r: TestResult) {
     r := Require(forall i :: 0 <= i < |BASE64_TEST_VECTORS_DECODED_UINT8| ==>
       Encode(BASE64_TEST_VECTORS_DECODED_UINT8[i]) == BASE64_TEST_VECTORS_ENCODED[i]);
   }
 
-  method {:test} TestEncodeDecode() returns (r: Result<()>) {
+  method {:test} TestEncodeDecode() returns (r: TestResult) {
     r := Require(forall i :: 0 <= i < |BASE64_TEST_VECTORS_DECODED_UINT8| ==>
       Decode(Encode(BASE64_TEST_VECTORS_DECODED_UINT8[i])) == Success(BASE64_TEST_VECTORS_DECODED_UINT8[i]));
   }
 
-  method {:test} TestDecodeEncode() returns (r: Result<()>) {
+  method {:test} TestDecodeEncode() returns (r: TestResult) {
     r := Require(forall i :: 0 <= i < |BASE64_TEST_VECTORS_ENCODED| ==>
       (Decode(BASE64_TEST_VECTORS_ENCODED[i]).Success?
       && Encode(Decode(BASE64_TEST_VECTORS_ENCODED[i]).value) == BASE64_TEST_VECTORS_ENCODED[i]));

--- a/test/StandardLibrary/StandardLibrary.dfy
+++ b/test/StandardLibrary/StandardLibrary.dfy
@@ -3,115 +3,115 @@ include "../../src/StandardLibrary/StandardLibrary.dfy"
 module TestStandardLibrary {
   import opened StandardLibrary
 
-  method {:test} TestRequireFailure() returns (ret: Result<()>) {
+  method {:test} TestRequireFailure() returns (ret: TestResult) {
     var failure: Result<string> := Failure("Some failure");
-    var _ :- RequireFailure(failure);
+    :- RequireFailure(failure);
 
     var requireFailureGivenSuccess := RequireFailure(Success(()));
-    var _ :- Require(requireFailureGivenSuccess.Failure?);
-    ret := RequireFailure(requireFailureGivenSuccess);
+    :- Require(requireFailureGivenSuccess.TestFailure?);
+    ret := RequireFailure<()>(Failure(requireFailureGivenSuccess.error));
   }
 
-  method {:test} TestJoinMultiElementSeq() returns (ret: Result<()>) {
+  method {:test} TestJoinMultiElementSeq() returns (ret: TestResult) {
     var input := ["comma", "separated", "list"];
     var output := Join(input, ",");
     ret := RequireEqual("comma,separated,list", output);
   }
 
-  method {:test} TestJoinSingleElementSeq() returns (ret: Result<()>) {
+  method {:test} TestJoinSingleElementSeq() returns (ret: TestResult) {
     var input := ["one"];
     var output := Join(input, ",");
     ret := RequireEqual("one", output);
   }
 
-  method {:test} TestJoinSplit() returns (ret: Result<()>) {
+  method {:test} TestJoinSplit() returns (ret: TestResult) {
     var input := "comma,separated,list";
     var output := Join(Split(input, ','), ",");
     ret := RequireEqual(input, output);
   }
 
-  method {:test} TestSplitJoin() returns (ret: Result<()>) {
+  method {:test} TestSplitJoin() returns (ret: TestResult) {
     var input := ["comma", "separated", "list"];
     var output := Split(Join(input, ","), ',');
     ret := RequireEqual(input, output);
   }
 
-  method {:test} TestSplitByteSeq() returns (ret: Result<()>) {
+  method {:test} TestSplitByteSeq() returns (ret: TestResult) {
     var input := "comma,separated,list";
     var output := Split(input, ',');
     ret := RequireEqual(["comma", "separated", "list"], output);
   }
 
-  method {:test} TestSplitNumSeq() returns (ret: Result<()>) {
+  method {:test} TestSplitNumSeq() returns (ret: TestResult) {
     var input := [1, 2, 3, 0, 1, 2, 3];
     var output := Split(input, 0);
     ret := RequireEqual([[1, 2, 3], [1, 2, 3]], output);
   }
 
-  method {:test} TestSplitFinalElementDelim() returns (ret: Result<()>) {
+  method {:test} TestSplitFinalElementDelim() returns (ret: TestResult) {
     var input := "one,";
     var output := Split(input, ',');
     ret := RequireEqual(["one", ""], output);
   }
 
-  method {:test} TestSplitNoDelim() returns (ret: Result<()>) {
+  method {:test} TestSplitNoDelim() returns (ret: TestResult) {
     var input := "no comma";
     var output := Split(input, ',');
     ret := RequireEqual(["no comma"], output);
   }
 
-  method {:test} TestSplitOnlyElemIsDelim() returns (ret: Result<()>) {
+  method {:test} TestSplitOnlyElemIsDelim() returns (ret: TestResult) {
     var input := ",";
     var output := Split(input, ',');
     ret := RequireEqual(["", ""], output);
   }
 
-  method {:test} TestSplitEmpty() returns (ret: Result<()>) {
+  method {:test} TestSplitEmpty() returns (ret: TestResult) {
     var input := "";
     var output := Split(input, ',');
     ret := RequireEqual([""], output);
   }
 
-  method {:test} TestFindIndexMatchingSimple() returns (ret: Result<()>) {
+  method {:test} TestFindIndexMatchingSimple() returns (ret: TestResult) {
     var input := "abcd";
     var output := FindIndexMatching(input, 'c', 0);
     ret := RequireEqual(Some(2), output);
   }
 
-  method {:test} TestFindIndexMatchingDuplicates() returns (ret: Result<()>) {
+  method {:test} TestFindIndexMatchingDuplicates() returns (ret: TestResult) {
     var input := "abcdc";
     var output := FindIndexMatching(input, 'c', 0);
     ret := RequireEqual(Some(2), output);
   }
 
-  method {:test} TestFindIndexMatchingNone() returns (ret: Result<()>) {
+  method {:test} TestFindIndexMatchingNone() returns (ret: TestResult) {
     var input := "abcd";
     var output := FindIndexMatching(input, 'e', 0);
     ret := RequireEqual(None, output);
   }
 
-  method {:test} TestFindIndexSimple() returns (ret: Result<()>)
+  method {:test} TestFindIndexSimple() returns (ret: TestResult)
   {
     var input := "abcd";
     var output := FindIndex(input, x => x == 'c', 0);
     ret := RequireEqual(Some(2), output);
   }
 
-  method {:test} TestFindIndexComplex() returns (ret: Result<()>)
+  method {:test} TestFindIndexComplex() returns (ret: TestResult)
   {
     var input := "abcd";
     var output := FindIndex(input, x => x in "crepe", 0);
     ret := RequireEqual(Some(2), output);
   }
 
-  method {:test} TestFindIndexDuplicates() returns (ret: Result<()>)
+  method {:test} TestFindIndexDuplicates() returns (ret: TestResult)
   {
     var input := "abcdc";
     var output := FindIndex(input, x => x == 'c', 0);
     ret := RequireEqual(Some(2), output);
   }
 
-  method {:test} TestFindIndexNone() returns (ret: Result<()>)
+  method {:test} TestFindIndexNone() returns (ret: TestResult)
   {
     var input := "abcd";
     var output := FindIndex(input, x => false, 0);
@@ -122,41 +122,41 @@ module TestStandardLibrary {
     entry in ["a"]
   }
 
-  method {:test} TestFilterSomeValid() returns (ret: Result<()>) {
+  method {:test} TestFilterSomeValid() returns (ret: TestResult) {
     var input := ["a", "b", "a"];
     var output := Filter(input, TestFilterPredicate);
     ret := RequireEqual(["a", "a"], output);
   }
 
-  method {:test} TestFilterNoneValid() returns (ret: Result<()>) {
+  method {:test} TestFilterNoneValid() returns (ret: TestResult) {
     var input := ["c", "b", "c"];
     var output := Filter(input, TestFilterPredicate);
     ret := RequireEqual([], output);
   }
 
-  method {:test} TestFilterNothing() returns (ret: Result<()>) {
+  method {:test} TestFilterNothing() returns (ret: TestResult) {
     var input := [];
     var output := Filter(input, TestFilterPredicate);
     ret := RequireEqual([], output);
   }
 
-  method {:test} TestMinPositives() returns (ret: Result<()>) {
+  method {:test} TestMinPositives() returns (ret: TestResult) {
     ret := RequireEqual(1, Min(1, 2));
   }
 
-  method {:test} TestMinNegatives() returns (ret: Result<()>) {
+  method {:test} TestMinNegatives() returns (ret: TestResult) {
     ret := RequireEqual(-2, Min(-1, -2));
   }
 
-  method {:test} TestMinPositivesNegatives() returns (ret: Result<()>) {
+  method {:test} TestMinPositivesNegatives() returns (ret: TestResult) {
     ret := RequireEqual(-1, Min(-1, 1));
   }
 
-  method {:test} TestMinDuplicateNumber() returns (ret: Result<()>) {
+  method {:test} TestMinDuplicateNumber() returns (ret: TestResult) {
     ret := RequireEqual(0, Min(0, 0));
   }
 
-  method {:test} TestSeqToArray() returns (ret: Result<()>) {
+  method {:test} TestSeqToArray() returns (ret: TestResult) {
     var input: seq<int> := [1, 2, 3];
     var output := SeqToArray(input);
 
@@ -165,13 +165,13 @@ module TestStandardLibrary {
     expected[1] := 2;
     expected[2] := 3;
 
-    var _ :- RequireEqual(expected.Length, output.Length);
-    var _ :- RequireEqual(expected[0], output[0]);
-    var _ :- RequireEqual(expected[1], output[1]);
+    :- RequireEqual(expected.Length, output.Length);
+    :- RequireEqual(expected[0], output[0]);
+    :- RequireEqual(expected[1], output[1]);
     ret := RequireEqual(expected[2], output[2]);
   }
 
-  method {:test} TestSeqToArrayEmpty() returns (ret: Result<()>) {
+  method {:test} TestSeqToArrayEmpty() returns (ret: TestResult) {
     var input: seq<char> := [];
     var output := SeqToArray(input);
     ret := RequireEqual(0, output.Length);
@@ -179,31 +179,31 @@ module TestStandardLibrary {
 
   predicate method TestStandardLibraryLessPredicate(a: int, b: int) { a < b }
 
-  method {:test} TestLexicographicLessOrEqualTrue() returns (ret: Result<()>) {
+  method {:test} TestLexicographicLessOrEqualTrue() returns (ret: TestResult) {
     var a: seq<int> := [1, 2, 3];
     var b: seq<int> := [1, 2, 4];
     ret := RequireEqual(true, LexicographicLessOrEqual(a, b, TestStandardLibraryLessPredicate));
   }
 
-  method {:test} TestLexicographicLessOrEqualFalse() returns (ret: Result<()>) {
+  method {:test} TestLexicographicLessOrEqualFalse() returns (ret: TestResult) {
     var a: seq<int> := [1, 2, 3];
     var b: seq<int> := [1, 2, 4];
     ret := RequireEqual(false, LexicographicLessOrEqual(b, a, TestStandardLibraryLessPredicate));
   }
 
-  method {:test} TestLexicographicLessOrEqualAllEqual() returns (ret: Result<()>) {
+  method {:test} TestLexicographicLessOrEqualAllEqual() returns (ret: TestResult) {
     var a: seq<int> := [1, 2, 3];
     var b: seq<int> := [1, 2, 3];
     ret := RequireEqual(true, LexicographicLessOrEqual(a, b, TestStandardLibraryLessPredicate));
   }
 
-  method {:test} TestLexicographicLessOrEqualNoneEqual() returns (ret: Result<()>) {
+  method {:test} TestLexicographicLessOrEqualNoneEqual() returns (ret: TestResult) {
     var a: seq<int> := [1];
     var b: seq<int> := [2];
     ret := RequireEqual(true, LexicographicLessOrEqual(a, b, TestStandardLibraryLessPredicate));
   }
 
-  method {:test} TestLexicographicLessOrEqualEmpty() returns (ret: Result<()>) {
+  method {:test} TestLexicographicLessOrEqualEmpty() returns (ret: TestResult) {
     var a: seq<int> := [];
     var b: seq<int> := [];
     ret := RequireEqual(true, LexicographicLessOrEqual(a, b, TestStandardLibraryLessPredicate));

--- a/test/StandardLibrary/UInt.dfy
+++ b/test/StandardLibrary/UInt.dfy
@@ -5,32 +5,32 @@ module TestUInt {
   import opened StandardLibrary
   import opened UInt = StandardLibrary.UInt
 
-  method {:test} TestUInt16ToSeq() returns (r: Result<()>) {
+  method {:test} TestUInt16ToSeq() returns (r: TestResult) {
     var x: uint16 := 0x0122;
     r := RequireEqual([0x01, 0x22], UInt16ToSeq(x));
   }
 
-  method {:test} TestSeqToUInt16() returns (r: Result<()>) {
+  method {:test} TestSeqToUInt16() returns (r: TestResult) {
     var s := [0x01, 0x22];
     r := RequireEqual(0x0122 as uint16, SeqToUInt16(s));
   }
 
-  method {:test} TestUInt32ToSeq() returns (r: Result<()>) {
+  method {:test} TestUInt32ToSeq() returns (r: TestResult) {
     var x := 0x01023044;
     r := RequireEqual([0x01, 0x02, 0x30, 0x44], UInt32ToSeq(x));
   }
 
-  method {:test} TestSeqToUInt32() returns (r: Result<()>) {
+  method {:test} TestSeqToUInt32() returns (r: TestResult) {
     var s := [0x01, 0x02, 0x30, 0x44];
     r := RequireEqual(0x01023044 as uint32, SeqToUInt32(s));
   }
 
-  method {:test} TestUInt64ToSeq() returns (r: Result<()>) {
+  method {:test} TestUInt64ToSeq() returns (r: TestResult) {
     var x: uint64 := 0x0102304455667788;
     r := RequireEqual([0x01, 0x02, 0x30, 0x44, 0x55, 0x66, 0x77, 0x88], UInt64ToSeq(x));
   }
 
-  method {:test} TestSeqToUInt64() returns (r: Result<()>) {
+  method {:test} TestSeqToUInt64() returns (r: TestResult) {
     var s := [0x01, 0x02, 0x30, 0x44, 0x55, 0x66, 0x77, 0x88];
     r := RequireEqual(0x0102304455667788 as uint64, SeqToUInt64(s));
   }

--- a/test/Util/Streams.dfy
+++ b/test/Util/Streams.dfy
@@ -6,165 +6,165 @@ module TestStreams {
   import opened UInt = StandardLibrary.UInt
   import opened Streams
 
-  method {:test} TestSeqReaderReadElements() returns (r: Result<()>) {
+  method {:test} TestSeqReaderReadElements() returns (r: TestResult) {
     var s: seq<nat> := [0, 100, 200, 300, 400];
     var reader := new Streams.SeqReader<nat>(s);
 
     var res := reader.ReadElements(3);
-    var _ :- RequireEqual([0, 100, 200], res);
+    :- RequireEqual([0, 100, 200], res);
 
     res := reader.ReadElements(0);
-    var _ :- RequireEqual([], res);
+    :- RequireEqual([], res);
 
     res := reader.ReadElements(2);
     r := RequireEqual([300, 400], res);
   }
 
-  method {:test} TestSeqReaderReadExact() returns (r: Result<()>) {
+  method {:test} TestSeqReaderReadExact() returns (r: TestResult) {
     var s: seq<nat> := [0, 100, 200, 300, 400];
     var reader := new Streams.SeqReader<nat>(s);
 
     var res :- reader.ReadExact(3);
-    var _ :- RequireEqual([0, 100, 200], res);
+    :- RequireEqual([0, 100, 200], res);
 
     res :- reader.ReadExact(0);
-    var _ :- RequireEqual([], res);
+    :- RequireEqual([], res);
 
     res :- reader.ReadExact(2);
-    var _ :- RequireEqual([300, 400], res);
+    :- RequireEqual([300, 400], res);
 
     var isFailure := reader.ReadExact(1);
     r := RequireFailure(isFailure);
   }
 
-  method {:test} TestByteReader() returns (r: Result<()>) {
+  method {:test} TestByteReader() returns (r: TestResult) {
     var s: seq<uint8> := [0, 3, 10, 20, 50, 100, 150, 200, 250, 255];
     var reader := new Streams.ByteReader(s);
 
     var uint8Res :- reader.ReadByte();
     var sizeRead := reader.GetSizeRead();
     var isDoneReading := reader.IsDoneReading();
-    var _ :- RequireEqual(0, uint8Res);
-    var _ :- RequireEqual(1, sizeRead);
-    var _ :- Require(!isDoneReading);
+    :- RequireEqual(0, uint8Res);
+    :- RequireEqual(1, sizeRead);
+    :- Require(!isDoneReading);
 
     var sRes :- reader.ReadBytes(0);
     sizeRead := reader.GetSizeRead();
     isDoneReading := reader.IsDoneReading();
-    var _ :- RequireEqual([], sRes);
-    var _ :- RequireEqual(1, sizeRead);
-    var _ :- Require(!isDoneReading);
+    :- RequireEqual([], sRes);
+    :- RequireEqual(1, sizeRead);
+    :- Require(!isDoneReading);
 
     sRes :- reader.ReadBytes(3);
     sizeRead := reader.GetSizeRead();
     isDoneReading := reader.IsDoneReading();
-    var _ :- RequireEqual([3, 10, 20], sRes);
-    var _ :- RequireEqual(4, sizeRead);
-    var _ :- Require(!isDoneReading);
+    :- RequireEqual([3, 10, 20], sRes);
+    :- RequireEqual(4, sizeRead);
+    :- Require(!isDoneReading);
 
     var uint16 :- reader.ReadUInt16();
     var expectedUint16 := SeqToUInt16([50, 100]);
     sizeRead := reader.GetSizeRead();
     isDoneReading := reader.IsDoneReading();
-    var _ :- RequireEqual(expectedUint16, uint16);
-    var _ :- RequireEqual(6, sizeRead);
-    var _ :- Require(!isDoneReading);
+    :- RequireEqual(expectedUint16, uint16);
+    :- RequireEqual(6, sizeRead);
+    :- Require(!isDoneReading);
 
     var uint32 :- reader.ReadUInt32();
     var expectedUint32 := SeqToUInt32([150, 200, 250, 255]);
     sizeRead := reader.GetSizeRead();
     isDoneReading := reader.IsDoneReading();
-    var _ :- RequireEqual(expectedUint32, uint32);
-    var _ :- RequireEqual(10, sizeRead);
-    var _ :- Require(isDoneReading);
+    :- RequireEqual(expectedUint32, uint32);
+    :- RequireEqual(10, sizeRead);
+    :- Require(isDoneReading);
 
     var isByteFailure := reader.ReadByte();
     sizeRead := reader.GetSizeRead();
     isDoneReading := reader.IsDoneReading();
-    var _ :- RequireFailure(isByteFailure);
-    var _ :- RequireEqual(10, sizeRead);
-    var _ :- Require(isDoneReading);
+    :- RequireFailure(isByteFailure);
+    :- RequireEqual(10, sizeRead);
+    :- Require(isDoneReading);
 
     var isBytesFailure := reader.ReadBytes(1);
     sizeRead := reader.GetSizeRead();
     isDoneReading := reader.IsDoneReading();
-    var _ :- RequireFailure(isBytesFailure);
-    var _ :- RequireEqual(10, sizeRead);
-    var _ :- Require(isDoneReading);
+    :- RequireFailure(isBytesFailure);
+    :- RequireEqual(10, sizeRead);
+    :- Require(isDoneReading);
 
     var isUint16Failure := reader.ReadUInt16();
     sizeRead := reader.GetSizeRead();
     isDoneReading := reader.IsDoneReading();
-    var _ :- RequireFailure(isUint16Failure);
-    var _ :- RequireEqual(10, sizeRead);
-    var _ :- Require(isDoneReading);
+    :- RequireFailure(isUint16Failure);
+    :- RequireEqual(10, sizeRead);
+    :- Require(isDoneReading);
 
     var isUint32Failure := reader.ReadUInt32();
     sizeRead := reader.GetSizeRead();
     isDoneReading := reader.IsDoneReading();
-    var _ :- RequireFailure(isUint32Failure);
-    var _ :- RequireEqual(10, sizeRead);
+    :- RequireFailure(isUint32Failure);
+    :- RequireEqual(10, sizeRead);
     r := Require(isDoneReading);
   }
 
-  method {:test} TestSeqWriter() returns (r: Result<()>) {
+  method {:test} TestSeqWriter() returns (r: TestResult) {
     var writer := new Streams.SeqWriter<nat>();
-    var _ :- RequireEqual([], writer.data);
+    :- RequireEqual([], writer.data);
 
     var elemSize := writer.WriteElements([]);
-    var _ :- RequireEqual(0, elemSize);
-    var _ :- RequireEqual([], writer.data);
+    :- RequireEqual(0, elemSize);
+    :- RequireEqual([], writer.data);
 
     elemSize := writer.WriteElements([0, 100, 200]);
-    var _ :- RequireEqual(3, elemSize);
-    var _ :- RequireEqual([0, 100, 200], writer.data);
+    :- RequireEqual(3, elemSize);
+    :- RequireEqual([0, 100, 200], writer.data);
 
     elemSize := writer.WriteElements([300, 400, 500, 600]);
-    var _ :- RequireEqual(4, elemSize);
+    :- RequireEqual(4, elemSize);
     r := RequireEqual([0, 100, 200, 300, 400, 500, 600], writer.data);
   }
 
-  method {:test} TestByteWriter() returns (r: Result<()>) {
+  method {:test} TestByteWriter() returns (r: TestResult) {
     var writer := new Streams.ByteWriter();
     var dataWritten := writer.GetDataWritten();
-    var _ :- RequireEqual([], dataWritten);
+    :- RequireEqual([], dataWritten);
     var sizeWritten := writer.GetSizeWritten();
-    var _ :- RequireEqual(0, sizeWritten);
+    :- RequireEqual(0, sizeWritten);
 
     var res := writer.WriteByte(0);
-    var _ :- RequireEqual(1, res);
+    :- RequireEqual(1, res);
     dataWritten := writer.GetDataWritten();
-    var _ :- RequireEqual([0], dataWritten);
+    :- RequireEqual([0], dataWritten);
     sizeWritten := writer.GetSizeWritten();
-    var _ :- RequireEqual(1, sizeWritten);
+    :- RequireEqual(1, sizeWritten);
 
     res := writer.WriteBytes([]);
-    var _ :- RequireEqual(0, res);
+    :- RequireEqual(0, res);
     dataWritten := writer.GetDataWritten();
-    var _ :- RequireEqual([0], dataWritten);
+    :- RequireEqual([0], dataWritten);
     sizeWritten := writer.GetSizeWritten();
-    var _ :- RequireEqual(1, sizeWritten);
+    :- RequireEqual(1, sizeWritten);
 
     res := writer.WriteBytes([5, 50, 100]);
-    var _ :- RequireEqual(3, res);
+    :- RequireEqual(3, res);
     dataWritten := writer.GetDataWritten();
-    var _ :- RequireEqual([0, 5, 50, 100], dataWritten);
+    :- RequireEqual([0, 5, 50, 100], dataWritten);
     sizeWritten := writer.GetSizeWritten();
-    var _ :- RequireEqual(4, sizeWritten);
+    :- RequireEqual(4, sizeWritten);
 
     var uint16Written := SeqToUInt16([150, 200]);
     res := writer.WriteUInt16(uint16Written);
-    var _ :- RequireEqual(2, res);
+    :- RequireEqual(2, res);
     dataWritten := writer.GetDataWritten();
-    var _ :- RequireEqual([0, 5, 50, 100, 150, 200], dataWritten);
+    :- RequireEqual([0, 5, 50, 100, 150, 200], dataWritten);
     sizeWritten := writer.GetSizeWritten();
-    var _ :- RequireEqual(6, sizeWritten);
+    :- RequireEqual(6, sizeWritten);
 
     var uint32Written := SeqToUInt32([50, 150, 200, 255]);
     res := writer.WriteUInt32(uint32Written);
-    var _ :- RequireEqual(4, res);
+    :- RequireEqual(4, res);
     dataWritten := writer.GetDataWritten();
-    var _ :- RequireEqual([0, 5, 50, 100, 150, 200, 50, 150, 200, 255], dataWritten);
+    :- RequireEqual([0, 5, 50, 100, 150, 200, 50, 150, 200, 255], dataWritten);
     sizeWritten := writer.GetSizeWritten();
     r := RequireEqual(10, sizeWritten);
   }

--- a/test/Util/UTF8.dfy
+++ b/test/Util/UTF8.dfy
@@ -6,169 +6,169 @@ module TestUTF8 {
   import opened UInt = StandardLibrary.UInt
   import opened UTF8
 
-  method {:test} TestEncodeHappyCase() returns (r: Result<()>) {
+  method {:test} TestEncodeHappyCase() returns (r: TestResult) {
     var unicodeString := "abc\u0306\u01FD\u03B2";
     var expectedBytes := [0x61, 0x62, 0x63, 0xCC, 0x86, 0xC7, 0xBD, 0xCE, 0xB2];
     var encoded :- UTF8.Encode(unicodeString);
     r := RequireEqual(expectedBytes, encoded);
   }
 
-  method {:test} TestEncodeInvalidUnicode() returns (r: Result<()>) {
+  method {:test} TestEncodeInvalidUnicode() returns (r: TestResult) {
     // Create string with UTF-16 surrogate (\uD800)
     var invalidUnicode := "abc\uD800";
     var encoded := UTF8.Encode(invalidUnicode);
     r := RequireFailure(encoded);
   }
 
-  method {:test} TestDecodeHappyCase() returns (r: Result<()>) {
+  method {:test} TestDecodeHappyCase() returns (r: TestResult) {
     var unicodeBytes := [0x61, 0x62, 0x63, 0xCC, 0x86, 0xC7, 0xBD, 0xCE, 0xB2];
     var expectedString := "abc\u0306\u01FD\u03B2";
     var decoded :- UTF8.Decode(unicodeBytes);
     r := RequireEqual(expectedString, decoded);
   }
 
-  method {:test} TestDecodeInvalidUnicode() returns (r: Result<()>) {
+  method {:test} TestDecodeInvalidUnicode() returns (r: TestResult) {
     // Create byte sequence with UTF-16 surrogate (0xEDA080)
     var invalidUnicode := [0x61, 0x62, 0x63, 0xED, 0xA0, 0x80];
     r := Require(!ValidUTF8Seq(invalidUnicode));
   }
 
-  method {:test} Test1Byte() returns (r: Result<()>) {
+  method {:test} Test1Byte() returns (r: TestResult) {
     // Null
     var decoded := "\u0000";
     var encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0x00], encoded);
-    var _ :- Require(Uses1Byte(encoded));
+    :- RequireEqual([0x00], encoded);
+    :- Require(Uses1Byte(encoded));
     var redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     // Space
     decoded := "\u0020";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0x20], encoded);
-    var _ :- Require(Uses1Byte(encoded));
+    :- RequireEqual([0x20], encoded);
+    :- Require(Uses1Byte(encoded));
     redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     decoded := "$";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0x24], encoded);
-    var _ :- Require(Uses1Byte(encoded));
+    :- RequireEqual([0x24], encoded);
+    :- Require(Uses1Byte(encoded));
     redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     decoded := "0";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0x30], encoded);
-    var _ :- Require(Uses1Byte(encoded));
+    :- RequireEqual([0x30], encoded);
+    :- Require(Uses1Byte(encoded));
     redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     decoded := "A";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0x41], encoded);
-    var _ :- Require(Uses1Byte(encoded));
+    :- RequireEqual([0x41], encoded);
+    :- Require(Uses1Byte(encoded));
     redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     decoded := "a";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0x61], encoded);
-    var _ :- Require(Uses1Byte(encoded));
+    :- RequireEqual([0x61], encoded);
+    :- Require(Uses1Byte(encoded));
     redecoded :- UTF8.Decode(encoded);
     r := RequireEqual(decoded, redecoded);
   }
 
-  method {:test} Test2Bytes() returns (r: Result<()>) {
+  method {:test} Test2Bytes() returns (r: TestResult) {
     // British pound
     var decoded := "\u00A3";
     var encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xC2, 0xA3], encoded);
-    var _ :- Require(Uses2Bytes(encoded));
+    :- RequireEqual([0xC2, 0xA3], encoded);
+    :- Require(Uses2Bytes(encoded));
     var redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     // Copyright
     decoded := "\u00A9";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xC2, 0xA9], encoded);
-    var _ :- Require(Uses2Bytes(encoded));
+    :- RequireEqual([0xC2, 0xA9], encoded);
+    :- Require(Uses2Bytes(encoded));
     redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     // Registered
     decoded := "\u00AE";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xC2, 0xAE], encoded);
-    var _ :- Require(Uses2Bytes(encoded));
+    :- RequireEqual([0xC2, 0xAE], encoded);
+    :- Require(Uses2Bytes(encoded));
     redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     // Greek Pi
     decoded := "\u03C0";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xCF, 0x80], encoded);
-    var _ :- Require(Uses2Bytes(encoded));
+    :- RequireEqual([0xCF, 0x80], encoded);
+    :- Require(Uses2Bytes(encoded));
     redecoded :- UTF8.Decode(encoded);
     r := RequireEqual(decoded, redecoded);
   }
 
-  method {:test} Test3Bytes() returns (r: Result<()>) {
+  method {:test} Test3Bytes() returns (r: TestResult) {
     // Enter symbol
     var decoded := "\u2386";
     var encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xE2, 0x8E, 0x86], encoded);
-    var _ :- Require(Uses3Bytes(encoded));
+    :- RequireEqual([0xE2, 0x8E, 0x86], encoded);
+    :- Require(Uses3Bytes(encoded));
     var redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     // Alternative key
     decoded := "\u2387";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xE2, 0x8E, 0x87], encoded);
-    var _ :- Require(Uses3Bytes(encoded));
+    :- RequireEqual([0xE2, 0x8E, 0x87], encoded);
+    :- Require(Uses3Bytes(encoded));
     redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     // Hourglass emoji
     decoded := "\u231B";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xE2, 0x8C, 0x9B], encoded);
-    var _ :- Require(Uses3Bytes(encoded));
+    :- RequireEqual([0xE2, 0x8C, 0x9B], encoded);
+    :- Require(Uses3Bytes(encoded));
     redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     // Modifier letter cyrillic EN
     decoded := "\u1D78";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xE1, 0xB5, 0xB8], encoded);
-    var _ :- Require(Uses3Bytes(encoded));
+    :- RequireEqual([0xE1, 0xB5, 0xB8], encoded);
+    :- Require(Uses3Bytes(encoded));
     redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     // Chinese cat (mao)
     decoded := "\u732B";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xE7, 0x8C, 0xAB], encoded);
-    var _ :- Require(Uses3Bytes(encoded));
+    :- RequireEqual([0xE7, 0x8C, 0xAB], encoded);
+    :- Require(Uses3Bytes(encoded));
     redecoded :- UTF8.Decode(encoded);
     r := RequireEqual(decoded, redecoded);
   }
 
-  method {:test} Test4Bytes() returns (r: Result<()>) {
+  method {:test} Test4Bytes() returns (r: TestResult) {
     // Cuneiform Sign A - represented as a surrogate of U+12000
     var decoded := "\uD808\uDC00";
     var encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xF0, 0x92, 0x80, 0x80], encoded);
-    var _ :- Require(Uses4Bytes(encoded));
+    :- RequireEqual([0xF0, 0x92, 0x80, 0x80], encoded);
+    :- Require(Uses4Bytes(encoded));
     var redecoded :- UTF8.Decode(encoded);
-    var _ :- RequireEqual(decoded, redecoded);
+    :- RequireEqual(decoded, redecoded);
 
     // Mathematical Sans-Serif Bold Italic Small Psi - represented as a surrogate of U+1D7C1
     decoded := "\uD835\uDFC1";
     encoded :- UTF8.Encode(decoded);
-    var _ :- RequireEqual([0xF0, 0x9D, 0x9F, 0x81], encoded);
-    var _ :- Require(Uses4Bytes(encoded));
+    :- RequireEqual([0xF0, 0x9D, 0x9F, 0x81], encoded);
+    :- Require(Uses4Bytes(encoded));
     redecoded :- UTF8.Decode(encoded);
     r := RequireEqual(decoded, redecoded);
   }

--- a/test/hkdf/HKDF.dfy
+++ b/test/hkdf/HKDF.dfy
@@ -8,7 +8,7 @@ module {:extern "TestHKDF"} TestHKDF {
   import opened HKDF
   import opened Digests
 
-  method {:test} Test0() returns (r: Result<()>) {
+  method {:test} Test0() returns (r: TestResult) {
     // Test vector 0: Basic test case with SHA-256
     var tv_ikm  := new [][ 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
                              0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b ];
@@ -26,7 +26,7 @@ module {:extern "TestHKDF"} TestHKDF {
     return RequireEqual(tv_okm_desired[..], okm[..]);
   }
 
-  method {:test} Test1() returns (r: Result<()>) {
+  method {:test} Test1() returns (r: TestResult) {
     // Test vector 1:  Test with SHA-256 and longer inputs/outputs
     var tv_ikm  := new [][ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
                            0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
@@ -61,7 +61,7 @@ module {:extern "TestHKDF"} TestHKDF {
     return RequireEqual(tv_okm_desired[..], okm[..]);
   }
 
-  method {:test} Test2() returns (r: Result<()>) {
+  method {:test} Test2() returns (r: TestResult) {
     // Test vector 2: Test with SHA-256 and zero-length salt/info
     var tv_salt := None;
 
@@ -79,7 +79,7 @@ module {:extern "TestHKDF"} TestHKDF {
     return RequireEqual(tv_okm_desired[..], okm[..]);
   }
 
-  method {:test} Test3() returns (r: Result<()>) {
+  method {:test} Test3() returns (r: TestResult) {
     // Test vector 3: Basic test case with SHA-384
     var tv_salt := new [][ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c ];
 
@@ -97,7 +97,7 @@ module {:extern "TestHKDF"} TestHKDF {
     return RequireEqual(tv_okm_desired[..], okm[..]);
   }
 
-  method {:test} Test4() returns (r: Result<()>) {
+  method {:test} Test4() returns (r: TestResult) {
     // Test vector 4:  Test with SHA-384 and longer inputs/outputs
     var tv_salt := new [][ 0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d,
                            0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x7b,
@@ -132,7 +132,7 @@ module {:extern "TestHKDF"} TestHKDF {
     return RequireEqual(tv_okm_desired[..], okm[..]);
   }
 
-  method {:test} Test5() returns (r: Result<()>) {
+  method {:test} Test5() returns (r: TestResult) {
     // Test vector 5: Test with SHA-384 and zero-length salt/info
     var tv_salt := None;
 
@@ -150,7 +150,7 @@ module {:extern "TestHKDF"} TestHKDF {
     return RequireEqual(tv_okm_desired[..], okm[..]);
   }
 
-  method {:test} Test7() returns (r: Result<()>) {
+  method {:test} Test7() returns (r: TestResult) {
     // Test vector 7: Test with SHA-256 for N = ceil(L/HashLen) = 255
     var tv_ikm  := new [][ 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
                            0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b ];


### PR DESCRIPTION
*Description of changes:*

This PR-for-consideration uses Dafny's PR https://github.com/dafny-lang/dafny/pull/537,
which extends the functionality of `:-`. In particular, it is now possible to have a
`TestResult` type that `Result` converts to. The benefit to the ESDK is that we get rid
of those `var _` left-hand sides in front of `:- Require(...)`.

See what you think. If you like the result, we should vote for the Dafny extension in the
PR above. As a language extension, it's slightly quirky (well, it wouldn't be quirky if Dafny
already supported method overloading). So, as a language feature, I see this PR and the
Dafny PR as a way to experiment with improvements of `:-`. That is, I hope that merging
these PRs will lead us to realize what we _really_ want `:-` to do.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
