### PR TITLE
docs(readme): link to wiki for macOS setup

### DIFF
--- a/aws-encryption-sdk-net/README.md
+++ b/aws-encryption-sdk-net/README.md
@@ -20,21 +20,12 @@ Alternatively, you may directly modify the `.csproj` and add the AWS Encryption 
 
 The AWS Encryption SDK targets both [.NET/.NET Core](https://docs.microsoft.com/en-us/dotnet/core/introduction) 3.1 and newer on all platforms, and [.NET Framework](https://docs.microsoft.com/en-us/dotnet/framework/) 4.5.2 and newer on Windows only.
 
-### Configure system dependencies - macOS only
+### Additional setup for macOS only
 
 If you are using macOS then you must install OpenSSL 1.1,
 and the OpenSSL 1.1 `lib` directory must be on the dynamic linker path at runtime.
-We recommend that you install OpenSSL via Homebrew using `brew install openssl@1.1`,
-and then set the `DYLD_LIBRARY_PATH` environment variable as follows:
-
-```bash
-$ export DYLD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib"
-```
-
-If the .NET runtime cannot locate your OpenSSL 1.1 libraries,
-you may encounter an error that says:
-
-> No usable version of libssl was found
+Also, if using an M1-based Mac, you must install OpenSSL and the .NET SDK for x86-64.
+Please refer to [the wiki](https://github.com/aws/aws-encryption-sdk-dafny/wiki/Using-the-AWS-Encryption-SDK-for-.NET-on-macOS) for detailed instructions.
 
 ## Building the AWS Encryption SDK for .NET
 


### PR DESCRIPTION
*Description of changes:* I've moved macOS setup instructions for Apple M1-based Macs and Intel-based Macs into a wiki in order to avoid crowding the README: https://github.com/aws/aws-encryption-sdk-dafny/wiki/Using-the-AWS-Encryption-SDK-for-.NET-on-macOS. This PR replaces the original Intel-based-Mac-only instructions with a link to the wiki.

Reviewers - please also review the wiki's content.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
