### PR TITLE
ci: use .NET 6.0 for release buildspecs

### DIFF
--- a/aws-encryption-sdk-net/codebuild/release/release-prod.yml
+++ b/aws-encryption-sdk-net/codebuild/release/release-prod.yml
@@ -18,7 +18,7 @@ env:
 phases:
   install:
     runtime-versions:
-      dotnet: 5.0
+      dotnet: 6.0
       python: 3.x
     commands:
       - cd ..

--- a/aws-encryption-sdk-net/codebuild/release/release-prod.yml
+++ b/aws-encryption-sdk-net/codebuild/release/release-prod.yml
@@ -26,10 +26,6 @@ phases:
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
-      # Install additional .NET runtime(s) as needed
-      - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
-      - chmod +x dotnet-install.sh
-      - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Switch back to the main directory
       - cd aws-encryption-sdk-dafny/aws-encryption-sdk-net
   pre_build:
@@ -54,8 +50,8 @@ phases:
       # Now validate we can run examples
       - sed -i.backup '/Source\/AWSEncryptionSDK.csproj/d' Examples/AWSEncryptionSDKExamples.csproj
       - dotnet add Examples/AWSEncryptionSDKExamples.csproj package AWS.EncryptionSDK --version $VERSION
-      # Target only netcoreapp3.1, because we only support net452 for windows.
+      # Run examples for just one supported version.
       # Since all frameworks and OS's are tested on commit, we mainly want to
       # run this as a smoke test and the confirm we can find the dependency,
       # rather than a comprehensive test suite.
-      - dotnet test Examples -f netcoreapp3.1
+      - dotnet test Examples -f net6.0

--- a/aws-encryption-sdk-net/codebuild/release/release-prod.yml
+++ b/aws-encryption-sdk-net/codebuild/release/release-prod.yml
@@ -26,6 +26,10 @@ phases:
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
+      # Install additional .NET runtime(s) as needed
+      - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
+      - chmod +x dotnet-install.sh
+      - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Switch back to the main directory
       - cd aws-encryption-sdk-dafny/aws-encryption-sdk-net
   pre_build:

--- a/aws-encryption-sdk-net/codebuild/release/release-staging.yml
+++ b/aws-encryption-sdk-net/codebuild/release/release-staging.yml
@@ -26,10 +26,6 @@ phases:
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
-      # Install additional .NET runtime(s) as needed
-      - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
-      - chmod +x dotnet-install.sh
-      - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Switch back to the main directory
       - cd aws-encryption-sdk-dafny/aws-encryption-sdk-net
   pre_build:
@@ -63,11 +59,11 @@ phases:
       # Now validate we can run examples
       - sed -i.backup '/Source\/AWSEncryptionSDK.csproj/d' Examples/AWSEncryptionSDKExamples.csproj
       - dotnet add Examples/AWSEncryptionSDKExamples.csproj package AWS.EncryptionSDK --version $UNIQUE_VERSION
-      # Target only netcoreapp3.1, because we only support net452 for windows.
+      # Run examples for just one supported version.
       # Since all frameworks and OS's are tested on commit, we mainly want to
       # run this as a smoke test and the confirm we can find the dependency,
       # rather than a comprehensive test suite.
-      - dotnet test Examples -f netcoreapp3.1
+      - dotnet test Examples -f net6.0
   post_build:
     commands:
       - >-

--- a/aws-encryption-sdk-net/codebuild/release/release-staging.yml
+++ b/aws-encryption-sdk-net/codebuild/release/release-staging.yml
@@ -18,7 +18,7 @@ env:
 phases:
   install:
     runtime-versions:
-      dotnet: 5.0
+      dotnet: 6.0
       python: 3.x
     commands:
       - cd ..

