### PR TITLE
fix: Make Option be co-variant in its type argument

### DIFF
--- a/src/StandardLibrary/StandardLibrary.dfy
+++ b/src/StandardLibrary/StandardLibrary.dfy
@@ -4,7 +4,7 @@ module {:extern "STL"} StandardLibrary {
   import opened U = UInt
 
   // TODO: Depend on types defined in dafny-lang/libraries instead
-  datatype Option<T> = None | Some(get: T)
+  datatype Option<+T> = None | Some(get: T)
   {
     function method ToResult(): Result<T> {
       match this


### PR DESCRIPTION
*Description of changes:*

This makes sense for the type Option and could have been done before.
We need it in writing a nice `KeyRepr` function for keyrings (see upcoming PR).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
