### PR TITLE
feat: add trait for Enumerator and Aggregator interfaces

### DIFF
--- a/src/StandardLibrary/Collections.dfy
+++ b/src/StandardLibrary/Collections.dfy
@@ -1,0 +1,321 @@
+include "StandardLibrary.dfy"
+
+module {:extern "Collections"} Collections {
+  import opened StandardLibrary
+
+  // Enumerator is an interface for enumerating finite elements of type T
+  trait {:termination false} Enumerator<T> {
+    var signaledDone: bool
+    var hasFailed: bool
+    ghost var Repr: set<object>
+
+    predicate Valid() reads this, Repr ensures Valid() ==> this in Repr
+
+    // Next returns the next element T in the enumeration, Success(None) to
+    // indicate the end of elements, or a Failure.
+    // If calling after the end of elements has already been indicated,
+    // returns a Failure.
+    // If a Failure has been returned, the enumerator goes into a failed state
+    // and will always return a Failure on Next()
+    method Next() returns (element: Result<Option<T>>)
+      requires Valid()
+      modifies Repr
+      ensures Valid()
+      ensures Repr == old(Repr)
+      ensures old(signaledDone) || old(hasFailed) ==> element.Failure?
+      ensures element.Failure? ==> hasFailed
+      ensures element.Success? && element.value.None? ==> signaledDone
+  }
+
+  // Aggregator is an interface for aggregating finite elements of type T
+  trait {:termination false} Aggregator<T> {
+    ghost var Repr: set<object>
+    var done: bool
+    var hasFailed: bool
+
+    predicate Valid() reads this, Repr ensures Valid() ==> this in Repr
+
+    // Accept puts the input element T into the aggregation and returns Success(true),
+    // does not put the input element T into the aggregation and returns Success(false),
+    // or returns a Failure.
+    // If a Sucess(false) is returned, Accept() or End() are allowed to be called again.
+    // If a Failure has been returned, the aggregator goes into a failed state
+    // and will always return a Failure on Next()
+    method Accept(element: T) returns (res: Result<bool>)
+      requires Valid()
+      modifies Repr
+      ensures Valid()
+      ensures Repr == old(Repr)
+      ensures old(done) || old(hasFailed) ==> res.Failure?
+      ensures res.Failure? ==> hasFailed
+
+    // End signals the end of the aggregation and returns Success(true),
+    // does not signal the end of the aggregation and returns Success(false),
+    // or returns a Failure.
+    // If a Sucess(false) is returned, Accept() or End() are allowed to be called again.
+    // If a Failure has been returned, the aggregator goes into a failed state
+    // and will always return a Failure on Next()
+    method End() returns (res: Result<bool>)
+      requires Valid()
+      modifies Repr
+      ensures Valid()
+      ensures Repr == old(Repr)
+      ensures old(done) || old(hasFailed) ==> res.Failure?
+      ensures res.Failure? ==> hasFailed
+      ensures res.Success? && res.value ==> done
+  }
+
+  // SeqEnumerator implements an enumerator which enumerates one T at a time from an underlying seq<T>
+  class SeqEnumerator<T> extends Enumerator<T> {
+    const s: seq<T>
+    ghost var enumerated: seq<T>
+    var i: nat
+
+    predicate Valid() reads this, Repr ensures Valid() ==> this in Repr
+    {
+      && i <= |s|
+      && enumerated == s[..i]
+      && this in Repr 
+    }
+
+    constructor (data: seq<T>)
+      ensures s == data
+      ensures enumerated == []
+      ensures !signaledDone
+      ensures !hasFailed
+      ensures i == 0
+      ensures Valid() && fresh(Repr)
+    {
+        s := data;
+        enumerated := [];
+        signaledDone := false;
+        hasFailed := false;
+        i := 0;
+        Repr := {this};
+    }
+    
+    method Next() returns (element: Result<Option<T>>)
+      requires Valid()
+      modifies Repr
+      ensures Valid()
+      ensures Repr == old(Repr)
+      ensures old(signaledDone) || old(hasFailed) ==> element.Failure?
+      ensures element.Failure? ==> hasFailed
+      ensures element.Success? && element.value.None? ==> signaledDone
+      ensures !signaledDone && !hasFailed && old(i) < |s| ==>
+        && i == old(i) + 1
+        && element.Success?
+        && element.value.Some?
+        && element.value.get == s[old(i)]
+      ensures !signaledDone && !hasFailed && old(i) == |s| ==>
+        && i == |s|
+        && element.Success?
+        && element.value.None?
+    {
+      if signaledDone {
+        hasFailed := true;
+        return Failure("Enumerator has ended and cannot be read.");
+      } else if hasFailed {
+        return Failure("Enumerator is in a failed state.");
+      } else if i >= |s| {
+        signaledDone := true;
+        return Success(None());
+      }
+
+        
+      var data := s[i];
+      i := i + 1;
+      enumerated := enumerated + [data];
+      return Success(Some(data));
+    }
+  }
+
+  // SeqChunkEnumerator implements an enumerator which enumerates an underlying seq<T>
+  // in chunks of seq<T> of up to size chunkSize
+  class SeqChunkEnumerator<T> extends Enumerator<seq<T>> {
+    const s: seq<T>
+    ghost var enumerated: seq<T>
+    const chunkSize: nat
+    var i: nat
+
+    predicate Valid() reads this, Repr ensures Valid() ==> this in Repr
+    {
+      && i <= |s|
+      && chunkSize > 0
+      && enumerated == s[..i]
+      && this in Repr 
+    }
+
+    constructor (data: seq<T>, chunkSize: nat)
+      requires chunkSize > 0
+      ensures s == data
+      ensures enumerated == []
+      ensures !signaledDone
+      ensures !hasFailed
+      ensures i == 0
+      ensures this.chunkSize == chunkSize
+      ensures Valid() && fresh(Repr)
+    {
+        s := data;
+        enumerated := [];
+        signaledDone := false;
+        hasFailed := false;
+        i := 0;
+        this.chunkSize := chunkSize;
+        Repr := {this};
+    }
+    
+    method Next() returns (element: Result<Option<seq<T>>>)
+      requires Valid()
+      modifies Repr
+      ensures Valid()
+      ensures Repr == old(Repr)
+      ensures old(signaledDone) || old(hasFailed) ==> element.Failure?
+      ensures element.Failure? ==> hasFailed
+      ensures element.Success? && element.value.None? ==> signaledDone
+      ensures element.Success? && element.value.None? ==> i == |s|
+      ensures
+        var endSlice := Min(|s|, old(i)+chunkSize);
+        element.Success? && element.value.Some? ==> element.value.get == s[old(i)..endSlice]
+        && i == endSlice
+    {
+      if signaledDone {
+        hasFailed := true;
+        return Failure("Enumerator has ended and cannot be read.");
+      } else if hasFailed {
+        return Failure("Enumerator is in a failed state.");
+      } else if i >= |s| {
+        signaledDone := true;
+        return Success(None());
+      }
+
+        
+      var endSlice := Min(|s|, i+chunkSize);
+      var data := s[i..endSlice];
+      i := endSlice;
+      enumerated := enumerated + data;
+      return Success(Some(data));
+    }
+  }
+
+  // SeqAggregator implements an aggregator that accepts one T at a time to an underlying seq<T>
+  class SeqAggregator<T> extends Aggregator<T> {
+    var s: seq<T>
+
+    predicate Valid() reads this, Repr ensures Valid() ==> this in Repr
+    {
+      this in Repr 
+    }
+
+    constructor ()
+      ensures !done
+      ensures !hasFailed
+      ensures Valid() && fresh(Repr)
+    {
+        s := [];
+        done := false;
+        hasFailed := false;
+        Repr := {this};
+    }
+
+    method Accept(element: T) returns (res: Result<bool>)
+      requires Valid()
+      modifies Repr
+      ensures Valid()
+      ensures Repr == old(Repr)
+      ensures old(done) || old(hasFailed) ==> res.Failure?
+      ensures res.Failure? ==> hasFailed
+      ensures !done && !hasFailed ==> res.Success? && res.value
+    {
+      if done {
+        hasFailed := true;
+        return Failure("Aggregator has been ended and cannot accept any more data");
+      } else if hasFailed {
+        return Failure("Aggregator is in a failed state.");
+      }
+      s := s + [element];
+      return Success(true);
+    }
+
+    method End() returns (res: Result<bool>)
+      requires Valid()
+      modifies Repr
+      ensures Valid()
+      ensures Repr == old(Repr)
+      ensures old(done) || old(hasFailed) ==> res.Failure?
+      ensures res.Failure? ==> hasFailed
+      ensures res.Success? && res.value ==> done
+      ensures !done && !hasFailed ==> res.Success? && res.value
+    {
+      if done {
+        hasFailed := true;
+        return Failure("Aggregator is already Ended.");
+      } else if hasFailed {
+        return Failure("Aggregator is in a failed state.");
+      }
+      done := true;
+      return Success(true);
+    }
+  }
+
+  // SeqChunkAggregator implements an aggregator that concatenates chunks of seq<T>
+  // to an underlying seq<T>
+  class SeqChunkAggregator<T> extends Aggregator<seq<T>> {
+    var s: seq<T>
+
+    predicate Valid() reads this, Repr ensures Valid() ==> this in Repr
+    {
+      this in Repr 
+    }
+
+    constructor ()
+      ensures !done
+      ensures !hasFailed
+      ensures Valid() && fresh(Repr)
+    {
+        s := [];
+        done := false;
+        hasFailed := false;
+        Repr := {this};
+    }
+
+    method Accept(element: seq<T>) returns (res: Result<bool>)
+      requires Valid()
+      modifies Repr
+      ensures Valid()
+      ensures Repr == old(Repr)
+      ensures old(done) || old(hasFailed) ==> res.Failure?
+      ensures res.Failure? ==> hasFailed
+      ensures !done && !hasFailed ==> res.Success? && res.value
+    {
+      if done {
+        hasFailed := true;
+        return Failure("Aggregator has been ended and cannot accept any more data");
+      } else if hasFailed {
+        return Failure("Aggregator is in a failed state.");
+      }
+      s := s + element;
+      return Success(true);
+    }
+
+    method End() returns (res: Result<bool>)
+      requires Valid()
+      modifies Repr
+      ensures Valid()
+      ensures Repr == old(Repr)
+      ensures old(done) || old(hasFailed) ==> res.Failure?
+      ensures res.Failure? ==> hasFailed
+      ensures res.Success? && res.value ==> done
+      ensures !done && !hasFailed ==> res.Success? && res.value
+    {
+      if done {
+        hasFailed := true;
+        return Failure("Aggregator is already Ended.");
+      } else if hasFailed {
+        return Failure("Aggregator is in a failed state.");
+      }
+      done := true;
+      return Success(true);
+    }
+  }
+}

