### PR TITLE
fix: Key generation and signatures are not functions

### DIFF
--- a/src/Crypto/Signature.dfy
+++ b/src/Crypto/Signature.dfy
@@ -54,12 +54,16 @@ module {:extern "Signature"} Signature {
     }
   }
 
-  function method {:extern "Signature.ECDSA", "ExternKeyGen"} ExternKeyGen(s: ECDSAParams)
-    : (res: Result<SignatureKeyPair, string>)
+  method {:extern "Signature.ECDSA", "ExternKeyGen"} ExternKeyGen(s: ECDSAParams)
+    returns (res: Result<SignatureKeyPair, string>)
     ensures res.Success? ==> IsValidSignatureKeyPair(res.value)
 
-  function method {:extern "Signature.ECDSA", "Sign"} Sign(s: ECDSAParams, key: seq<uint8>, msg: seq<uint8>) : (sig: Result<seq<uint8>, string>)
+  method {:extern "Signature.ECDSA", "Sign"} Sign(s: ECDSAParams, key: seq<uint8>, msg: seq<uint8>)
+    returns (sig: Result<seq<uint8>, string>)
     ensures sig.Success? ==> IsSigned(key, msg, sig.value)
 
-  function method {:extern "Signature.ECDSA", "Verify"} Verify(s: ECDSAParams, key: seq<uint8>, msg: seq<uint8>, sig: seq<uint8>) : (res: Result<bool, string>)
+  // This is a valid function
+  // because the same inputs will result in the same outputs.
+  function method {:extern "Signature.ECDSA", "Verify"} Verify(s: ECDSAParams, key: seq<uint8>, msg: seq<uint8>, sig: seq<uint8>)
+    : (res: Result<bool, string>)
 }


### PR DESCRIPTION
To be a function the code MUST always return
the same output for the same input.

This can not be true for either sign or generate.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
