### PR TITLE
feat: run test vectors as part of CI

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,10 +3,11 @@ version: 0.2
 batch:
   fast-fail: false
   build-list:
-    # This is commented out in favor of running in the GHA OSX.
-    # Once Dafny 3.4 is released and Linux and OSX perform the same,
-    # re-enable this action.
     - identifier: dafny_verify
       buildspec: codebuild/dafny/verify.yml
-    - identifier: dotnet 
-      buildspec: codebuild/dotnet/ci.yml
+    - identifier: dotnet_tests
+      buildspec: codebuild/dotnet/tests.yml
+    - identifier: dotnet_examples
+      buildspec: codebuild/dotnet/examples.yml
+    - identifier: dotnet_vectors
+      buildspec: codebuild/dotnet/test-vectors.yml

--- a/codebuild/dotnet/examples.yml
+++ b/codebuild/dotnet/examples.yml
@@ -1,0 +1,22 @@
+version: 0.2
+
+env:
+  variables:
+    AWS_ENCRYPTION_SDK_EXAMPLE_KMS_KEY_ID: >-
+      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+
+phases:
+  install:
+    runtime-versions:
+      dotnet: 5.0
+    commands:
+      - cd ..
+      # Get Dafny
+      - curl https://github.com/dafny-lang/dafny/releases/download/v3.4.1/dafny-3.4.1-x64-ubuntu-16.04.zip -L -o dafny.zip
+      - unzip -qq dafny.zip && rm dafny.zip
+      - export PATH="$PWD/dafny:$PATH"
+      # Switch back to the main directory
+      - cd aws-encryption-sdk-dafny/aws-encryption-sdk-net-formally-verified
+  build:
+    commands:
+      - dotnet test Examples /nowarn:CS0105

--- a/codebuild/dotnet/test-vectors.yml
+++ b/codebuild/dotnet/test-vectors.yml
@@ -1,0 +1,23 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      dotnet: 5.0
+    commands:
+      - cd ..
+      # Get Dafny
+      - curl https://github.com/dafny-lang/dafny/releases/download/v3.4.1/dafny-3.4.1-x64-ubuntu-16.04.zip -L -o dafny.zip
+      - unzip -qq dafny.zip && rm dafny.zip
+      - export PATH="$PWD/dafny:$PATH"
+      # Set up environment for running test vectors
+      - wget https://github.com/awslabs/aws-encryption-sdk-test-vectors/raw/master/vectors/awses-decrypt/python-2.3.0.zip
+      - unzip -qq python-2.3.0.zip && rm python-2.3.0.zip
+      # Explicitly set this (rather than as a codebuild env variable like above) because it depends on the
+      # current working directory
+      - export DAFNY_AWS_ESDK_TEST_VECTOR_MANIFEST_PATH="${PWD}/manifest.json"
+      # Switch back to the main directory
+      - cd aws-encryption-sdk-dafny/aws-encryption-sdk-net-formally-verified
+  build:
+    commands:
+      - dotnet test TestVectors /nowarn:CS0105

--- a/codebuild/dotnet/tests.yml
+++ b/codebuild/dotnet/tests.yml
@@ -1,11 +1,5 @@
 version: 0.2
 
-env:
-  variables:
-    DAFNY_AWS_ESDK_DECRYPT_ORACLE_URL: http://xi1mwx3ttb.execute-api.us-west-2.amazonaws.com/api/v0/decrypt
-    AWS_ENCRYPTION_SDK_EXAMPLE_KMS_KEY_ID: >-
-      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
-
 phases:
   install:
     runtime-versions:
@@ -16,21 +10,12 @@ phases:
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.4.1/dafny-3.4.1-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
-      # Set up environment for running test vectors
-      - wget https://github.com/awslabs/aws-encryption-sdk-test-vectors/raw/master/vectors/awses-decrypt/python-2.3.0.zip
-      - unzip -qq python-2.3.0.zip && rm python-2.3.0.zip
-      # Explicitly set this (rather than as a codebuild env variable like above) because it depends on the
-      # current working directory
-      - export DAFNY_AWS_ESDK_TEST_VECTOR_MANIFEST_PATH="${PWD}/manifest.json"
       # Switch back to the main directory
       - cd aws-encryption-sdk-dafny/aws-encryption-sdk-net-formally-verified
   build:
     commands:
       # Unit tests
       - dotnet test Test /nowarn:CS0105
-      # TODO: uncomment when we update TestVectors
-      #- dotnet test TestVectors /nowarn:CS0105
-      - dotnet test Examples /nowarn:CS0105
       # Code Coverage
       - cd Test/
       # Run Coverlet


### PR DESCRIPTION
*Description of changes:*
Now that test vectors are green, we can run them as part of CI to ensure no regressions.

I want to run the various dotnet CI in parallel, so I've created new spec files. For now I'm just copying the dafny installation steps, though there may be room to move this to a shared place (but I couldn't figure out a way of doing this easily with CodeBuild).

*Testing:*
CI is fully green and running all of the new specs: https://tiny.amazon.com/1djz0hjju/IsenLink

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
