### PR TITLE
chore: run examples after prod release

### DIFF
--- a/aws-encryption-sdk-net/codebuild/release/release-prod.yml
+++ b/aws-encryption-sdk-net/codebuild/release/release-prod.yml
@@ -44,3 +44,11 @@ phases:
       - export API_ACCESS_KEY=$(python $BASE/retrieve_api_access_key.py)
       # TODO: Pending secrets manager creds from SDK team
       #- dotnet nuget push build/AWS.EncryptionSDK.$VERSION.nupkg --source crypto-tools-internal/net-esdk-staging
+      # Now validate we can run examples
+      - sed -i.backup '/Source\/AWSEncryptionSDK.csproj/d' Examples/AWSEncryptionSDKExamples.csproj
+      - dotnet add Examples/AWSEncryptionSDKExamples.csproj package AWS.EncryptionSDK --version $VERSION
+      # Target only netcoreapp3.1, because we only support net452 for windows.
+      # Since all frameworks and OS's are tested on commit, we mainly want to
+      # run this as a smoke test and the confirm we can find the dependency,
+      # rather than a comprehensive test suite.
+      - dotnet test Examples -f netcoreapp3.1


### PR DESCRIPTION
*Description of changes:*
One more step towards full release. Run the examples after publishing. Important bits to note are that we're searching for the actual `$VERSION` found in the Source csproj file (rather than a temporary unique version like we do for staging), and we're *not* including any steps to login to codeartifact (where we can find the staging version).

Note that I currently expect this to fail, since the version it is looking for does not exist in Nuget.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
