### PR TITLE
feat: vary frame length in benchmarks

### DIFF
--- a/aws-encryption-sdk-net-formally-verified/Benchmarks/Benchmarks.cs
+++ b/aws-encryption-sdk-net-formally-verified/Benchmarks/Benchmarks.cs
@@ -15,6 +15,9 @@ namespace Benchmarks
         [Params(0, 10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000)]
         public int PlaintextLengthBytes { get; set; }
 
+        [Params(1024, 4096, 65536)]
+        public int FrameLengthBytes { get; set; }
+
         private IAwsEncryptionSdk _encryptionSdk;
         private IKeyring _keyring;
         private MemoryStream _plaintext;
@@ -56,6 +59,7 @@ namespace Benchmarks
                 Plaintext = _plaintext,
                 EncryptionContext = _encryptionContext,
                 AlgorithmSuiteId = AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY,
+                FrameLength = FrameLengthBytes
             });
 
         [Benchmark]


### PR DESCRIPTION
*Description of changes:* Varies frame length in .NET ESDK benchmarks, using values of 1024, 4096 (default), and 65536 bytes.

Note that this more than triples the time required to run all benchmarks - they now take 28 minutes on my laptop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
