### PR TITLE
fix(examples): check encryption context on decrypt

### DIFF
--- a/aws-encryption-sdk-net-formally-verified/Examples/Keyring/AwsKmsMrkAwareSymmetricKeyringExample/AwsKmsMrkAwareSymmetricKeyringExample.cs
+++ b/aws-encryption-sdk-net-formally-verified/Examples/Keyring/AwsKmsMrkAwareSymmetricKeyringExample/AwsKmsMrkAwareSymmetricKeyringExample.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Amazon.KeyManagementService;
@@ -70,17 +71,24 @@ public class AwsKmsMrkAwareSymmetricKeyringExample {
             MaterialsManager = materialsManager,
         };
         DecryptOutput decryptOutput = encryptionSdkClient.Decrypt(decryptInput);
-        MemoryStream decrypted = decryptOutput.Plaintext;
 
-        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
-        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
-
-        // Verify that the encryption context used in the decrypt operation includes
-        // the encryption context that you specified when encrypting.
-        // The AWS Encryption SDK can add pairs, so don't require an exact match.
+        // Before your application uses plaintext data, verify that the encryption context that
+        // you used to encrypt the message is included in the encryption context that was used to
+        // decrypt the message. The AWS Encryption SDK can add pairs, so don't require an exact match.
         //
         // In production, always use a meaningful encryption context.
-        // TODO: Add logic that checks the encryption context.
+        foreach (var (expectedKey, expectedValue) in encryptionContext)
+        {
+            if (!decryptOutput.EncryptionContext.TryGetValue(expectedKey, out var decryptedValue)
+                || !decryptedValue.Equals(expectedValue))
+            {
+                throw new Exception("Encryption context does not match expected values");
+            }
+        }
+
+        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
+        MemoryStream decrypted = decryptOutput.Plaintext;
+        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
     }
 
     // We test examples to ensure they remain up-to-date.

--- a/aws-encryption-sdk-net-formally-verified/Examples/Keyring/AwsKmsStrictMultiKeyring/AwsKmsStrictMultiKeyring.cs
+++ b/aws-encryption-sdk-net-formally-verified/Examples/Keyring/AwsKmsStrictMultiKeyring/AwsKmsStrictMultiKeyring.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Amazon.KeyManagementService;
@@ -69,17 +70,24 @@ public class AwsKmsStrictMultiKeyring {
             Keyring = keyring,
         };
         DecryptOutput decryptOutput = encryptionSdkClient.Decrypt(decryptInput);
-        MemoryStream decrypted = decryptOutput.Plaintext;
 
-        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
-        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
-
-        // Verify that the encryption context used in the decrypt operation includes
-        // the encryption context that you specified when encrypting.
-        // The AWS Encryption SDK can add pairs, so don't require an exact match.
+        // Before your application uses plaintext data, verify that the encryption context that
+        // you used to encrypt the message is included in the encryption context that was used to
+        // decrypt the message. The AWS Encryption SDK can add pairs, so don't require an exact match.
         //
         // In production, always use a meaningful encryption context.
-        // TODO: Add logic that checks the encryption context.
+        foreach (var (expectedKey, expectedValue) in encryptionContext)
+        {
+            if (!decryptOutput.EncryptionContext.TryGetValue(expectedKey, out var decryptedValue)
+                || !decryptedValue.Equals(expectedValue))
+            {
+                throw new Exception("Encryption context does not match expected values");
+            }
+        }
+
+        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
+        MemoryStream decrypted = decryptOutput.Plaintext;
+        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
     }
 
     // We test examples to ensure they remain up-to-date.

--- a/aws-encryption-sdk-net-formally-verified/Examples/Keyring/KmsDiscoveryKeyring/KmsDiscoveryKeyring.cs
+++ b/aws-encryption-sdk-net-formally-verified/Examples/Keyring/KmsDiscoveryKeyring/KmsDiscoveryKeyring.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Amazon.KeyManagementService;
@@ -71,17 +72,24 @@ public class AwsKmsDiscoveryKeyringExample {
             Keyring = decryptKeyring,
         };
         DecryptOutput decryptOutput = encryptionSdkClient.Decrypt(decryptInput);
-        MemoryStream decrypted = decryptOutput.Plaintext;
 
-        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
-        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
-
-        // Verify that the encryption context used in the decrypt operation includes
-        // the encryption context that you specified when encrypting.
-        // The AWS Encryption SDK can add pairs, so don't require an exact match.
+        // Before your application uses plaintext data, verify that the encryption context that
+        // you used to encrypt the message is included in the encryption context that was used to
+        // decrypt the message. The AWS Encryption SDK can add pairs, so don't require an exact match.
         //
         // In production, always use a meaningful encryption context.
-        // TODO: Add logic that checks the encryption context.
+        foreach (var (expectedKey, expectedValue) in encryptionContext)
+        {
+            if (!decryptOutput.EncryptionContext.TryGetValue(expectedKey, out var decryptedValue)
+                || !decryptedValue.Equals(expectedValue))
+            {
+                throw new Exception("Encryption context does not match expected values");
+            }
+        }
+
+        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
+        MemoryStream decrypted = decryptOutput.Plaintext;
+        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
     }
 
     // We test examples to ensure they remain up-to-date.

