### PR TITLE
chore: add change log, support policy, and versioning

### DIFF
--- a/aws-encryption-sdk-net-formally-verified/CHANGELOG.md
+++ b/aws-encryption-sdk-net-formally-verified/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0 (2022-05-10)
+
+Initial launch of the AWS Encryption SDK for .NET.

--- a/aws-encryption-sdk-net-formally-verified/SUPPORT_POLICY.rst
+++ b/aws-encryption-sdk-net-formally-verified/SUPPORT_POLICY.rst
@@ -1,0 +1,29 @@
+Overview
+========
+This page describes the support policy for the AWS Encryption SDK. We regularly provide the AWS Encryption SDK with updates that may contain support for new or updated APIs, new features, enhancements, bug fixes, security patches, or documentation updates. Updates may also address changes with dependencies, language runtimes, and operating systems.
+
+We recommend users to stay up-to-date with Encryption SDK releases to keep up with the latest features, security updates, and underlying dependencies. Continued use of an unsupported SDK version is not recommended and is done at the user’s discretion
+
+
+Major Version Lifecycle
+========================
+The AWS Encryption SDK follows the same major version lifecycle as the AWS SDK. For details on this lifecycle, see  `AWS SDKs and Tools Maintenance Policy`_.
+
+Version Support Matrix
+======================
+This table describes the current support status of each major version of the AWS Encryption SDK for Java. It also shows the next status each major version will transition to, and the date at which that transition will happen.
+
+.. list-table::
+    :widths: 30 50 50 50
+    :header-rows: 1
+
+    * - Major version
+      - Current status
+      - Next status
+      - Next status date
+    * - 1.x
+      - Generally Available 
+      -
+      -
+
+.. _AWS SDKs and Tools Maintenance Policy: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html#version-life-cycle

--- a/aws-encryption-sdk-net-formally-verified/VERSIONING.rst
+++ b/aws-encryption-sdk-net-formally-verified/VERSIONING.rst
@@ -1,0 +1,30 @@
+*****************
+Versioning Policy
+*****************
+
+We use a three-part X.Y.Z (Major.Minor.Patch) versioning definition, as follows:
+
+* **X (Major)** version changes are significant and expected to break backwards compatibility.
+* **Y (Minor)** version changes are moderate changes. These include:
+
+  * Significant non-breaking feature additions.
+  * Any change to the version of a dependency.
+  * Possible backwards-incompatible changes. These changes will be noted and explained in detail in the release notes.
+
+* **Z (Patch)** version changes are small changes. These changes will not break backwards compatibility.
+
+  * Z releases will also include warning of upcoming breaking changes, whenever possible.
+
+What this means for you
+=======================
+
+We recommend running the most recent version. Here are our suggestions for managing updates:
+
+* X changes will require some effort to incorporate.
+* Y changes will not require significant effort to incorporate.
+
+  * If you have good unit and integration tests, these changes are generally safe to pick up automatically.
+
+* Z changes will not require any changes to your code. Z changes are intended to be picked up automatically.
+
+  * Good unit and integration tests are always recommended.


### PR DESCRIPTION
*Description of changes:*
Adds some house keeping files.

Note that I've chosen to add these *only* to the net sub-directory, rather than the parent Dafny directory, because from our customers' perspective the Dafny "ESDK" is not its own product, just a tool we use to build the actual product(s). Plus things like change log and support policy will be different for different implementations.

Open questions:
* Initial version. I have us starting at 1.0, but have heard some in favor of starting at something closer to our other ESDKs like 3.0. I prefer 1.0 for a few reasons. Starting at something other than 1 may confuse customers. And we've already diverged major versions in our other ESDKs; this is generally something we need to be able to handle, because we'll never be able to keep versions in sync. The main reason to start at >1.0 is for doc simplicity related to key commitment; docs are easier if they can say "all 1.x versions do Foo, all 2.x versions do Bar" when talking about commitment.
* Should the initial commit in the changelog contain more? Perhaps a link to the "what's new", but that's not particularly useful, and we won't have that link for a while.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
