### PR TITLE
feat: add user agent to default KMS clients

### DIFF
--- a/aws-encryption-sdk-net/Source/AWSEncryptionSDK.csproj
+++ b/aws-encryption-sdk-net/Source/AWSEncryptionSDK.csproj
@@ -1,13 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.1;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
+
+    <!-- This should be kept in sync with the version number in AssemblyInfo.cs -->
     <Version>3.0.0</Version>
+
     <AssemblyName>AWS.EncryptionSDK</AssemblyName>
     <PackageId>AWS.EncryptionSDK</PackageId>
     <Title>AWS Encryption SDK for .NET</Title>

--- a/aws-encryption-sdk-net/Source/AssemblyInfo.cs
+++ b/aws-encryption-sdk-net/Source/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System.Reflection;
+
+[assembly: AssemblyTitle("AWS.EncryptionSDK")]
+
+// This should be kept in sync with the version number in AWSEncryptionSDK.csproj
+[assembly: AssemblyVersion("3.0.0")]

--- a/aws-encryption-sdk-net/Source/Extern/DefaultClientSupplier.cs
+++ b/aws-encryption-sdk-net/Source/Extern/DefaultClientSupplier.cs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Reflection;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.KeyManagementService;
@@ -79,11 +77,9 @@ namespace DefaultClientSupplier
 
         static UserAgentHandler()
         {
-            AssemblyName assembly = typeof(UserAgentHandler).Assembly.GetName();
-            string version = $"{assembly.Version.Major}.{assembly.Version.Minor}.{assembly.Version.Build}";
-            UserAgentSuffix = $" AwsEncryptionSdkNet/{version}";
-
-            Console.WriteLine(assembly);
+            var version = typeof(UserAgentHandler).Assembly.GetName().Version;
+            var semver = $"{version.Major}.{version.Minor}.{version.Build}";
+            UserAgentSuffix = $" AwsEncryptionSdkNet/{semver}";
         }
 
         /// <inheritdoc />
@@ -100,7 +96,7 @@ namespace DefaultClientSupplier
             return base.InvokeAsync<T>(executionContext);
         }
 
-        protected void AddUserAgent(IExecutionContext executionContext)
+        private static void AddUserAgent(IExecutionContext executionContext)
         {
             var request = executionContext.RequestContext.Request;
             request.Headers[AWSSDKUtils.UserAgentHeader] += UserAgentSuffix;

--- a/aws-encryption-sdk-net/Source/Extern/DefaultClientSupplier.cs
+++ b/aws-encryption-sdk-net/Source/Extern/DefaultClientSupplier.cs
@@ -1,9 +1,14 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
 using Amazon;
 using Amazon.KeyManagementService;
 using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.Util;
 // ReSharper disable once RedundantUsingDirective
 using AWS.EncryptionSDK.Core;
 
@@ -24,16 +29,14 @@ namespace DefaultClientSupplier
                 AWS.EncryptionSDK.Core.TypeConversion.FromDafny_N3_aws__N13_encryptionSdk__N4_core__S14_GetClientInput(input);
             try
             {
-                IAmazonKeyManagementService client;
-                if (convertedInput.Region != "")
+                var regionEndpoint = string.IsNullOrEmpty(convertedInput.Region)
+                    ? null
+                    : RegionEndpoint.GetBySystemName(convertedInput.Region);
+                var clientConfig = new AmazonKeyManagementServiceConfig
                 {
-                    var regionEndpoint = RegionEndpoint.GetBySystemName(convertedInput.Region);
-                    client = new AmazonKeyManagementServiceClient(regionEndpoint);
-                }
-                else
-                {
-                    client = new AmazonKeyManagementServiceClient();
-                }
+                    RegionEndpoint = regionEndpoint
+                };
+                var client = new DefaultKmsClient(clientConfig);
 
                 // ReSharper disable once RedundantNameQualifier
                 return Wrappers_Compile.Result<Dafny.Com.Amazonaws.Kms.IKeyManagementServiceClient,
@@ -48,6 +51,59 @@ namespace DefaultClientSupplier
                     AWS.EncryptionSDK.Core.TypeConversion.ToDafny_CommonError(e)
                 );
             }
+        }
+    }
+
+    /// <summary>
+    /// A KMS client that adds the Encryption SDK version to the user agent.
+    /// </summary>
+    internal class DefaultKmsClient : AmazonKeyManagementServiceClient
+    {
+        public DefaultKmsClient(AmazonKeyManagementServiceConfig config) : base(config)
+        {
+        }
+
+        protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
+        {
+            base.CustomizeRuntimePipeline(pipeline);
+            pipeline.AddHandlerAfter<Marshaller>(new UserAgentHandler());
+        }
+    }
+
+    /// <summary>
+    /// Adds the Encryption SDK version to the user agent.
+    /// </summary>
+    internal class UserAgentHandler : PipelineHandler
+    {
+        private static readonly string UserAgentSuffix;
+
+        static UserAgentHandler()
+        {
+            AssemblyName assembly = typeof(UserAgentHandler).Assembly.GetName();
+            string version = $"{assembly.Version.Major}.{assembly.Version.Minor}.{assembly.Version.Build}";
+            UserAgentSuffix = $" AwsEncryptionSdkNet/{version}";
+
+            Console.WriteLine(assembly);
+        }
+
+        /// <inheritdoc />
+        public override void InvokeSync(IExecutionContext executionContext)
+        {
+            AddUserAgent(executionContext);
+            base.InvokeSync(executionContext);
+        }
+
+        /// <inheritdoc />
+        public override Task<T> InvokeAsync<T>(IExecutionContext executionContext)
+        {
+            AddUserAgent(executionContext);
+            return base.InvokeAsync<T>(executionContext);
+        }
+
+        protected void AddUserAgent(IExecutionContext executionContext)
+        {
+            var request = executionContext.RequestContext.Request;
+            request.Headers[AWSSDKUtils.UserAgentHeader] += UserAgentSuffix;
         }
     }
 }


### PR DESCRIPTION
*Description of changes:* Adds a `AwsEncryptionSdkNet/x.y.z` user agent to KMS clients vended by the default client supplier. Adding the user agent to other KMS calls (including in single-key keyrings) is left as later work.

This was tested by running the AWS KMS multi-keyring example and checking that the desired user agent appears in the CloudTrail logs for the corresponding KMS actions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