--- a/aws-encryption-sdk-net/codebuild/release/release-staging.yml
+++ b/aws-encryption-sdk-net/codebuild/release/release-staging.yml
@@ -26,6 +26,10 @@ phases:
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
+      # Install additional .NET runtime(s) as needed
+      - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
+      - chmod +x dotnet-install.sh
+      - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Switch back to the main directory
       - cd aws-encryption-sdk-dafny/aws-encryption-sdk-net
   pre_build:

--- a/aws-encryption-sdk-net/codebuild/release/release.yml
+++ b/aws-encryption-sdk-net/codebuild/release/release.yml
@@ -5,19 +5,28 @@ batch:
   build-graph:
     - identifier: sign
       buildspec: aws-encryption-sdk-net/codebuild/release/sign.yml
-    - identifier: verify 
+      env:
+        type: LINUX_CONTAINER
+        image: aws/codebuild/standard:6.0
+    - identifier: verify
       buildspec: aws-encryption-sdk-net/codebuild/release/verify.yml
       env:
         type: WINDOWS_SERVER_2019_CONTAINER
-        image: aws/codebuild/windows-base:2019-1.0
+        image: aws/codebuild/windows-base:2019-2.0
       depend-on:
         - sign
     - identifier: release_staging
       buildspec: aws-encryption-sdk-net/codebuild/release/release-staging.yml
+      env:
+        type: LINUX_CONTAINER
+        image: aws/codebuild/standard:6.0
       depend-on:
         - sign
     - identifier: release_prod
       buildspec: aws-encryption-sdk-net/codebuild/release/release-prod.yml
+      env:
+        type: LINUX_CONTAINER
+        image: aws/codebuild/standard:6.0
       depend-on:
         - verify
         - release_staging

--- a/aws-encryption-sdk-net/codebuild/release/sign.yml
+++ b/aws-encryption-sdk-net/codebuild/release/sign.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 5.0
+      dotnet: 6.0
       python: 3.x
     commands:
       - cd ..

--- a/aws-encryption-sdk-net/codebuild/release/verify.yml
+++ b/aws-encryption-sdk-net/codebuild/release/verify.yml
@@ -8,7 +8,7 @@ env:
 phases:
   install:
     runtime-versions:
-      dotnet: 5.0
+      dotnet: 6.0
       python: 3.x
   build:
     commands:

--- a/codebuild/dotnet/generate-test-vectors.yml
+++ b/codebuild/dotnet/generate-test-vectors.yml
@@ -7,7 +7,7 @@ env:
 phases:
   install:
     runtime-versions:
-      dotnet: 5.0
+      dotnet: 6.0
       nodejs: 14
     commands:
       # Get Dafny

--- a/codebuild/dotnet/generate-test-vectors.yml
+++ b/codebuild/dotnet/generate-test-vectors.yml
@@ -7,7 +7,8 @@ env:
 phases:
   install:
     runtime-versions:
-      dotnet: 6.0
+      # TODO update to .NET 6.0
+      dotnet: 5.0
       nodejs: 16
     commands:
       # Get Dafny
@@ -15,10 +16,6 @@ phases:
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
-      # Install additional .NET runtime(s) as needed
-      - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
-      - chmod +x dotnet-install.sh
-      - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Install the Javascript ESDK test vector runners
       - npm install -g @aws-crypto/integration-node
   build:

--- a/codebuild/dotnet/generate-test-vectors.yml
+++ b/codebuild/dotnet/generate-test-vectors.yml
@@ -15,6 +15,10 @@ phases:
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
+      # Install additional .NET runtime(s) as needed
+      - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
+      - chmod +x dotnet-install.sh
+      - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Install the Javascript ESDK test vector runners
       - npm install -g @aws-crypto/integration-node
   build:

--- a/codebuild/dotnet/generate-test-vectors.yml
+++ b/codebuild/dotnet/generate-test-vectors.yml
@@ -9,7 +9,7 @@ phases:
     runtime-versions:
       # TODO update to .NET 6.0
       dotnet: 5.0
-      nodejs: 16
+      nodejs: 14
     commands:
       # Get Dafny
       - cd $CODEBUILD_SRC_DIR/..

