### PR TITLE
chore: use public spec URL for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/dafny-lang/libraries.git
 [submodule "aws-encryption-sdk-specification"]
 	path = aws-encryption-sdk-specification
-	url = https://github.com/awslabs/private-aws-encryption-sdk-specification-staging.git
+	url = https://github.com/awslabs/aws-encryption-sdk-specification.git
 [submodule "aws-encryption-sdk-net-formally-verified/TestVectors/resources/aws-encryption-sdk-test-vectors"]
 	path = aws-encryption-sdk-net/TestVectors/resources/aws-encryption-sdk-test-vectors
 	url = https://github.com/awslabs/aws-encryption-sdk-test-vectors.git


### PR DESCRIPTION
*Description of changes:* Sets the `aws-encryption-sdk-specification` submodule to point to the public spec repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
