### PR TITLE
fix(codeowners)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default code owner for everything is our aws-crypto-tools group
-*       @aws/aws-crypto-tools
+*       @awslabs/aws-crypto-tools


### PR DESCRIPTION
*Issue #, if available:* fix codeowners

*Description of changes:*

Our codeowners file has an error because the team aws/aws-crypto-tools
does not have write permission to this repo.

awslabs/aws-crypto-tools has write permission.

*Squash/merge commit message, if applicable:*
`fix(codeowners)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
