### PR TITLE
fix: The RawAES keyring was depending on the SDK

### DIFF
--- a/src/AwsCryptographicMaterialProviders/Keyrings/RawAESKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/RawAESKeyring.dfy
@@ -355,7 +355,7 @@ module
   ): 
     (res: Result<seq<uint8>, string>)
   {
-    :- Need(|encryptionContext| < UINT16_LIMIT, "asdf");
+    :- Need(|encryptionContext| < UINT16_LIMIT, "Encryption Context is too large");
     var keys := SetToOrderedSequence(encryptionContext.Keys, UInt.UInt8Less);
 
     var KeyIntoPairBytes := k


### PR DESCRIPTION
The Material Provider library can not have a circular dependency


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
