### PR TITLE
Add RawAESKeyring to Decrypt vector tests

### DIFF
--- a/src/api/dotnet/DafnyFFI.cs
+++ b/src/api/dotnet/DafnyFFI.cs
@@ -62,6 +62,9 @@ public class DafnyFFI {
     public enum RSAPaddingModes {
         PKCS1, OAEP_SHA1, OAEP_SHA256, OAEP_SHA384, OAEP_SHA512
     }
+    public enum AESWrappingAlgorithm {
+        AES_GCM_128, AES_GCM_192, AES_GCM_256
+    }
 }
 
 public class DafnyException : Exception {

--- a/src/api/dotnet/Keyrings.cs
+++ b/src/api/dotnet/Keyrings.cs
@@ -37,6 +37,24 @@ namespace AWSEncryptionSDK
             result.__ctor(generator, children);
             return result;
         }
+        public static RawAESKeyring MakeRawAESKeyring(byte[] nameSpace, byte[] name, byte[] wrappingKey, DafnyFFI.AESWrappingAlgorithm wrappingAlgorithm)
+        {
+            // TODO: Check for null values, consider taking a CipherParams class instead of enum.
+            RawAESKeyring result = new RawAESKeyring();
+            EncryptionSuites.EncryptionSuite wrappingAlgDafny = wrappingAlgorithm switch {
+                DafnyFFI.AESWrappingAlgorithm.AES_GCM_128 => EncryptionSuites.__default.AES__GCM__128,
+                DafnyFFI.AESWrappingAlgorithm.AES_GCM_192 => EncryptionSuites.__default.AES__GCM__192,
+                DafnyFFI.AESWrappingAlgorithm.AES_GCM_256 => EncryptionSuites.__default.AES__GCM__256,
+                _ => throw new ArgumentException("Unsupported AES Wrapping Algorithm")
+            };
+            result.__ctor(
+                    DafnyFFI.SequenceFromByteArray(nameSpace),
+                    DafnyFFI.SequenceFromByteArray(name),
+                    DafnyFFI.SequenceFromByteArray(wrappingKey),
+                    wrappingAlgDafny
+                    );
+            return result;
+        }
         public static RawRSAKeyring MakeRawRSAKeyring(byte[] nameSpace, byte[] name, DafnyFFI.RSAPaddingModes paddingMode, byte[] publicKey, byte[] privateKey)
         {
             // TODO: check for null values, ensure at least one key is non-null.

--- a/testVectors/TestVectors.cs
+++ b/testVectors/TestVectors.cs
@@ -116,11 +116,6 @@ namespace TestVectorTests {
                 string vectorID = vectorEntry.Key;
                 TestVector vector = vectorEntry.Value;
                 
-                //TODO: Remove this if-block once we can test the RawAESKeyring.
-                if (VectorContainsRawAESKey(vector)) {
-                    continue;
-                }
-
                 string plaintextPath = ManifestURIToPath(vector.plaintext, vectorRoot);
                 if (!File.Exists(plaintextPath)) {
                     throw new ArgumentException($"Could not find plaintext file at path: {plaintextPath}");
@@ -190,8 +185,12 @@ namespace TestVectorTests {
                 ClientSupplier clientSupplier = new DefaultClientSupplier();
                 return Keyrings.MakeKMSKeyring(clientSupplier, Enumerable.Empty<String>(), key.ID, Enumerable.Empty<String>());
             } else if (keyInfo.type == "raw" && keyInfo.encryptionAlgorithm == "aes") {
-                //TODO: Once RawAESKeyring is ready for tests, add it here.
-                return new MultiKeyring();
+                return Keyrings.MakeRawAESKeyring(
+                        Encoding.UTF8.GetBytes(keyInfo.providerID),
+                        Encoding.UTF8.GetBytes(key.ID),
+                        Convert.FromBase64String(key.material),
+                        AESAlgorithmFromBits(key.bits)
+                        );
             } else if (keyInfo.type == "raw" && keyInfo.encryptionAlgorithm == "rsa") {
                 return Keyrings.MakeRawRSAKeyring(
                         Encoding.UTF8.GetBytes(keyInfo.providerID),
@@ -204,6 +203,14 @@ namespace TestVectorTests {
             else {
                 throw new Exception("Unsupported keyring type!");
             }
+        }
+        private static DafnyFFI.AESWrappingAlgorithm AESAlgorithmFromBits(ushort bits) {
+            return bits switch {
+                128 => DafnyFFI.AESWrappingAlgorithm.AES_GCM_128,
+                192 => DafnyFFI.AESWrappingAlgorithm.AES_GCM_192,
+                256 => DafnyFFI.AESWrappingAlgorithm.AES_GCM_256,
+                _ => throw new Exception("Unsupported AES wrapping algorithm")
+            };
         }
         private static DafnyFFI.RSAPaddingModes RSAPAddingFromStrings(string strAlg, string strHash) {
             return (strAlg, strHash) switch {


### PR DESCRIPTION
*Issue #, if available:* #180 

*Description of changes:* Added temporary shim code to instantiate a `RawAESKeyring` from C# code, and removed the continue statement stopping AES decrypt tests in `TestVectors.cs`.

`MakeRawAESKeyring()` should be replaced with whatever method expose to users for `RawAESKeyring` instantiation when available.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
