### PR TITLE
chore: Fix broken GHA

### DIFF
--- a/src/Generated/Aws.dfy
+++ b/src/Generated/Aws.dfy
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 module {:extern "Dafny.Aws"} Aws {
     // No content, this just creates the parent module so that
     // we can add sub-modules.

--- a/src/Generated/AwsCryptographicMaterialProviders.dfy
+++ b/src/Generated/AwsCryptographicMaterialProviders.dfy
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 include "../Util/UTF8.dfy"
 include "../StandardLibrary/StandardLibrary.dfy"
 include "../KMS/AmazonKeyManagementService.dfy"

--- a/src/Generated/AwsEncryptionSdk.dfy
+++ b/src/Generated/AwsEncryptionSdk.dfy
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 include "../Util/UTF8.dfy"
 include "../StandardLibrary/StandardLibrary.dfy"
 include "../KMS/AmazonKeyManagementService.dfy"


### PR DESCRIPTION
*Description of changes:*

`not-grep` GHA is failing: https://github.com/awslabs/aws-encryption-sdk-dafny/runs/4144138560?check_suite_focus=true

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
