### PR TITLE
chore: Faster proof of TestUtils.ValidSmallEncryptionContext

### DIFF
--- a/test/Util/TestUtils.dfy
+++ b/test/Util/TestUtils.dfy
@@ -84,10 +84,20 @@ module {:extern "TestUtils"} TestUtils {
   {
     reveal MessageHeader.ValidAAD();
     assert MessageHeader.KVPairsLength(encryptionContext) < UINT16_LIMIT by {
-      var keys: seq<UTF8.ValidUTF8Bytes> := SetToOrderedSequence(encryptionContext.Keys, UInt.UInt8Less);
-      var kvPairs := seq(|keys|, i requires 0 <= i < |keys| => (keys[i], encryptionContext[keys[i]]));
-      KVPairsLengthBound(kvPairs, |kvPairs|, 200);
-      assert MessageHeader.KVPairEntriesLength(kvPairs, 0, |kvPairs|) <= (5 * 204) as nat;
+      if |encryptionContext| != 0 {
+        var keys: seq<UTF8.ValidUTF8Bytes> := SetToOrderedSequence(encryptionContext.Keys, UInt.UInt8Less);
+        var kvPairs := seq(|keys|, i requires 0 <= i < |keys| => (keys[i], encryptionContext[keys[i]]));
+        assert MessageHeader.KVPairsLength(encryptionContext) ==
+          2 + MessageHeader.KVPairEntriesLength(kvPairs, 0, |kvPairs|);
+
+        var n := |kvPairs|;
+        assert n <= 5;
+        
+        assert MessageHeader.KVPairEntriesLength(kvPairs, 0, n) <= n * 204 by {
+          KVPairsLengthBound(kvPairs, |kvPairs|, 200);
+        }
+        assert n * 204 <= 1020 < UINT16_LIMIT;
+      }
     }
   }
 


### PR DESCRIPTION
PR #247 provided a temporary fix for the getting the proof of `TestUtils.ValidSmallEncryptionContext` to go through. The verifier has been shown to be flakey on this lemma. Looking into it, I think the flakiness comes from the use of non-linear arithmetic in the call to the `KVPairsLengthBound` lemma. This PR provides a slightly more detailed proof, which hopes to hand-guide the verifier to a proof, without going down some non-linear rat hole.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
