### PR TITLE
chore: remove errant copy-pasta comment

### DIFF
--- a/.github/not-grep.toml
+++ b/.github/not-grep.toml
@@ -1,5 +1,4 @@
 [prefix]
-# Exclude the copies of msrcrypto included in examples packages.
 "**/*.dfy" = """
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
*Description of changes:*

Removing a comment line I accidentally left in the not-grep config in #325 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
