### PR TITLE
fix: build breaks with latest Dafny

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,7 +18,7 @@ phases:
       # Although Dafny does have releases, we often need a newer hash than the latest release, while still needing the
       # the security of reproducible builds.
       - cd dafny
-      - git reset --hard 2bebbe235cf470b071be4cdb99b9b34f14229cae
+      - git reset --hard 5ca6ef8347c9675b6824e987967925b1208ca47c
       - cd ..
       - nuget restore dafny/Source/Dafny.sln
       - msbuild dafny/Source/Dafny.sln

--- a/test/Util/TestUtils.dfy
+++ b/test/Util/TestUtils.dfy
@@ -87,7 +87,7 @@ module {:extern "TestUtils"} TestUtils {
       var keys: seq<UTF8.ValidUTF8Bytes> := SetToOrderedSequence(encryptionContext.Keys, UInt.UInt8Less);
       var kvPairs := seq(|keys|, i requires 0 <= i < |keys| => (keys[i], encryptionContext[keys[i]]));
       KVPairsLengthBound(kvPairs, |kvPairs|, 200);
-      assert MessageHeader.KVPairEntriesLength(kvPairs, 0, |kvPairs|) <= 5 * 204;
+      assert MessageHeader.KVPairEntriesLength(kvPairs, 0, |kvPairs|) <= (5 * 204) as nat;
     }
   }
 


### PR DESCRIPTION
As seen in https://github.com/awslabs/aws-encryption-sdk-dafny/pull/246 updating Dafny fails. From investigating different commits, I found the offending commit to be https://github.com/dafny-lang/dafny/commit/64cd62199ea1413d8f76bb7cf256645e284f6cff which handles some number conversion differences.

This change updates to the latest version of Dafny and fixes the current assertion failure, which appears to have been caused by a type mismatch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