--- a/aws-encryption-sdk-net-formally-verified/Examples/Keyring/KmsMrkAwareDiscoveryMultiKeyring/KmsMrkAwareDiscoveryMultiKeyring.cs
+++ b/aws-encryption-sdk-net-formally-verified/Examples/Keyring/KmsMrkAwareDiscoveryMultiKeyring/KmsMrkAwareDiscoveryMultiKeyring.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Amazon.KeyManagementService;
@@ -80,17 +81,24 @@ public class KmsMrkAwareDiscoveryMultiKeyringExample {
             Keyring = keyring,
         };
         DecryptOutput decryptOutput = encryptionSdkClient.Decrypt(decryptInput);
-        MemoryStream decrypted = decryptOutput.Plaintext;
 
-        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
-        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
-
-        // Verify that the encryption context used in the decrypt operation includes
-        // the encryption context that you specified when encrypting.
-        // The AWS Encryption SDK can add pairs, so don't require an exact match.
+        // Before your application uses plaintext data, verify that the encryption context that
+        // you used to encrypt the message is included in the encryption context that was used to
+        // decrypt the message. The AWS Encryption SDK can add pairs, so don't require an exact match.
         //
         // In production, always use a meaningful encryption context.
-        // TODO: Add logic that checks the encryption context.
+        foreach (var (expectedKey, expectedValue) in encryptionContext)
+        {
+            if (!decryptOutput.EncryptionContext.TryGetValue(expectedKey, out var decryptedValue)
+                || !decryptedValue.Equals(expectedValue))
+            {
+                throw new Exception("Encryption context does not match expected values");
+            }
+        }
+
+        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
+        MemoryStream decrypted = decryptOutput.Plaintext;
+        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
     }
 
     // We test examples to ensure they remain up-to-date.

--- a/aws-encryption-sdk-net-formally-verified/Examples/Keyring/MultiKeyring/MultiKeyringExample.cs
+++ b/aws-encryption-sdk-net-formally-verified/Examples/Keyring/MultiKeyring/MultiKeyringExample.cs
@@ -44,7 +44,7 @@ public class MultiKeyringExample {
         // Create a raw AES keyring to additionally encrypt under
         IKeyring rawAESKeyring = CreateRawAESKeyring(materialProviders);
 
-        CreateMultiKeyringInput createMultiKeyringInput = new CreateMultiKeyringInput 
+        CreateMultiKeyringInput createMultiKeyringInput = new CreateMultiKeyringInput
         {
             Generator = rawAESKeyring,
             ChildKeyrings = Array.Empty<IKeyring>().ToList()
@@ -80,17 +80,24 @@ public class MultiKeyringExample {
             MaterialsManager = materialsManager,
         };
         DecryptOutput decryptOutput = encryptionSdkClient.Decrypt(decryptInput);
-        MemoryStream decrypted = decryptOutput.Plaintext;
 
-        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
-        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
-
-        // Verify that the encryption context used in the decrypt operation includes
-        // the encryption context that you specified when encrypting.
-        // The AWS Encryption SDK can add pairs, so don't require an exact match.
+        // Before your application uses plaintext data, verify that the encryption context that
+        // you used to encrypt the message is included in the encryption context that was used to
+        // decrypt the message. The AWS Encryption SDK can add pairs, so don't require an exact match.
         //
         // In production, always use a meaningful encryption context.
-        // TODO: Add logic that checks the encryption context.
+        foreach (var (expectedKey, expectedValue) in encryptionContext)
+        {
+            if (!decryptOutput.EncryptionContext.TryGetValue(expectedKey, out var decryptedValue)
+                || !decryptedValue.Equals(expectedValue))
+            {
+                throw new System.Exception("Encryption context does not match expected values");
+            }
+        }
+
+        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
+        MemoryStream decrypted = decryptOutput.Plaintext;
+        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
     }
 
     // We test examples to ensure they remain up-to-date.

--- a/aws-encryption-sdk-net-formally-verified/Examples/Keyring/RawAESKeyring/RawAESKeyringExample.cs
+++ b/aws-encryption-sdk-net-formally-verified/Examples/Keyring/RawAESKeyring/RawAESKeyringExample.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -87,17 +88,24 @@ public class RawAESKeyringExample {
             MaterialsManager = materialsManager,
         };
         DecryptOutput decryptOutput = encryptionSdkClient.Decrypt(decryptInput);
-        MemoryStream decrypted = decryptOutput.Plaintext;
 
-        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
-        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
-
-        // Verify that the encryption context used in the decrypt operation includes
-        // the encryption context that you specified when encrypting.
-        // The AWS Encryption SDK can add pairs, so don't require an exact match.
+        // Before your application uses plaintext data, verify that the encryption context that
+        // you used to encrypt the message is included in the encryption context that was used to
+        // decrypt the message. The AWS Encryption SDK can add pairs, so don't require an exact match.
         //
         // In production, always use a meaningful encryption context.
-        // TODO: Add logic that checks the encryption context.
+        foreach (var (expectedKey, expectedValue) in encryptionContext)
+        {
+            if (!decryptOutput.EncryptionContext.TryGetValue(expectedKey, out var decryptedValue)
+                || !decryptedValue.Equals(expectedValue))
+            {
+                throw new Exception("Encryption context does not match expected values");
+            }
+        }
+
+        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
+        MemoryStream decrypted = decryptOutput.Plaintext;
+        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
     }
 
     // We test examples to ensure they remain up-to-date.

