### PR TITLE
docs[README]: correct link to .NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dotnet build -t:VerifyDafny test
 The tests currently require native implementations of cryptographic primitives and other methods,
 so they can only be run when embedding this library into one of the compilation target languages supported by Dafny:
 
-- [.NET](https://github.com/awslabs/aws-encryption-sdk-net)
+- [.NET](aws-encryption-sdk-net)
 
 ## Generate Duvet Reports
 


### PR DESCRIPTION
*Issue #, if available:* README's hyperlink to ESDK-.NET is incorrect

*Description of changes:* correct link to ESDK-NET

*Squash/merge commit message, if applicable:* `docs[README]: correct link to .NET`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
