### PR TITLE
fix: Remove Encrypt/Decrypt check for valid maxEdks

### DIFF
--- a/src/SDK/Serialize/EncryptedDataKeys.dfy
+++ b/src/SDK/Serialize/EncryptedDataKeys.dfy
@@ -90,7 +90,7 @@ module EncryptedDataKeys {
 
   function method {:opaque} ReadEncryptedDataKeysSection(
     buffer: ReadableBuffer,
-    maxEdks: Option<int64>
+    maxEdks: Option<posInt64>
   )
     :(res: ReadCorrect<ESDKEncryptedDataKeys>)
     ensures CorrectlyRead(buffer, res, WriteEncryptedDataKeysSection)
@@ -99,7 +99,7 @@ module EncryptedDataKeys {
 
     if
       && maxEdks.Some?
-      && count as int64 > maxEdks.value
+      && count as int > maxEdks.value as int
     then
       //= compliance/client-apis/decrypt.txt#2.7.1
       //# If the number of encrypted data keys (../framework/
@@ -265,7 +265,7 @@ module EncryptedDataKeys {
     data: ESDKEncryptedDataKeys,
     bytes: seq<uint8>,
     buffer: ReadableBuffer,
-    maxEdks: Option<int64>
+    maxEdks: Option<posInt64>
   )
     returns (ret: ReadCorrect<ESDKEncryptedDataKeys>)
     requires
@@ -295,7 +295,7 @@ module EncryptedDataKeys {
     var edksSection := ReadEncryptedDataKeysSection(buffer, maxEdks);
     if
       && maxEdks.Some?
-      && |edks.data| as int64 > maxEdks.value
+      && |edks.data| > maxEdks.value as int
     {
       assert edksSection.Failure?;
       return edksSection;

--- a/src/SDK/Serialize/Header.dfy
+++ b/src/SDK/Serialize/Header.dfy
@@ -112,7 +112,7 @@ module Header {
   //# header (../data-format/message-header.md).
   function method ReadHeaderBody(
      buffer: ReadableBuffer,
-     maxEdks: Option<int64>
+     maxEdks: Option<posInt64>
   )
     :(res: ReadCorrect<HeaderTypes.HeaderBody>)
     ensures CorrectlyReadHeaderBody(buffer, res)

--- a/src/SDK/Serialize/V1HeaderBody.dfy
+++ b/src/SDK/Serialize/V1HeaderBody.dfy
@@ -119,7 +119,7 @@ module V1HeaderBody {
 
   function method {:vcs_split_on_every_assert} ReadV1HeaderBody(
     buffer: ReadableBuffer,
-    maxEdks: Option<int64>
+    maxEdks: Option<posInt64>
   )
     :(res: ReadCorrect<V1HeaderBody>)
     ensures CorrectlyReadV1HeaderBody(buffer, res)

--- a/src/SDK/Serialize/V2HeaderBody.dfy
+++ b/src/SDK/Serialize/V2HeaderBody.dfy
@@ -96,7 +96,7 @@ module V2HeaderBody {
 
   function method {:vcs_split_on_every_assert} ReadV2HeaderBody(
     buffer: ReadableBuffer,
-    maxEdks: Option<int64>
+    maxEdks: Option<posInt64>
   )
     :(res: ReadCorrect<V2HeaderBody>)
     ensures CorrectlyReadV2HeaderBody(buffer, res)

--- a/src/StandardLibrary/UInt.dfy
+++ b/src/StandardLibrary/UInt.dfy
@@ -11,6 +11,7 @@ module StandardLibrary.UInt {
 
   newtype int32 = x | -0x8000_0000 <= x < 0x8000_0000
   newtype int64 = x | -0x8000_0000_0000_0000 <= x < 0x8000_0000_0000_0000
+  newtype posInt64 = x | 0 < x < 0x8000_0000_0000_0000 witness 1
 
   const UINT16_LIMIT := 0x1_0000
   const UINT32_LIMIT := 0x1_0000_0000


### PR DESCRIPTION
update maxEDK type internally to only represent positive int64 integers, remove all runtime checks after client creation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
