### PR TITLE
Lock Dafny to a specific commit

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,7 @@ phases:
       - msbuild boogie/Source/Boogie.sln
       # Get Dafny
       - git clone https://github.com/microsoft/dafny.git
-      # Although Dafny does has releases, we often need a newer hash than the latest release, while still needing the
+      # Although Dafny does have releases, we often need a newer hash than the latest release, while still needing the
       # the security of reproducible builds.
       - cd dafny
       - git reset --hard 3f31d66499ab5e2e5d9a7b21f541de5b1d3eb585


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-encryption-sdk-dafny/issues/182

*Description of changes:*
Locking the version of Dafny to a commit. I don't believe you can checkout a specific hash, and Dafny does not use release tags/ release branches. 

`reset --hard` ensures there isn't any "detached head" issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