--- a/aws-encryption-sdk-net-formally-verified/Examples/Keyring/RawRSAKeyring/RawRSAKeyringExample.cs
+++ b/aws-encryption-sdk-net-formally-verified/Examples/Keyring/RawRSAKeyring/RawRSAKeyringExample.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -27,7 +28,7 @@ public class RawRSAKeyringExample {
             {"is_public", "true"},
             {"purpose", "useful metadata"}
         };
-    
+
         // Generate a 2,048 bit RSA Key to use with your keyring.
         // We generate a key with Bouncy Castle, but you could also load a key,
         // or generate a key with another low level cryptographic library.
@@ -43,7 +44,7 @@ public class RawRSAKeyringExample {
         string keyNamespace = "Some managed raw keys";
         string keyName = "My 2048-bit RSA wrapping key";
 
-        // Create clients to access the Encryption SDK APIs.    
+        // Create clients to access the Encryption SDK APIs.
         // TODO: add client configuration objects
         IAwsCryptographicMaterialProviders materialProviders = new AwsCryptographicMaterialProvidersClient();
         AwsEncryptionSdkClientConfig config = new AwsEncryptionSdkClientConfig
@@ -92,17 +93,24 @@ public class RawRSAKeyringExample {
             MaterialsManager = materialsManager,
         };
         DecryptOutput decryptOutput = encryptionSdkClient.Decrypt(decryptInput);
-        MemoryStream decrypted = decryptOutput.Plaintext;
 
-        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
-        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
-
-        // Verify that the encryption context used in the decrypt operation includes
-        // the encryption context that you specified when encrypting.
-        // The AWS Encryption SDK can add pairs, so don't require an exact match.
+        // Before your application uses plaintext data, verify that the encryption context that
+        // you used to encrypt the message is included in the encryption context that was used to
+        // decrypt the message. The AWS Encryption SDK can add pairs, so don't require an exact match.
         //
         // In production, always use a meaningful encryption context.
-        // TODO: Add logic that checks the encryption context.        
+        foreach (var (expectedKey, expectedValue) in encryptionContext)
+        {
+            if (!decryptOutput.EncryptionContext.TryGetValue(expectedKey, out var decryptedValue)
+                || !decryptedValue.Equals(expectedValue))
+            {
+                throw new Exception("Encryption context does not match expected values");
+            }
+        }
+
+        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
+        MemoryStream decrypted = decryptOutput.Plaintext;
+        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
     }
 
     // We test examples to ensure they remain up-to-date.

--- a/aws-encryption-sdk-net-formally-verified/Examples/Keyring/StrictAwsKmsKeyring/StrictAwsKmsKeyringExample.cs
+++ b/aws-encryption-sdk-net-formally-verified/Examples/Keyring/StrictAwsKmsKeyring/StrictAwsKmsKeyringExample.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Amazon.KeyManagementService;
@@ -70,17 +71,24 @@ public class StrictAwsKmsKeyringExample {
             MaterialsManager = materialsManager,
         };
         DecryptOutput decryptOutput = encryptionSdkClient.Decrypt(decryptInput);
-        MemoryStream decrypted = decryptOutput.Plaintext;
 
-        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
-        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
-
-        // Verify that the encryption context used in the decrypt operation includes
-        // the encryption context that you specified when encrypting.
-        // The AWS Encryption SDK can add pairs, so don't require an exact match.
+        // Before your application uses plaintext data, verify that the encryption context that
+        // you used to encrypt the message is included in the encryption context that was used to
+        // decrypt the message. The AWS Encryption SDK can add pairs, so don't require an exact match.
         //
         // In production, always use a meaningful encryption context.
-        // TODO: Add logic that checks the encryption context.
+        foreach (var (expectedKey, expectedValue) in encryptionContext)
+        {
+            if (!decryptOutput.EncryptionContext.TryGetValue(expectedKey, out var decryptedValue)
+                || !decryptedValue.Equals(expectedValue))
+            {
+                throw new Exception("Encryption context does not match expected values");
+            }
+        }
+
+        // Demonstrate that the decrypted plaintext is identical to the original plaintext.
+        MemoryStream decrypted = decryptOutput.Plaintext;
+        Assert.Equal(decrypted.ToArray(), plaintext.ToArray());
     }
 
     // We test examples to ensure they remain up-to-date.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* In each of our .NET examples, check for expected encryption context key-value pairs on decrypt before accessing the plaintext.

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