--- a/codebuild/dotnet/generate-test-vectors.yml
+++ b/codebuild/dotnet/generate-test-vectors.yml
@@ -8,7 +8,7 @@ phases:
   install:
     runtime-versions:
       dotnet: 6.0
-      nodejs: 14
+      nodejs: 16
     commands:
       # Get Dafny
       - cd $CODEBUILD_SRC_DIR/..

--- a/codebuild/dotnet/test-vectors.yml
+++ b/codebuild/dotnet/test-vectors.yml
@@ -3,17 +3,14 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 6.0
+      # TODO update to .NET 6.0
+      dotnet: 5.0
     commands:
       - cd ..
       # Get Dafny
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
-      # Install additional .NET runtime(s) as needed
-      - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
-      - chmod +x dotnet-install.sh
-      - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Set up environment for running test vectors
       - wget https://github.com/awslabs/aws-encryption-sdk-test-vectors/raw/master/vectors/awses-decrypt/python-2.3.0.zip
       - unzip -qq python-2.3.0.zip && rm python-2.3.0.zip

--- a/codebuild/dotnet/test-vectors.yml
+++ b/codebuild/dotnet/test-vectors.yml
@@ -10,6 +10,10 @@ phases:
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
+      # Install additional .NET runtime(s) as needed
+      - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
+      - chmod +x dotnet-install.sh
+      - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Set up environment for running test vectors
       - wget https://github.com/awslabs/aws-encryption-sdk-test-vectors/raw/master/vectors/awses-decrypt/python-2.3.0.zip
       - unzip -qq python-2.3.0.zip && rm python-2.3.0.zip

--- a/codebuild/dotnet/test-vectors.yml
+++ b/codebuild/dotnet/test-vectors.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 5.0
+      dotnet: 6.0
     commands:
       - cd ..
       # Get Dafny

--- a/codebuild/dotnet/tests.yml
+++ b/codebuild/dotnet/tests.yml
@@ -12,6 +12,7 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Install additional .NET runtime(s) as needed
       - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
+      - chmod +x dotnet-install.sh
       - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Switch back to the main directory
       - cd aws-encryption-sdk-dafny/aws-encryption-sdk-net

--- a/codebuild/dotnet/tests.yml
+++ b/codebuild/dotnet/tests.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 5.0
+      dotnet: 6.0
     commands:
       - cd ..
       # Get Dafny

--- a/codebuild/dotnet/tests.yml
+++ b/codebuild/dotnet/tests.yml
@@ -10,6 +10,9 @@ phases:
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
+      # Install additional .NET runtime(s) as needed
+      - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
+      - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Switch back to the main directory
       - cd aws-encryption-sdk-dafny/aws-encryption-sdk-net
   build:

--- a/codebuild/dotnet/tests.yml
+++ b/codebuild/dotnet/tests.yml
@@ -3,17 +3,14 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 6.0
+      # TODO update to .NET 6.0
+      dotnet: 5.0
     commands:
       - cd ..
       # Get Dafny
       - curl https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-ubuntu-16.04.zip -L -o dafny.zip
       - unzip -qq dafny.zip && rm dafny.zip
       - export PATH="$PWD/dafny:$PATH"
-      # Install additional .NET runtime(s) as needed
-      - curl https://dot.net/v1/dotnet-install.sh -L -o dotnet-install.sh
-      - chmod +x dotnet-install.sh
-      - ./dotnet-install.sh --runtime dotnet --channel 3.1
       # Switch back to the main directory
       - cd aws-encryption-sdk-dafny/aws-encryption-sdk-net
   build:


### PR DESCRIPTION
*Description of changes:* This upgrades the version of .NET used in our release buildspecs (and by extension, NuGet tooling) in order to mitigate https://github.com/NuGet/NuGet.Client/security/advisories/GHSA-3885-8gqc-3wpf.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.