### PR TITLE
fix: Exclude temporary emacs files from test files

### DIFF
--- a/test/AWSEncryptionSDKTests.csproj
+++ b/test/AWSEncryptionSDKTests.csproj
@@ -27,7 +27,9 @@
   -->
   <ItemGroup>
     <DafnySource Include="../src/**/*.dfy" />
+    <!-- While a file is being edited in emacs, emacs spills out a .# copy of the file -->
     <DafnySource Remove="**/.#*.dfy" />
+    <!-- While a file is being verified in emacs, the Dafny plug-in spills out a flycheck_ copy of the file -->
     <DafnySource Remove="**/flycheck_*.dfy" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This makes it easier to have an emacs buffer open while working on the ESDK.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
