### PR TITLE
style(DeafultCMM): annotate with spec and uniform variables

### DIFF
--- a/src/SDK/CMM/DefaultCMM.dfy
+++ b/src/SDK/CMM/DefaultCMM.dfy
@@ -89,13 +89,10 @@ module {:extern "DefaultCMMDef"} DefaultCMMDef {
       (
         && Materials.EC_PUBLIC_KEY_FIELD in res.value.encryptionContext
         && |res.value.encryptionContext[Materials.EC_PUBLIC_KEY_FIELD]| > 0
-        // Why is it UTF8 encoded? That is not in the spec...
+        //TODO implement and then us "Base64.IsBase64ByteSeq" to prove verification key
+        // is Base64 encoded.
+        //Note: UTF8 is required by the Spec for EncryptionContext
         && UTF8.ValidUTF8Seq(res.value.encryptionContext[Materials.EC_PUBLIC_KEY_FIELD])
-        // &&
-        // ( // HELP: How can I validate that this is base64 encoded if it is UTF8 encoded?
-        //   var validationKey := UTF8.Decode(res.value.encryptionContext[Materials.EC_PUBLIC_KEY_FIELD]);
-        //   && Base64.IsBase64String(validationKey)
-        // )
       )
         
       ensures res.Success? ==> res.value.Serializable()

--- a/src/SDK/CMM/DefaultCMM.dfy
+++ b/src/SDK/CMM/DefaultCMM.dfy
@@ -228,10 +228,10 @@ module {:extern "DefaultCMMDef"} DefaultCMMDef {
       //# includes the reserved "aws-crypto-public-key" key, the operation MUST
       //# fail without returning any decryption materials.
       ensures
-        && res.Success? 
-        &&  materialsRequest.algorithmSuiteID.SignatureType().None?
+        && materialsRequest.algorithmSuiteID.SignatureType().None?
+        && Materials.EC_PUBLIC_KEY_FIELD in materialsRequest.encryptionContext
       ==>
-         forall key | key in res.value.encryptionContext :: key != Materials.EC_PUBLIC_KEY_FIELD
+        res.Failure?
 
       // TODO: update spec to specify that this is for signing algorithms
       //= compliance/framework/default-cmm.txt#2.6.2

--- a/src/SDK/CMM/DefaultCMM.dfy
+++ b/src/SDK/CMM/DefaultCMM.dfy
@@ -42,13 +42,18 @@ module {:extern "DefaultCMMDef"} DefaultCMMDef {
       keyring in Repr && keyring.Repr <= Repr && this !in keyring.Repr && keyring.Valid()
     }
 
-    constructor OfKeyring(k: KeyringDefs.Keyring)
-      requires k.Valid()
-      ensures keyring == k
-      ensures Valid() && fresh(Repr - k.Repr)
+    constructor OfKeyring(a_keyring: KeyringDefs.Keyring)
+      //= compliance/framework/default-cmm.txt#2.5
+      //= type=implication
+      //# On default CMM initialization, the caller MUST provide the following
+      //# value:
+      // A valid Keyring
+      requires a_keyring.Valid()
+      ensures keyring == a_keyring
+      ensures Valid() && fresh(Repr - a_keyring.Repr)
     {
-      keyring := k;
-      Repr := {this} + k.Repr;
+      keyring := a_keyring;
+      Repr := {this} + a_keyring.Repr;
     }
 
     method GetEncryptionMaterials(materialsRequest: Materials.EncryptionMaterialsRequest)
@@ -57,14 +62,35 @@ module {:extern "DefaultCMMDef"} DefaultCMMDef {
       ensures Valid()
       ensures res.Success? ==> CMMDefs.EncryptionMaterialsSignature(res.value)
       ensures res.Success? ==> res.value.plaintextDataKey.Some? && res.value.Serializable()
+
+      //= compliance/framework/default-cmm.txt#2.6.1
+      //= type=implication
+      //# If the encryption context included in the
+      //# encryption materials request (cmm-interface.md#encryption-materials-
+      //# request) already contains the "aws-crypto-public-key" key, this
+      //# operation MUST fail rather than overwrite the associated value.
       ensures Materials.EC_PUBLIC_KEY_FIELD in materialsRequest.encryptionContext ==> res.Failure?
+      
       ensures res.Success? && (materialsRequest.algorithmSuiteID.None? || materialsRequest.algorithmSuiteID.value.SignatureType().Some?) ==>
         Materials.EC_PUBLIC_KEY_FIELD in res.value.encryptionContext
       ensures res.Success? ==> res.value.Serializable()
       ensures res.Success? ==>
         match materialsRequest.algorithmSuiteID
-        case Some(id) => res.value.algorithmSuiteID == id
-        case None => res.value.algorithmSuiteID == 0x0378
+        //= compliance/framework/default-cmm.txt#2.6.1
+        //= type=implication
+        //# *  If the encryption materials request (cmm-interface.md#encryption-
+        //# materials-request) does contain an algorithm suite, the encryption
+        //# materials returned MUST contain the same algorithm suite.
+          case Some(id) => res.value.algorithmSuiteID == id
+            
+        //= compliance/framework/default-cmm.txt#2.6.1
+        //= type=TODO
+        //# *  If the encryption materials request (cmm-interface.md#encryption-
+        //# materials-request) does contain an algorithm suite, the request
+        //# MUST fail if the algorithm suite is not supported by the
+        //# commitment policy (../client-apis/client.md#commitment-policy) on
+        //# the request.
+          case None => res.value.algorithmSuiteID == 0x0378        
     {
       reveal CMMDefs.EncryptionMaterialsSignatureOpaque();
       var reservedField := Materials.EC_PUBLIC_KEY_FIELD;
@@ -72,31 +98,86 @@ module {:extern "DefaultCMMDef"} DefaultCMMDef {
       if reservedField in materialsRequest.encryptionContext.Keys {
         return Failure("Reserved Field found in EncryptionContext keys.");
       }
-      var id := materialsRequest.algorithmSuiteID.UnwrapOr(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384);
-      var enc_sk := None;
-      var enc_ctx := materialsRequest.encryptionContext;
+      
+      //= compliance/framework/default-cmm.txt#2.6.1
+      //= type=TODO
+      //# *  If the encryption materials request (cmm-interface.md#encryption-
+      //# materials-request) does not contain an algorithm suite, the
+      //# operation MUST add the default algorithm suite for the commitment
+      //# policy (../client-apis/client.md#commitment-policy) as the
+      //# algorithm suite in the encryption materials returned.
+      var algID := materialsRequest.algorithmSuiteID.UnwrapOr(AlgorithmSuite.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384);
+      
+      var signingKey := None;
+      var encryptionContext := materialsRequest.encryptionContext;
 
-      match id.SignatureType() {
+      match algID.SignatureType() {
         case None =>
+
+        //= compliance/framework/default-cmm.txt#2.6.1
+        //# If the algorithm suite contains a signing algorithm (algorithm-
+        //# suites.md#signature-algorithm), the default CMM MUST Add the
+        //# following key-value pair to the encryption context
+        //# (structures.md#encryption-context):
         case Some(param) =>
+          
+          //= compliance/framework/default-cmm.txt#2.6.1
+          //# If the algorithm suite contains a signing algorithm (algorithm-
+          //# suites.md#signature-algorithm), the default CMM MUST Generate a
+          //# signing key (structures.md#signing-key).
           var signatureKeys :- Signature.KeyGen(param);
-          enc_sk := Some(signatureKeys.signingKey);
-          var enc_vk :- UTF8.Encode(Base64.Encode(signatureKeys.verificationKey));
-          enc_ctx := enc_ctx[reservedField := enc_vk];
+
+          
+          signingKey := Some(signatureKeys.signingKey);
+          
+          //= compliance/framework/default-cmm.txt#2.6.1
+          //# *  The value MUST be the base64-encoded public verification key.
+          var verificationKey :- UTF8.Encode(Base64.Encode(signatureKeys.verificationKey));
+
+          //= compliance/framework/default-cmm.txt#2.6.1
+          //# *  The key MUST be the reserved name, "aws-crypto-public-key".
+          encryptionContext := encryptionContext[reservedField := verificationKey];
+          // The above also provides:
+          //= compliance/framework/default-cmm.txt#2.6.1
+          //= type=implication
+          //# Adding the key "aws-crypto-public-key" SHOULD be done
+          //# to a copy of the encryption context so that the caller's encryption
+          //# context is not mutated.
+          // Dafny implies this, as maps are immutable; thus changing a value
+          // in a map actually creates a new map
       }
 
       // Check validity of the encryption context at runtime.
-      var validAAD := EncryptionContext.CheckSerializable(enc_ctx);
+      var validAAD := EncryptionContext.CheckSerializable(encryptionContext);
       if !validAAD {
         //TODO: Provide a more specific error message here, depending on how the EncCtx spec was violated.
         return Failure("Invalid Encryption Context");
       }
-      assert EncryptionContext.Serializable(enc_ctx);
+      assert EncryptionContext.Serializable(encryptionContext);
 
-      var materials := Materials.EncryptionMaterials.WithoutDataKeys(enc_ctx, id, enc_sk);
-      assert materials.encryptionContext == enc_ctx;
+      var materials := Materials.EncryptionMaterials.WithoutDataKeys(encryptionContext, algID, signingKey);
+      assert materials.encryptionContext == encryptionContext;
+
+      //= compliance/framework/default-cmm.txt#2.6.1
+      //# On each call to Get Encryption Materials, the default CMM MUST make a
+      //# call to its keyring's (Section 2.5.1) On Encrypt (keyring-
+      //# interface.md#onencrypt) operation.
       materials :- keyring.OnEncrypt(materials);
-      if materials.plaintextDataKey.None? || |materials.encryptedDataKeys| == 0 {
+
+      // The following two tags are provided by the negative:
+      if
+        //= compliance/framework/default-cmm.txt#2.6.1
+        //# The default CMM MUST obtain the Plaintext Data Key from the Get
+        //# Encryption Materials Response and include it in the encryption
+        //# materials (structures.md#encryption-materials) returned.
+        materials.plaintextDataKey.None?
+
+        //= compliance/framework/default-cmm.txt#2.6.1
+        //# The default CMM MUST obtain the Encrypted Data Keys
+        //# (structures.md#encrypted-data-keys) from the Get Encryption Materials
+        //# Response and include it in the encryption materials
+        //# (structures.md#encryption-materials) returned.
+        || |materials.encryptedDataKeys| == 0 {
         return Failure("Could not retrieve materials required for encryption");
       }
       assert materials.Valid();
@@ -107,26 +188,64 @@ module {:extern "DefaultCMMDef"} DefaultCMMDef {
                             returns (res: Result<Materials.ValidDecryptionMaterials, string>)
       requires Valid()
       ensures Valid()
+      
+      //= compliance/framework/default-cmm.txt#2.6.2
+      //= type=implication
+      //# The default CMM MUST obtain the Plaintext Data Key from the Decrypt
+      //# Materials response and include it in the decrypt materials returned.
       ensures res.Success? ==> res.value.plaintextDataKey.Some?
+      
     {
-      // Retrieve and decode verification key from encryption context if using signing algorithm
-      var vkey := None;
-      var algID := materialsRequest.algorithmSuiteID;
-      var encCtx := materialsRequest.encryptionContext;
+      var verificationKey := None;
 
+      //= compliance/framework/default-cmm.txt#2.6.2
+      //= type=TODO
+      //# The request MUST fail if the algorithm suite on the request is not
+      //# supported by the commitment policy (../client-apis/
+      //# client.md#commitment-policy) on the request.
+      var algID := materialsRequest.algorithmSuiteID;
+      var encryptionContext := materialsRequest.encryptionContext;
+      var reservedField := Materials.EC_PUBLIC_KEY_FIELD;
+
+      //= compliance/framework/default-cmm.txt#2.6.2
+      //# If the algorithm suite contains a signing algorithm (algorithm-
+      //# suites.md#signature-algorithm), the default CMM MUST extract the
+      //# verification key from the encryption context under the reserved "aws-
+      //# crypto-public-key" key.
       if algID.SignatureType().Some? {
-        var reservedField := Materials.EC_PUBLIC_KEY_FIELD;
-        if reservedField !in encCtx {
+
+        //= compliance/framework/default-cmm.txt#2.6.2
+        //# If this key is not present in the encryption
+        //# context, the operation MUST fail without returning any decryption
+        //# materials.
+        if reservedField !in encryptionContext {
           return Failure("Could not get materials required for decryption.");
         }
-        var encodedVKey := encCtx[reservedField];
-        var utf8Decoded :- UTF8.Decode(encodedVKey);
+        
+        var encodedVerificationKey := encryptionContext[reservedField];
+        var utf8Decoded :- UTF8.Decode(encodedVerificationKey);
         var base64Decoded :- Base64.Decode(utf8Decoded);
-        vkey := Some(base64Decoded);
+        verificationKey := Some(base64Decoded);
+
+      } else {
+
+        //= compliance/framework/default-cmm.txt#2.6.2
+        //# If the algorithm suite does not contain a signing algorithm
+        //# (algorithm-suites.md#signature-algorithm), but the encryption context
+        //# includes the reserved "aws-crypto-public-key" key, the operation MUST
+        //# fail without returning any decryption materials.
+        if reservedField in encryptionContext {
+          return Failure("encryption context includes public key but algorithm is not a signing algorithm.");
+        }
       }
 
-      var materials := Materials.DecryptionMaterials.WithoutPlaintextDataKey(encCtx, algID, vkey);
+      var materials := Materials.DecryptionMaterials.WithoutPlaintextDataKey(encryptionContext, algID, verificationKey);
+      //= compliance/framework/default-cmm.txt#2.6.2
+      //# On each call to Decrypt Materials, the default CMM MUST make a call
+      //# to its keyring's (Section 2.5.1) On Decrypt (keyring-
+      //# interface.md#ondecrypt) operation.
       materials :- keyring.OnDecrypt(materials, materialsRequest.encryptedDataKeys);
+      
       if materials.plaintextDataKey.None? {
         return Failure("Keyring.OnDecrypt failed to decrypt the plaintext data key.");
       }
@@ -135,3 +254,51 @@ module {:extern "DefaultCMMDef"} DefaultCMMDef {
     }
   }
 }
+
+//= compliance/framework/default-cmm.txt#2.7.1
+//= type=implication
+//# Master key providers SHOULD NOT be
+//# included in any additional implementations.
+
+  //= compliance/framework/default-cmm.txt#2.7
+  //= type=exception
+  //# For implementations that support master key providers (master-key-
+  //# provider-interface.md), the default CMM MUST support generating,
+  //# encrypting, and decrypting data keys using master key providers.
+
+  //= compliance/framework/default-cmm.txt#2.7.2
+  //= type=exception
+  //# On default CMM initialization, the caller MUST provide the following
+  //# value:
+  //#*  Master Key Provider (master-key-provider-interface.md)
+
+  //= compliance/framework/default-cmm.txt#2.7.3
+  //= type=exception
+  //# The default CMM MUST call its master key provider's Get Master Keys
+  //# for Encryption (master-key-provider-interface.md#get-master-keys-for-
+  //# encryption) operation to obtain a list of master keys to use.
+
+  //= compliance/framework/default-cmm.txt#2.7.3
+  //= type=exception
+  //# If the master key provider does not identify which master key MUST
+  //# generate the data key, the default CMM MUST use the first master key
+  //# in the list for that purpose.
+
+  //= compliance/framework/default-cmm.txt#2.7.3
+  //= type=exception
+  //# The default CMM MUST generate the data
+  //# key using this master key's Generate Data Key (master-key-
+  //# interface.md#generate-data-key) operation.
+
+  //= compliance/framework/default-cmm.txt#2.7.3
+  //= type=exception
+  //# For each remaining master key, the default CMM MUST call the master
+  //# key's Encrypt Data Key (master-key-interface.md#encrypt-data-key)
+  //# operation with the plaintext data key.
+
+  //= compliance/framework/default-cmm.txt#2.7.4
+  //= type=exception
+  //# The default CMM MUST call its master key provider's Decrypt Data Key
+  //# (master-key-provider-interface.md#decrypt-data-key) operation.
+
+


### PR DESCRIPTION
*Issue #, if available:* Annotate DefaultCMM with spec via duvet; use the same variable names in Decrypt and Encrypt paths. 

*Description of changes:*

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
