### PR TITLE
ci: Use dafny-reportgenerator instead of Python script for verification time limits

### DIFF
--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Check durations
         if: always()
-        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 test/TestResults/*.csv
+        run: dafny-reportgenerator summarize-csv-results --max-resource-count 300000000 test/TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -28,8 +28,10 @@ jobs:
         run: dotnet tool install --global dafny-reportgenerator
 
       - name: Verify Dafny code
-        # Currently, test depends on src, so verifying test will also verify src
-        run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" test
+        run: |
+          SRC_DFYS=`find src -name "*.dfy"`
+          TEST_DFYS=`find test -name "*.dfy"`
+          dafny /compile:0 /verificationLogger:csv /vcsCores:3 /trace ${SRC_DFYS} ${TEST_DFYS}
 
       - name: Check durations
-        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 test/TestResults/*.csv
+        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -14,8 +14,6 @@ jobs:
       # it to verify the Dafny code. Instead we manually pull the submodule we DO need.
       - run: git submodule update --init libraries
 
-      # .NET is already installed, but v5.0, which dafny-reportgenerator
-      # currently doesn't work with.
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
@@ -29,16 +27,9 @@ jobs:
       - name: Install dafny-reportgenerator
         run: dotnet tool install --global dafny-reportgenerator
 
-      - name: Verify Dafny code with stability analysis
-        # Analyzes the stability of verification by running it several
-        # more times and calculating statistics
-        #
-        # Runs Dafny directly because it doesn't seem like we can pass
-        # multiple arguments to it through MSBuild.
-        run: |
-          SRC_DFYS=`find src -name "*.dfy"`
-          TEST_DFYS=`find test -name "*.dfy"`
-          dafny /compile:0 /vcsCores:3 /verificationLogger:csv /randomSeedIterations:3 ${SRC_DFYS} ${TEST_DFYS}
+      - name: Verify Dafny code
+        # Currently, test depends on src, so verifying test will also verify src
+        run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" test
 
       - name: Check durations
-        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 TestResults/*.csv
+        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 test/TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -29,8 +29,9 @@ jobs:
         run: dotnet tool install --global dafny-reportgenerator
 
       - name: Verify Dafny code
-        # Currently, test depends on src, so verifying test will also verify src
-        run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" test
+        # We can't use `dotnet build` because we need to pass more
+        # options to Dafny
+        run: dafny /compile:0 /trace /vcsCores:2 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"`
 
       - name: Check durations
         if: always()

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Dafny and dafny-reportgenerator
         run: |
-          dotnet tool install --global Dafny --version 3.7.2
+          dotnet tool install --global Dafny --version 3.7.1
           dotnet tool install --global dafny-reportgenerator --version 1.0.1
 
       - name: Verify Dafny code

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -32,4 +32,4 @@ jobs:
         run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" test
 
       - name: Check durations
-        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 .
+        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 test/TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -20,10 +20,13 @@ jobs:
         with:
           dotnet-version: 6.0.x
 
-      - name: Install Dafny and dafny-reportgenerator
-        run: |
-          dotnet tool install --global Dafny --version 3.7.2
-          dotnet tool install --global dafny-reportgenerator --version 1.0.1
+      - name: Setup Dafny
+        uses: dafny-lang/setup-dafny-action@v1
+        with:
+          dafny-version: "3.7.1"
+
+      - name: Install dafny-reportgenerator
+        run: dotnet tool install --global dafny-reportgenerator
 
       - name: Verify Dafny code
         # We can't use `dotnet build` because we need to pass more than one option to Dafny

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Check durations
         if: always()
-        run: dafny-reportgenerator summarize-csv-results --max-resource-count 200000000 TestResults/*.csv
+        run: dafny-reportgenerator summarize-csv-results --max-resource-count 600000000 TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -14,6 +14,7 @@ jobs:
       # it to verify the Dafny code. Instead we manually pull the submodule we DO need.
       - run: git submodule update --init libraries
 
+      # .NET is already installed, but we need a newer version for dafny-reportgenerator
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
@@ -33,4 +34,4 @@ jobs:
 
       - name: Check durations
         if: always()
-        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 test/TestResults/*.csv
+        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 45 test/TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -31,9 +31,15 @@ jobs:
       - name: Verify Dafny code
         # We can't use `dotnet build` because we need to pass more than one option to Dafny
         run: |
-          dafny /compile:0 /trace /vcsCores:2 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"`
-          dafny /compile:0 /trace /vcsCores:2 /randomSeed:1 /randomSeedIterations:2 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"` || true
+          dafny /compile:0 /trace /vcsCores:4 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"`
+          dafny /compile:0 /trace /vcsCores:4 /randomSeed:1 /randomSeedIterations:2 /timeLimit:120 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"` || true
 
       - name: Check solver resource use
         if: always()
-        run: dafny-reportgenerator summarize-csv-results --max-resource-count 600000000 TestResults/*.csv
+        # The --allow-different-outcomes flag should be removed,
+        # eventually, once stability analysis no longer reliably leads
+        # to some proofs failing to complete. And --max-resource-cv-pct
+        # can probably get a smaller and smaller argument over time, as
+        # the proofs get more stable. Aiming for 10-20 is probably a
+        # good target.
+        run: dafny-reportgenerator summarize-csv-results --allow-different-outcomes --max-resource-cv-pct 150 --max-resource-count 800000000 TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Dafny and dafny-reportgenerator
         run: |
-          dotnet tool install --global Dafny --version 3.7.1
+          dotnet tool install --global Dafny --version 3.7.2
           dotnet tool install --global dafny-reportgenerator --version 1.0.1
 
       - name: Verify Dafny code

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -29,10 +29,9 @@ jobs:
         run: dotnet tool install --global dafny-reportgenerator
 
       - name: Verify Dafny code
-        # We can't use `dotnet build` because we need to pass more
-        # options to Dafny
+        # We can't use `dotnet build` because we need to pass more than one option to Dafny
         run: dafny /compile:0 /trace /vcsCores:2 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"`
 
-      - name: Check durations
+      - name: Check solver resource use
         if: always()
         run: dafny-reportgenerator summarize-csv-results --max-resource-count 600000000 TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -28,10 +28,8 @@ jobs:
         run: dotnet tool install --global dafny-reportgenerator
 
       - name: Verify Dafny code
-        run: |
-          SRC_DFYS=`find src -name "*.dfy"`
-          TEST_DFYS=`find test -name "*.dfy"`
-          dafny /compile:0 /verificationLogger:csv /vcsCores:3 /trace ${SRC_DFYS} ${TEST_DFYS}
+        # Currently, test depends on src, so verifying test will also verify src
+        run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" test
 
       - name: Check durations
         run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -32,4 +32,4 @@ jobs:
         run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" test
 
       - name: Check durations
-        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 TestResults/*.csv
+        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 `find . -name "*.csv"`

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -32,4 +32,5 @@ jobs:
         run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" test
 
       - name: Check durations
-        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 `find . -name "*.csv"`
+        if: always()
+        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 test/TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -17,11 +17,14 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1
         with:
-          dafny-version: "3.5.0"
+          dafny-version: "3.7.1"
+
+      - name: Install dafny-reportgenerator
+        run: dotnet tool install --global dafny-reportgenerator
 
       - name: Verify Dafny code
         # Currently, test depends on src, so verifying test will also verify src
-        run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:trx" test
+        run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" test
 
-      - if: always()
-        run: MAX_VERIFICATION_DURATION_SECONDS=40 python3 verification-times-from-trx.py test/TestResults/*.trx
+      - name: Check durations
+        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 .

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -14,6 +14,11 @@ jobs:
       # it to verify the Dafny code. Instead we manually pull the submodule we DO need.
       - run: git submodule update --init libraries
 
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1
         with:

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -20,13 +20,10 @@ jobs:
         with:
           dotnet-version: 6.0.x
 
-      - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1
-        with:
-          dafny-version: "3.7.1"
-
-      - name: Install dafny-reportgenerator
-        run: dotnet tool install --global dafny-reportgenerator
+      - name: Install Dafny and dafny-reportgenerator
+        run: |
+          dotnet tool install --global Dafny --version 3.7.2
+          dotnet tool install --global dafny-reportgenerator --version 1.0.1
 
       - name: Verify Dafny code
         # We can't use `dotnet build` because we need to pass more than one option to Dafny

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1
         with:
-          dafny-version: "3.5.0"
+          dafny-version: "3.7.1"
 
       - name: Install dafny-reportgenerator
         run: dotnet tool install --global dafny-reportgenerator

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -31,7 +31,11 @@ jobs:
       - name: Verify Dafny code
         # We can't use `dotnet build` because we need to pass more than one option to Dafny
         run: |
+          # Run the main verification
           dafny /compile:0 /trace /vcsCores:4 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"`
+          # Do two more iterations for stability analysis (for a total
+          # of three). Allow this part to fail in case different random
+          # seeds get in the way of completing certain proofs.
           dafny /compile:0 /trace /vcsCores:4 /randomSeed:1 /randomSeedIterations:2 /timeLimit:120 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"` || true
 
       - name: Check solver resource use
@@ -42,4 +46,6 @@ jobs:
         # can probably get a smaller and smaller argument over time, as
         # the proofs get more stable. Aiming for 10-20 is probably a
         # good target.
-        run: dafny-reportgenerator summarize-csv-results --allow-different-outcomes --max-resource-cv-pct 150 --max-resource-count 800000000 TestResults/*.csv
+        run: |
+          dafny-reportgenerator summarize-csv-results --allow-different-outcomes  --max-resource-count 1500000000 TestResults/*.csv
+          dafny-reportgenerator summarize-csv-results --allow-different-outcomes --max-resource-cv-pct 150 TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Check durations
         if: always()
-        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 45 TestResults/*.csv
+        run: dafny-reportgenerator summarize-csv-results --max-resource-count 200000000 TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -26,7 +26,7 @@ jobs:
           dafny-version: "3.7.1"
 
       - name: Install dafny-reportgenerator
-        run: dotnet tool install --global dafny-reportgenerator
+        run: dotnet tool install --global dafny-reportgenerator --version 1.2.0
 
       - name: Verify Dafny code
         # We can't use `dotnet build` because we need to pass more than one option to Dafny

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -30,7 +30,9 @@ jobs:
 
       - name: Verify Dafny code
         # We can't use `dotnet build` because we need to pass more than one option to Dafny
-        run: dafny /compile:0 /trace /vcsCores:2 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"`
+        run: |
+          dafny /compile:0 /trace /vcsCores:2 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"`
+          dafny /compile:0 /trace /vcsCores:2 /randomSeed:1 /randomSeedIterations:2 /verificationLogger:csv /verificationLogger:trx `find src test -name "*.dfy"` || true
 
       - name: Check solver resource use
         if: always()

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -14,6 +14,8 @@ jobs:
       # it to verify the Dafny code. Instead we manually pull the submodule we DO need.
       - run: git submodule update --init libraries
 
+      # .NET is already installed, but v5.0, which dafny-reportgenerator
+      # currently doesn't work with.
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
@@ -27,9 +29,16 @@ jobs:
       - name: Install dafny-reportgenerator
         run: dotnet tool install --global dafny-reportgenerator
 
-      - name: Verify Dafny code
-        # Currently, test depends on src, so verifying test will also verify src
-        run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" test
+      - name: Verify Dafny code with stability analysis
+        # Analyzes the stability of verification by running it several
+        # more times and calculating statistics
+        #
+        # Runs Dafny directly because it doesn't seem like we can pass
+        # multiple arguments to it through MSBuild.
+        run: |
+          SRC_DFYS=`find src -name "*.dfy"`
+          TEST_DFYS=`find test -name "*.dfy"`
+          dafny /compile:0 /vcsCores:3 /verificationLogger:csv /randomSeedIterations:3 ${SRC_DFYS} ${TEST_DFYS}
 
       - name: Check durations
-        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 test/TestResults/*.csv
+        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Check durations
         if: always()
-        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 45 test/TestResults/*.csv
+        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 45 TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Check durations
         if: always()
-        run: dafny-reportgenerator summarize-csv-results --max-resource-count 300000000 test/TestResults/*.csv
+        run: dafny-reportgenerator summarize-csv-results --max-duration-seconds 40 test/TestResults/*.csv

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1
         with:
-          dafny-version: "3.7.1"
+          dafny-version: "3.5.0"
 
       - name: Install dafny-reportgenerator
         run: dotnet tool install --global dafny-reportgenerator

--- a/src/StandardLibrary/UInt.dfy
+++ b/src/StandardLibrary/UInt.dfy
@@ -88,10 +88,11 @@ module StandardLibrary.UInt {
     requires |s| == 4
     ensures UInt32ToSeq(x) == s
   {
-    var x0 := s[0] as uint32 * 0x100_0000;
-    var x1 := x0 + s[1] as uint32 * 0x1_0000;
-    var x2 := x1 + s[2] as uint32 * 0x100;
-    x2 + s[3] as uint32
+    var x0 := 0x100_0000 * s[0] as uint32;
+    var x1 := 0x1_0000   * s[1] as uint32;
+    var x2 := 0x100      * s[2] as uint32;
+    var x3 := s[3] as uint32;
+    x0 + x1 + x2 + x3
   }
 
   lemma UInt32SeqSerializeDeserialize(x: uint32)


### PR DESCRIPTION
*Description of changes:*

The `verify-macos.yaml` workflow previously used a custom Python script to identify whether any individual proof ran for more than a given amount of time. The `dafny-reportgenerator` tool can do this, and also some deeper verification stability analysis.

This PR updates the verification workflow to use `dafny-reportgenerator` instead, and bounds the cost of verification using more deterministic solver "resource count" metric instead of time.

It also adds two extra rounds of verification and assesses the stability of verification by calculating the coefficient of variation of the resource counts over the three total iterations. This increases the runtime of the job from about 7m to about 17m. We could investigate different forms of parallelism if this is a problematic increase.

The invocation of `dafny-reportgenerator` includes the `--allow-different-outcomes` flag, which skips the process of flagging proofs that succeed with some random seeds and fail with others, since a few of the proofs in this repo would otherwise fail. Ultimately, it probably makes most sense to refactor those proofs to be more stable, but the current set of flags at least puts in guard rails to prevent any reduction in proof stability. To start the refactoring process, this PR also modifies one function very slightly to improve the stability of one of the lemmas.

*Squash/merge commit message, if applicable:*

Same as description above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
