### PR TITLE
chore: use Dafny 3.4.1 in CI

### DIFF
--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1
         with:
-          dafny-version: "3.4.0"
+          dafny-version: "3.4.1"
 
       - name: Verify Dafny code
         # Currently, test depends on src, so verifying test will also verify src

--- a/codebuild/dafny/verify.yml
+++ b/codebuild/dafny/verify.yml
@@ -4,7 +4,7 @@ phases:
     commands:
       - cd ..
       # Get Dafny
-      - curl https://github.com/dafny-lang/dafny/releases/download/v3.4.0/dafny-3.4.0-x64-ubuntu-16.04.zip -L -o dafny.zip
+      - curl https://github.com/dafny-lang/dafny/releases/download/v3.4.1/dafny-3.4.1-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
       - cd aws-encryption-sdk-dafny

--- a/codebuild/dotnet/ci.yml
+++ b/codebuild/dotnet/ci.yml
@@ -13,7 +13,7 @@ phases:
     commands:
       - cd ..
       # Get Dafny
-      - curl https://github.com/dafny-lang/dafny/releases/download/v3.4.0/dafny-3.4.0-x64-ubuntu-16.04.zip -L -o dafny.zip
+      - curl https://github.com/dafny-lang/dafny/releases/download/v3.4.1/dafny-3.4.1-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
       # Set up environment for running test vectors


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*
This PR updates our Actions and CodeBuild CI configuration to use Dafny 3.4.1, which resolves a Dafny compiler issue (https://github.com/dafny-lang/dafny/issues/1815) that blocked us from using our error types.

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
