### PR TITLE
refactor: Change Client.{Encrypt,Decrypt}Request from class to datatype

### DIFF
--- a/src/api/dotnet/Client.cs
+++ b/src/api/dotnet/Client.cs
@@ -54,15 +54,15 @@ namespace AWSEncryptionSDK
                 var dafnyPlaintext = DafnyFFI.SequenceFromMemoryStream(this.plaintext);
                 var optionalAlgID = this.algorithmSuiteID != null ? STL.Option<ushort>.create_Some((ushort)this.algorithmSuiteID) : STL.Option<ushort>.create_None();
 
-                return new ESDKClient.EncryptRequest{
-                    plaintext = dafnyPlaintext,
-                    cmm = this.cmm,
-                    keyring = this.keyring,
-                    plaintextLength = new BigInteger(dafnyPlaintext.Count),
-                    encryptionContext = ToDafnyEncryptionContext(this.encryptionContext),
-                    algorithmSuiteID = optionalAlgID,
-                    frameLength = this.frameLength != null ? STL.Option<uint>.create_Some((uint)this.frameLength) : STL.Option<uint>.create_None()
-                };
+                return ESDKClient.EncryptRequest.create(
+                    plaintext: dafnyPlaintext,
+                    cmm: this.cmm,
+                    keyring: this.keyring,
+                    plaintextLength: new BigInteger(dafnyPlaintext.Count),
+                    encryptionContext: ToDafnyEncryptionContext(this.encryptionContext),
+                    algorithmSuiteID: optionalAlgID,
+                    frameLength: this.frameLength != null ? STL.Option<uint>.create_Some((uint)this.frameLength) : STL.Option<uint>.create_None()
+                );
             }
         }
 
@@ -78,11 +78,11 @@ namespace AWSEncryptionSDK
 
                 var dafnyMessage = DafnyFFI.SequenceFromMemoryStream(this.message);
 
-                return new ESDKClient.DecryptRequest{
-                    message = dafnyMessage,
-                    cmm = this.cmm,
-                    keyring = this.keyring
-                };
+                return ESDKClient.DecryptRequest.create(
+                    message: dafnyMessage,
+                    cmm: this.cmm,
+                    keyring: this.keyring
+                );
             }
         }
     }

--- a/test/KMS/Integration.dfy
+++ b/test/KMS/Integration.dfy
@@ -53,8 +53,7 @@ module IntegTestKMS {
       expect encodeResult.Success?, "Failed to encode :( " + encodeResult.error + "\n";
       var encodedMsg := encodeResult.value;
       var encryptionContext := SmallEncryptionContext(SmallEncryptionContextVariation.A);
-      var encryptRequest := new Client.EncryptRequest.WithCMM(encodedMsg, cmm);
-      encryptRequest.SetEncryptionContext(encryptionContext);
+      var encryptRequest := Client.EncryptRequest.WithCMM(encodedMsg, cmm).SetEncryptionContext(encryptionContext);
       var e := Client.Encrypt(encryptRequest);
       if shouldFailGetClient {
         expect e.Failure?, "Successfully called GetClient when the call should have failed";
@@ -62,7 +61,7 @@ module IntegTestKMS {
       }
       expect e.Success?, "Bad encryption :( " + e.error + "\n";
 
-      var decryptRequest := new Client.DecryptRequest.WithCMM(e.value, cmm);
+      var decryptRequest := Client.DecryptRequest.WithCMM(e.value, cmm);
       var d := Client.Decrypt(decryptRequest);
       expect d.Success?, "bad decryption: " + d.error + "\n";
 

--- a/test/SDK/Client.dfy
+++ b/test/SDK/Client.dfy
@@ -43,11 +43,10 @@ module {:extern "TestClient"} TestClient {
       var msg :- expect UTF8.Encode("hello");
       var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
 
-      var encryptRequest := new Client.EncryptRequest.WithCMM(msg, cmm);
-      encryptRequest.SetEncryptionContext(encryptionContext);
+      var encryptRequest := Client.EncryptRequest.WithCMM(msg, cmm).SetEncryptionContext(encryptionContext);
       var e :- expect Client.Encrypt(encryptRequest);
 
-      var decryptRequest := new Client.DecryptRequest.WithCMM(e, cmm);
+      var decryptRequest := Client.DecryptRequest.WithCMM(e, cmm);
       var d :- expect Client.Decrypt(decryptRequest);
 
       expect msg == d;
@@ -66,8 +65,7 @@ module {:extern "TestClient"} TestClient {
   method {:test} EncryptCMMKeyringOverload() {
     var kr :- expect TestUtils.MakeRSAKeyring();
     var cmm := new DefaultCMMDef.DefaultCMM.OfKeyring(kr);
-    var badRequest := new Client.EncryptRequest.WithCMM([0], cmm);
-    badRequest.keyring := kr;
+    var badRequest := Client.EncryptRequest.WithCMM([0], cmm).(keyring := kr);
 
     var result := Client.Encrypt(badRequest);
 
@@ -77,8 +75,7 @@ module {:extern "TestClient"} TestClient {
 
   method {:test} EncryptInvalidAlgID() {
     var kr :- expect TestUtils.MakeRSAKeyring();
-    var badRequest := new Client.EncryptRequest.WithKeyring([0], kr);
-    badRequest.SetAlgorithmSuiteID(0);
+    var badRequest := Client.EncryptRequest.WithKeyring([0], kr).SetAlgorithmSuiteID(0);
 
     var result := Client.Encrypt(badRequest);
 
@@ -88,8 +85,7 @@ module {:extern "TestClient"} TestClient {
 
   method {:test} EncryptFrameLengthZero() {
     var kr :- expect TestUtils.MakeRSAKeyring();
-    var badRequest := new Client.EncryptRequest.WithKeyring([0], kr);
-    badRequest.SetFrameLength(0);
+    var badRequest := Client.EncryptRequest.WithKeyring([0], kr).SetFrameLength(0);
 
     var result := Client.Encrypt(badRequest);
 
@@ -100,8 +96,7 @@ module {:extern "TestClient"} TestClient {
   method {:test} DecryptCMMKeyringOverload() {
     var kr :- expect TestUtils.MakeRSAKeyring();
     var cmm := new DefaultCMMDef.DefaultCMM.OfKeyring(kr);
-    var badRequest := new Client.DecryptRequest.WithCMM([0], cmm);
-    badRequest.keyring := kr;
+    var badRequest := Client.DecryptRequest.WithCMM([0], cmm).(keyring := kr);
 
     var result := Client.Decrypt(badRequest);
 


### PR DESCRIPTION
*Description of changes:*

This PR is a suggestion to change the EncryptRequest and DecryptRequest types in Client to be datatypes instead of classes. Since the purpose of these types is to bundle up various parameters of the requests, it makes more sense to have them be immutable datatype values rather than objects on the heap with mutable fields.

In the Dafny code, this simplifies the specifications in Client (see lines 98-99 and 197-198).

In the generated C# code, these types are still classes (since C# doesn't know what a datatype is). How they are constructed in C# is slightly different, and the fields in the classes get declared to be `readonly`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