--- a/test/StandardLibrary/Collections.dfy
+++ b/test/StandardLibrary/Collections.dfy
@@ -1,0 +1,71 @@
+include "../../src/StandardLibrary/UInt.dfy"
+include "../../src/StandardLibrary/StandardLibrary.dfy"
+include "../../src/StandardLibrary/Collections.dfy"
+
+module TestCollections {
+  import opened StandardLibrary
+  import opened UInt = StandardLibrary.UInt
+  import opened Collections
+
+  method {:test} IntSeqEnumerator() {
+    var testSeq := [1, 2, 3];
+    var seqEnum := new SeqEnumerator<int>(testSeq);
+      
+    var res := seqEnum.Next();
+    expect res.Success? && res.value.Some? && res.value.get == 1;
+    res := seqEnum.Next();
+    expect res.Success? && res.value.Some? && res.value.get == 2;
+    res := seqEnum.Next();
+    expect res.Success? && res.value.Some? && res.value.get == 3;
+    res := seqEnum.Next();
+    expect res.Success? && res.value == None();
+    res := seqEnum.Next();
+    expect res.Failure?;
+  }
+
+  method {:test} IntSeqAggregator() {
+    var seqAgg := new SeqAggregator<int>();
+
+    var res2 := seqAgg.Accept(1);
+    expect res2.Success? && res2.value && seqAgg.s == [1];
+    res2 := seqAgg.Accept(2);
+    expect res2.Success? && res2.value && seqAgg.s == [1, 2];
+    res2 := seqAgg.End();
+    expect res2.Success? && res2.value;
+    res2 := seqAgg.Accept(1);
+    expect res2.Failure?;
+    res2 := seqAgg.End();
+    expect res2.Failure?;
+  }
+  
+  method {:test} IntSeqChunkEnumerator() {
+    var testSeq := [1, 2, 3, 4, 5];
+    var seqEnum := new SeqChunkEnumerator<int>(testSeq, 2);
+      
+    var res := seqEnum.Next();
+    expect res.Success? && res.value.Some? && res.value.get == [1, 2];
+    res := seqEnum.Next();
+    expect res.Success? && res.value.Some? && res.value.get == [3, 4];
+    res := seqEnum.Next();
+    expect res.Success? && res.value.Some? && res.value.get == [5];
+    res := seqEnum.Next();
+    expect res.Success? && res.value == None();
+    res := seqEnum.Next();
+    expect res.Failure?;
+  }
+
+  method {:test} IntSeqChunkAggregator() {
+    var seqAgg := new SeqChunkAggregator<int>();
+
+    var res2 := seqAgg.Accept([1,2,3]);
+    expect res2.Success? && res2.value && seqAgg.s == [1,2,3];
+    res2 := seqAgg.Accept([4,5]);
+    expect res2.Success? && res2.value && seqAgg.s == [1,2,3,4,5];
+    res2 := seqAgg.End();
+    expect res2.Success? && res2.value;
+    res2 := seqAgg.Accept([1]);
+    expect res2.Failure?;
+    res2 := seqAgg.End();
+    expect res2.Failure?;
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* Step 1 to complete #256.

*Description of changes:* Add interface for Enumerator and Aggregator. See #276 for proof of concept of this interface.

Specific implementations provided (and related tests) are not necessary for the ESDK, though would likely be desired for a StandardLibrary. I'm happy to remove these before merging, but considered them useful for the purposes of demonstrating this interface.

Blocked by https://github.com/dafny-lang/dafny/pull/613

Tested against https://github.com/awslabs/aws-encryption-sdk-net/tree/c05921b9b32af292773664c67c6f3de59a59ba41 using this branch as the Dafny submodule

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
