### PR TITLE
chore: omit build/test dependencies from nuspec

### DIFF
--- a/aws-encryption-sdk-net-formally-verified/Source/AWSEncryptionSDK.csproj
+++ b/aws-encryption-sdk-net-formally-verified/Source/AWSEncryptionSDK.csproj
@@ -20,12 +20,11 @@
     <DafnySource Include="../../src/**/*.dfy" />
   </ItemGroup>
 
+  <!-- Runtime dependencies -->
   <ItemGroup>
-    <PackageReference Include="dafny.msbuild" Version="1.0.0" />
     <PackageReference Include="AWSSDK.Core" Version="3.7.9.2" />
     <PackageReference Include="AWSSDK.KeyManagementService" Version="3.7.2" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <!--
       System.Collections.Immutable can be removed once dafny.msbuild is updated with
       https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned
@@ -33,6 +32,20 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
     <!-- Work around for dafny-lang/dafny/issues/1951; remove once resolved -->
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
+  <!-- Build dependencies -->
+  <ItemGroup>
+    <PackageReference Include="dafny.msbuild" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- Test dependencies -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Description of changes:* Ensure build/test dependencies aren't included in the nuspec, as per review finding in https://sim.amazon.com/issues/CrypTool-4448

Testing: Run the appropriate `dotnet pack` command (as written in GHA workflows) to produce a `.nupkg`, which is just a zip file containing a `AWSEncryptionSDK.nuspec` file. Diffing the `.nuspec` file before and after this PR yields:

```diff
12d11
<         <dependency id="Microsoft.NET.Test.Sdk" version="16.11.0" exclude="Build,Analyzers" />
16d14
<         <dependency id="dafny.msbuild" version="1.0.0" exclude="Build,Analyzers" />
21d18
<         <dependency id="Microsoft.NET.Test.Sdk" version="16.11.0" exclude="Build,Analyzers" />
25d21
<         <dependency id="dafny.msbuild" version="1.0.0" exclude="Build,Analyzers" />
```

which are the build/test dependencies we intend to remove.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
