### PR TITLE
chore: Dafny format preview

### DIFF
--- a/src/AwsCryptographicMaterialProviders/AlgorithmSuites.dfy
+++ b/src/AwsCryptographicMaterialProviders/AlgorithmSuites.dfy
@@ -81,19 +81,19 @@ module
   // TODO: may need to also bring iv length and header auth iv into this definition.
   // For now, hard-coding elsewhere
   datatype AlgorithmSuiteInfo = AlgorithmSuiteInfo(
-                                  //= compliance/client-apis/encrypt.txt#2.6.2
-                                  //= type=implication
-                                  //# The message
-                                  //# format version (../data-format/message-header.md#supported-versions)
-                                  //# MUST be associated with the algorithm suite (../framework/algorithm-
-                                  //# suites.md#supported-algorithm-suites).
-                                  nameonly messageVersion: int,
-                                  nameonly id: Crypto.AlgorithmSuiteId,
-                                  nameonly encrypt: AESEncryption.AES_GCM,
-                                  nameonly kdf: KeyDerivationAlgorithm,
-                                  nameonly commitment: CommitmentDerivationAlgorithm,
-                                  nameonly signature: SignatureAlgorithm
-                                )
+    //= compliance/client-apis/encrypt.txt#2.6.2
+    //= type=implication
+    //# The message
+    //# format version (../data-format/message-header.md#supported-versions)
+    //# MUST be associated with the algorithm suite (../framework/algorithm-
+    //# suites.md#supported-algorithm-suites).
+    nameonly messageVersion: int,
+    nameonly id: Crypto.AlgorithmSuiteId,
+    nameonly encrypt: AESEncryption.AES_GCM,
+    nameonly kdf: KeyDerivationAlgorithm,
+    nameonly commitment: CommitmentDerivationAlgorithm,
+    nameonly signature: SignatureAlgorithm
+  )
 
   type AlgorithmSuite = a: AlgorithmSuiteInfo |
       // General constraints for all existing Algorithm Suites.

--- a/src/AwsCryptographicMaterialProviders/AlgorithmSuites.dfy
+++ b/src/AwsCryptographicMaterialProviders/AlgorithmSuites.dfy
@@ -38,40 +38,40 @@ module
 
   datatype DerivationAlgorithm =
     | HKDF(
-      nameonly hmac: HMAC.Digests,
-      nameonly saltLength: int,
-      nameonly inputKeyLength: AESEncryption.KeyLength,
-      nameonly outputKeyLength: AESEncryption.KeyLength
-    )
-    // We are using both `IDENTITY` and `None` here
-    // to modle the fact that deriving
-    // the data encryption key and the commitment key
-    // MUST be the same.
-    // The specification treats NO_KDF as an identity operation.
-    // So this naming convention mirrors the specification.
+        nameonly hmac: HMAC.Digests,
+        nameonly saltLength: int,
+        nameonly inputKeyLength: AESEncryption.KeyLength,
+        nameonly outputKeyLength: AESEncryption.KeyLength
+      )
+      // We are using both `IDENTITY` and `None` here
+      // to modle the fact that deriving
+      // the data encryption key and the commitment key
+      // MUST be the same.
+      // The specification treats NO_KDF as an identity operation.
+      // So this naming convention mirrors the specification.
     | IDENTITY
     | None
 
   type KeyDerivationAlgorithm = kdf: DerivationAlgorithm
     |
-    && (
-      && kdf.HKDF?
-    ==>
-      && kdf.inputKeyLength == kdf.outputKeyLength
-      && (kdf.hmac == HMAC.Digests.SHA_512 ==> kdf.inputKeyLength == 32))
-    && !kdf.None?
+      && (
+           && kdf.HKDF?
+           ==>
+             && kdf.inputKeyLength == kdf.outputKeyLength
+             && (kdf.hmac == HMAC.Digests.SHA_512 ==> kdf.inputKeyLength == 32))
+      && !kdf.None?
     witness *
 
   type CommitmentDerivationAlgorithm = kdf: DerivationAlgorithm
     |
-    && (
-      && kdf.HKDF?
-    ==>
-      && kdf.hmac.SHA_512?
-      && kdf.saltLength == 32
-      && kdf.inputKeyLength == 32
-      && kdf.outputKeyLength == 32)
-    && !kdf.IDENTITY?
+      && (
+           && kdf.HKDF?
+           ==>
+             && kdf.hmac.SHA_512?
+             && kdf.saltLength == 32
+             && kdf.inputKeyLength == 32
+             && kdf.outputKeyLength == 32)
+      && !kdf.IDENTITY?
     witness *
 
   datatype SignatureAlgorithm =
@@ -81,141 +81,141 @@ module
   // TODO: may need to also bring iv length and header auth iv into this definition.
   // For now, hard-coding elsewhere
   datatype AlgorithmSuiteInfo = AlgorithmSuiteInfo(
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //= type=implication
-    //# The message
-    //# format version (../data-format/message-header.md#supported-versions)
-    //# MUST be associated with the algorithm suite (../framework/algorithm-
-    //# suites.md#supported-algorithm-suites).
-    nameonly messageVersion: int,
-    nameonly id: Crypto.AlgorithmSuiteId,
-    nameonly encrypt: AESEncryption.AES_GCM,
-    nameonly kdf: KeyDerivationAlgorithm,
-    nameonly commitment: CommitmentDerivationAlgorithm,
-    nameonly signature: SignatureAlgorithm
-  )
+                                  //= compliance/client-apis/encrypt.txt#2.6.2
+                                  //= type=implication
+                                  //# The message
+                                  //# format version (../data-format/message-header.md#supported-versions)
+                                  //# MUST be associated with the algorithm suite (../framework/algorithm-
+                                  //# suites.md#supported-algorithm-suites).
+                                  nameonly messageVersion: int,
+                                  nameonly id: Crypto.AlgorithmSuiteId,
+                                  nameonly encrypt: AESEncryption.AES_GCM,
+                                  nameonly kdf: KeyDerivationAlgorithm,
+                                  nameonly commitment: CommitmentDerivationAlgorithm,
+                                  nameonly signature: SignatureAlgorithm
+                                )
 
   type AlgorithmSuite = a: AlgorithmSuiteInfo |
-    // General constraints for all existing Algorithm Suites.
-    // These are here to make sure that these are true.
+      // General constraints for all existing Algorithm Suites.
+      // These are here to make sure that these are true.
 
-    // If there is a KDF, the output length MUST match the encrypt length
-    && (a.kdf.HKDF? ==> a.kdf.outputKeyLength == a.encrypt.keyLength)
-    // If there is a signature, there MUST be a KDF
-    && (a.signature.ECDSA? ==> a.kdf.HKDF?)
-    // If there is commitment, the KDF MUST match
-    && (a.commitment.HKDF? ==>
-      && a.commitment.saltLength == 32
-      && a.commitment == a.kdf)
-    // If there is a KDF and no commitment then salt MUST be 0
-    && (a.kdf.HKDF? && a.commitment.None? ==> a.kdf.saltLength == 0)
+      // If there is a KDF, the output length MUST match the encrypt length
+      && (a.kdf.HKDF? ==> a.kdf.outputKeyLength == a.encrypt.keyLength)
+         // If there is a signature, there MUST be a KDF
+      && (a.signature.ECDSA? ==> a.kdf.HKDF?)
+         // If there is commitment, the KDF MUST match
+      && (a.commitment.HKDF? ==>
+            && a.commitment.saltLength == 32
+            && a.commitment == a.kdf)
+         // If there is a KDF and no commitment then salt MUST be 0
+      && (a.kdf.HKDF? && a.commitment.None? ==> a.kdf.saltLength == 0)
 
-    // These are the specific Algorithm Suites definitions.
-    // Because the Smithy side can not fully express these kinds of requirements
-    // it only has the `AlgorithmSuiteId`.
-    // This means that on the cryptographic materials
-    // there is only a `AlgorithmSuiteId`.
-    // For Dafny to be able to reason practically about the `AlgorithmSuite`
-    // it needs to be able to prove that
-    // GetSuite(suite.id) == suite
+      // These are the specific Algorithm Suites definitions.
+      // Because the Smithy side can not fully express these kinds of requirements
+      // it only has the `AlgorithmSuiteId`.
+      // This means that on the cryptographic materials
+      // there is only a `AlgorithmSuiteId`.
+      // For Dafny to be able to reason practically about the `AlgorithmSuite`
+      // it needs to be able to prove that
+      // GetSuite(suite.id) == suite
 
-    // Legacy non-KDF suites
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF
-      ==>
-        && a.messageVersion == 1
-        && a.encrypt.keyLength == 16
-        && a.kdf.IDENTITY?
-        && a.signature.None?
-        && a.commitment.None?)
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF
-      ==>
-        && a.messageVersion == 1
-        && a.encrypt.keyLength == 24
-        && a.kdf.IDENTITY?
-        && a.signature.None?
-        && a.commitment.None?)
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF
-      ==>
-        && a.messageVersion == 1
-        && a.encrypt.keyLength == 32
-        && a.kdf.IDENTITY?
-        && a.signature.None?
-        && a.commitment.None?)
+      // Legacy non-KDF suites
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF
+          ==>
+            && a.messageVersion == 1
+            && a.encrypt.keyLength == 16
+            && a.kdf.IDENTITY?
+            && a.signature.None?
+            && a.commitment.None?)
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF
+          ==>
+            && a.messageVersion == 1
+            && a.encrypt.keyLength == 24
+            && a.kdf.IDENTITY?
+            && a.signature.None?
+            && a.commitment.None?)
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF
+          ==>
+            && a.messageVersion == 1
+            && a.encrypt.keyLength == 32
+            && a.kdf.IDENTITY?
+            && a.signature.None?
+            && a.commitment.None?)
 
-    // HKDF suites
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256
-      ==>
-        && a.messageVersion == 1
-        && a.encrypt.keyLength == 16
-        && a.kdf.HKDF?
-        && a.kdf.hmac == HMAC.Digests.SHA_256
-        && a.signature.None?
-        && a.commitment.None?)
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256
-      ==>
-        && a.messageVersion == 1
-        && a.encrypt.keyLength == 24
-        && a.kdf.HKDF?
-        && a.kdf.hmac == HMAC.Digests.SHA_256
-        && a.signature.None?
-        && a.commitment.None?)
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256
-      ==>
-        && a.messageVersion == 1
-        && a.encrypt.keyLength == 32
-        && a.kdf.HKDF?
-        && a.kdf.hmac == HMAC.Digests.SHA_256
-        && a.signature.None?
-        && a.commitment.None?)
+      // HKDF suites
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256
+          ==>
+            && a.messageVersion == 1
+            && a.encrypt.keyLength == 16
+            && a.kdf.HKDF?
+            && a.kdf.hmac == HMAC.Digests.SHA_256
+            && a.signature.None?
+            && a.commitment.None?)
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256
+          ==>
+            && a.messageVersion == 1
+            && a.encrypt.keyLength == 24
+            && a.kdf.HKDF?
+            && a.kdf.hmac == HMAC.Digests.SHA_256
+            && a.signature.None?
+            && a.commitment.None?)
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256
+          ==>
+            && a.messageVersion == 1
+            && a.encrypt.keyLength == 32
+            && a.kdf.HKDF?
+            && a.kdf.hmac == HMAC.Digests.SHA_256
+            && a.signature.None?
+            && a.commitment.None?)
 
-    // Signature suites
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256
-      ==>
-        && a.messageVersion == 1
-        && a.encrypt.keyLength == 16
-        && a.kdf.HKDF?
-        && a.kdf.hmac == HMAC.Digests.SHA_256
-        && a.signature.ECDSA?
-        && a.signature.curve == Signature.ECDSAParams.ECDSA_P256
-        && a.commitment.None?)
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384
-      ==>
-        && a.messageVersion == 1
-        && a.encrypt.keyLength == 24
-        && a.kdf.HKDF?
-        && a.kdf.hmac == HMAC.Digests.SHA_384
-        && a.signature.ECDSA?
-        && a.signature.curve == Signature.ECDSAParams.ECDSA_P384
-        && a.commitment.None?)
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384
-      ==>
-        && a.messageVersion == 1
-        && a.encrypt.keyLength == 32
-        && a.kdf.HKDF?
-        && a.kdf.hmac == HMAC.Digests.SHA_384
-        && a.signature.ECDSA?
-        && a.signature.curve == Signature.ECDSAParams.ECDSA_P384
-        && a.commitment.None?)
+      // Signature suites
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256
+          ==>
+            && a.messageVersion == 1
+            && a.encrypt.keyLength == 16
+            && a.kdf.HKDF?
+            && a.kdf.hmac == HMAC.Digests.SHA_256
+            && a.signature.ECDSA?
+            && a.signature.curve == Signature.ECDSAParams.ECDSA_P256
+            && a.commitment.None?)
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384
+          ==>
+            && a.messageVersion == 1
+            && a.encrypt.keyLength == 24
+            && a.kdf.HKDF?
+            && a.kdf.hmac == HMAC.Digests.SHA_384
+            && a.signature.ECDSA?
+            && a.signature.curve == Signature.ECDSAParams.ECDSA_P384
+            && a.commitment.None?)
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384
+          ==>
+            && a.messageVersion == 1
+            && a.encrypt.keyLength == 32
+            && a.kdf.HKDF?
+            && a.kdf.hmac == HMAC.Digests.SHA_384
+            && a.signature.ECDSA?
+            && a.signature.curve == Signature.ECDSAParams.ECDSA_P384
+            && a.commitment.None?)
 
-    // Suites with key commitment
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY
-      ==>
-        && a.messageVersion == 2
-        && a.encrypt.keyLength == 32
-        && a.kdf.HKDF?
-        && a.kdf.hmac == HMAC.Digests.SHA_512
-        && a.signature.None?
-        && a.commitment.HKDF?)
-    && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
-      ==>
-        && a.messageVersion == 2
-        && a.encrypt.keyLength == 32
-        && a.kdf.HKDF?
-        && a.kdf.hmac == HMAC.Digests.SHA_512
-        && a.signature.ECDSA?
-        && a.signature.curve == Signature.ECDSAParams.ECDSA_P384
-        && a.commitment.HKDF?)
-  witness *
+      // Suites with key commitment
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY
+          ==>
+            && a.messageVersion == 2
+            && a.encrypt.keyLength == 32
+            && a.kdf.HKDF?
+            && a.kdf.hmac == HMAC.Digests.SHA_512
+            && a.signature.None?
+            && a.commitment.HKDF?)
+      && (a.id == Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
+          ==>
+            && a.messageVersion == 2
+            && a.encrypt.keyLength == 32
+            && a.kdf.HKDF?
+            && a.kdf.hmac == HMAC.Digests.SHA_512
+            && a.signature.ECDSA?
+            && a.signature.curve == Signature.ECDSAParams.ECDSA_P384
+            && a.commitment.HKDF?)
+    witness *
 
   const Bits256 := 32 as AESEncryption.KeyLength;
   const Bits192 := 24 as AESEncryption.KeyLength;
@@ -224,19 +224,19 @@ module
   const IvLen := 12 as AESEncryption.IVLength;
 
   const AES_128_GCM_IV12_TAG16 := AESEncryption.AES_GCM(
-    keyLength := Bits128,
-    tagLength := TagLen,
-    ivLength := IvLen
+                                    keyLength := Bits128,
+                                    tagLength := TagLen,
+                                    ivLength := IvLen
   );
   const AES_192_GCM_IV12_TAG16 := AESEncryption.AES_GCM(
-    keyLength := Bits192,
-    tagLength := TagLen,
-    ivLength := IvLen
+                                    keyLength := Bits192,
+                                    tagLength := TagLen,
+                                    ivLength := IvLen
   );
   const AES_256_GCM_IV12_TAG16 := AESEncryption.AES_GCM(
-    keyLength := Bits256,
-    tagLength := TagLen,
-    ivLength := IvLen
+                                    keyLength := Bits256,
+                                    tagLength := TagLen,
+                                    ivLength := IvLen
   );
 
   function method HKDF_SHA_256(
@@ -282,112 +282,112 @@ module
 
   // Non-KDF suites
   const ALG_AES_128_GCM_IV12_TAG16_NO_KDF: AlgorithmSuite := AlgorithmSuiteInfo(
-    messageVersion := 1,
-    id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF,
-    encrypt := AES_128_GCM_IV12_TAG16,
-    kdf := KeyDerivationAlgorithm.IDENTITY,
-    commitment := CommitmentDerivationAlgorithm.None,
-    signature := SignatureAlgorithm.None
+                                                               messageVersion := 1,
+                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF,
+                                                               encrypt := AES_128_GCM_IV12_TAG16,
+                                                               kdf := KeyDerivationAlgorithm.IDENTITY,
+                                                               commitment := CommitmentDerivationAlgorithm.None,
+                                                               signature := SignatureAlgorithm.None
   )
   const ALG_AES_192_GCM_IV12_TAG16_NO_KDF: AlgorithmSuite := AlgorithmSuiteInfo(
-    messageVersion := 1,
-    id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF,
-    encrypt := AES_192_GCM_IV12_TAG16,
-    kdf := KeyDerivationAlgorithm.IDENTITY,
-    commitment := CommitmentDerivationAlgorithm.None,
-    signature := SignatureAlgorithm.None
+                                                               messageVersion := 1,
+                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF,
+                                                               encrypt := AES_192_GCM_IV12_TAG16,
+                                                               kdf := KeyDerivationAlgorithm.IDENTITY,
+                                                               commitment := CommitmentDerivationAlgorithm.None,
+                                                               signature := SignatureAlgorithm.None
   )
   const ALG_AES_256_GCM_IV12_TAG16_NO_KDF: AlgorithmSuite := AlgorithmSuiteInfo(
-    messageVersion := 1,
-    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF,
-    encrypt := AES_256_GCM_IV12_TAG16,
-    kdf := KeyDerivationAlgorithm.IDENTITY,
-    commitment := CommitmentDerivationAlgorithm.None,
-    signature := SignatureAlgorithm.None
+                                                               messageVersion := 1,
+                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF,
+                                                               encrypt := AES_256_GCM_IV12_TAG16,
+                                                               kdf := KeyDerivationAlgorithm.IDENTITY,
+                                                               commitment := CommitmentDerivationAlgorithm.None,
+                                                               signature := SignatureAlgorithm.None
   )
 
   //Non-Signature KDF suites
   const ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256: AlgorithmSuite := AlgorithmSuiteInfo(
-    messageVersion := 1,
-    id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256,
-    encrypt := AES_128_GCM_IV12_TAG16,
-    kdf := HKDF_SHA_256(Bits128),
-    commitment := CommitmentDerivationAlgorithm.None,
-    signature := SignatureAlgorithm.None
+                                                                    messageVersion := 1,
+                                                                    id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256,
+                                                                    encrypt := AES_128_GCM_IV12_TAG16,
+                                                                    kdf := HKDF_SHA_256(Bits128),
+                                                                    commitment := CommitmentDerivationAlgorithm.None,
+                                                                    signature := SignatureAlgorithm.None
   )
   const ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256: AlgorithmSuite := AlgorithmSuiteInfo(
-    messageVersion := 1,
-    id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256,
-    encrypt := AES_192_GCM_IV12_TAG16,
-    kdf := HKDF_SHA_256(Bits192),
-    commitment := CommitmentDerivationAlgorithm.None,
-    signature := SignatureAlgorithm.None
+                                                                    messageVersion := 1,
+                                                                    id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256,
+                                                                    encrypt := AES_192_GCM_IV12_TAG16,
+                                                                    kdf := HKDF_SHA_256(Bits192),
+                                                                    commitment := CommitmentDerivationAlgorithm.None,
+                                                                    signature := SignatureAlgorithm.None
   )
   const ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256: AlgorithmSuite := AlgorithmSuiteInfo(
-    messageVersion := 1,
-    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
-    encrypt := AES_256_GCM_IV12_TAG16,
-    kdf := HKDF_SHA_256(Bits256),
-    commitment := CommitmentDerivationAlgorithm.None,
-    signature := SignatureAlgorithm.None
+                                                                    messageVersion := 1,
+                                                                    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
+                                                                    encrypt := AES_256_GCM_IV12_TAG16,
+                                                                    kdf := HKDF_SHA_256(Bits256),
+                                                                    commitment := CommitmentDerivationAlgorithm.None,
+                                                                    signature := SignatureAlgorithm.None
   )
 
   //Signature KDF suites
   const ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256: AlgorithmSuite := AlgorithmSuiteInfo(
-    messageVersion := 1,
-    id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
-    encrypt := AES_128_GCM_IV12_TAG16,
-    kdf := HKDF_SHA_256(Bits128),
-    commitment := CommitmentDerivationAlgorithm.None,
-    signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P256)
+                                                                               messageVersion := 1,
+                                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
+                                                                               encrypt := AES_128_GCM_IV12_TAG16,
+                                                                               kdf := HKDF_SHA_256(Bits128),
+                                                                               commitment := CommitmentDerivationAlgorithm.None,
+                                                                               signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P256)
   )
   const ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384: AlgorithmSuite := AlgorithmSuiteInfo(
-    id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-    messageVersion := 1,
-    encrypt := AES_192_GCM_IV12_TAG16,
-    kdf := HKDF_SHA_384(Bits192),
-    commitment := CommitmentDerivationAlgorithm.None,
-    signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
+                                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+                                                                               messageVersion := 1,
+                                                                               encrypt := AES_192_GCM_IV12_TAG16,
+                                                                               kdf := HKDF_SHA_384(Bits192),
+                                                                               commitment := CommitmentDerivationAlgorithm.None,
+                                                                               signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
   )
   const ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384: AlgorithmSuite := AlgorithmSuiteInfo(
-    messageVersion := 1,
-    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-    encrypt := AES_256_GCM_IV12_TAG16,
-    kdf := HKDF_SHA_384(Bits256),
-    commitment := CommitmentDerivationAlgorithm.None,
-    signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
+                                                                               messageVersion := 1,
+                                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+                                                                               encrypt := AES_256_GCM_IV12_TAG16,
+                                                                               kdf := HKDF_SHA_384(Bits256),
+                                                                               commitment := CommitmentDerivationAlgorithm.None,
+                                                                               signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
   )
 
   // Commitment Suites
-    const ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY: AlgorithmSuite := AlgorithmSuiteInfo(
-    messageVersion := 2,
-    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY,
-    encrypt := AES_256_GCM_IV12_TAG16,
-    kdf := HKDF_SHA_512(Bits256),
-    commitment := HKDF_SHA_512(Bits256),
-    signature := SignatureAlgorithm.None
+  const ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY: AlgorithmSuite := AlgorithmSuiteInfo(
+                                                                    messageVersion := 2,
+                                                                    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY,
+                                                                    encrypt := AES_256_GCM_IV12_TAG16,
+                                                                    kdf := HKDF_SHA_512(Bits256),
+                                                                    commitment := HKDF_SHA_512(Bits256),
+                                                                    signature := SignatureAlgorithm.None
   )
   const ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384: AlgorithmSuite := AlgorithmSuiteInfo(
-    messageVersion := 2,
-    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384,
-    encrypt := AES_256_GCM_IV12_TAG16,
-    kdf := HKDF_SHA_512(Bits256),
-    commitment := HKDF_SHA_512(Bits256),
-    signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
+                                                                               messageVersion := 2,
+                                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384,
+                                                                               encrypt := AES_256_GCM_IV12_TAG16,
+                                                                               kdf := HKDF_SHA_512(Bits256),
+                                                                               commitment := HKDF_SHA_512(Bits256),
+                                                                               signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
   )
 
   const SupportedAlgorithmSuites: map<Crypto.AlgorithmSuiteId, AlgorithmSuite> := map[
-    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF := ALG_AES_128_GCM_IV12_TAG16_NO_KDF,
-    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF := ALG_AES_192_GCM_IV12_TAG16_NO_KDF,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF := ALG_AES_256_GCM_IV12_TAG16_NO_KDF,
-    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256 := ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256,
-    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256 := ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256 := ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
-    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256 := ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
-    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 := ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 := ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY := ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384 := ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF := ALG_AES_128_GCM_IV12_TAG16_NO_KDF,
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF := ALG_AES_192_GCM_IV12_TAG16_NO_KDF,
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF := ALG_AES_256_GCM_IV12_TAG16_NO_KDF,
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256 := ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256,
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256 := ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256,
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256 := ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256 := ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 := ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 := ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY := ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY,
+                                                                                    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384 := ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
   ];
 
   lemma LemmaSupportedAlgorithmSuitesIsComplete(id:Crypto.AlgorithmSuiteId)
@@ -414,17 +414,17 @@ module
   }
 
   const SupportedAlgorithmSuiteIds: set<Crypto.AlgorithmSuiteId> := {
-    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF,
-    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF,
-    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256,
-    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
-    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
-    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF,
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF,
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF,
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256,
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256,
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY,
+                                                                      Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
   };
 
   lemma LemmaSupportedAlgorithmSuiteIdsIsComplete()

--- a/src/AwsCryptographicMaterialProviders/AlgorithmSuites.dfy
+++ b/src/AwsCryptographicMaterialProviders/AlgorithmSuites.dfy
@@ -224,19 +224,19 @@ module
   const IvLen := 12 as AESEncryption.IVLength;
 
   const AES_128_GCM_IV12_TAG16 := AESEncryption.AES_GCM(
-                                    keyLength := Bits128,
-                                    tagLength := TagLen,
-                                    ivLength := IvLen
+    keyLength := Bits128,
+    tagLength := TagLen,
+    ivLength := IvLen
   );
   const AES_192_GCM_IV12_TAG16 := AESEncryption.AES_GCM(
-                                    keyLength := Bits192,
-                                    tagLength := TagLen,
-                                    ivLength := IvLen
+    keyLength := Bits192,
+    tagLength := TagLen,
+    ivLength := IvLen
   );
   const AES_256_GCM_IV12_TAG16 := AESEncryption.AES_GCM(
-                                    keyLength := Bits256,
-                                    tagLength := TagLen,
-                                    ivLength := IvLen
+    keyLength := Bits256,
+    tagLength := TagLen,
+    ivLength := IvLen
   );
 
   function method HKDF_SHA_256(
@@ -282,98 +282,98 @@ module
 
   // Non-KDF suites
   const ALG_AES_128_GCM_IV12_TAG16_NO_KDF: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                               messageVersion := 1,
-                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF,
-                                                               encrypt := AES_128_GCM_IV12_TAG16,
-                                                               kdf := KeyDerivationAlgorithm.IDENTITY,
-                                                               commitment := CommitmentDerivationAlgorithm.None,
-                                                               signature := SignatureAlgorithm.None
+    messageVersion := 1,
+    id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF,
+    encrypt := AES_128_GCM_IV12_TAG16,
+    kdf := KeyDerivationAlgorithm.IDENTITY,
+    commitment := CommitmentDerivationAlgorithm.None,
+    signature := SignatureAlgorithm.None
   )
   const ALG_AES_192_GCM_IV12_TAG16_NO_KDF: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                               messageVersion := 1,
-                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF,
-                                                               encrypt := AES_192_GCM_IV12_TAG16,
-                                                               kdf := KeyDerivationAlgorithm.IDENTITY,
-                                                               commitment := CommitmentDerivationAlgorithm.None,
-                                                               signature := SignatureAlgorithm.None
+    messageVersion := 1,
+    id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF,
+    encrypt := AES_192_GCM_IV12_TAG16,
+    kdf := KeyDerivationAlgorithm.IDENTITY,
+    commitment := CommitmentDerivationAlgorithm.None,
+    signature := SignatureAlgorithm.None
   )
   const ALG_AES_256_GCM_IV12_TAG16_NO_KDF: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                               messageVersion := 1,
-                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF,
-                                                               encrypt := AES_256_GCM_IV12_TAG16,
-                                                               kdf := KeyDerivationAlgorithm.IDENTITY,
-                                                               commitment := CommitmentDerivationAlgorithm.None,
-                                                               signature := SignatureAlgorithm.None
+    messageVersion := 1,
+    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF,
+    encrypt := AES_256_GCM_IV12_TAG16,
+    kdf := KeyDerivationAlgorithm.IDENTITY,
+    commitment := CommitmentDerivationAlgorithm.None,
+    signature := SignatureAlgorithm.None
   )
 
   //Non-Signature KDF suites
   const ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                                    messageVersion := 1,
-                                                                    id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256,
-                                                                    encrypt := AES_128_GCM_IV12_TAG16,
-                                                                    kdf := HKDF_SHA_256(Bits128),
-                                                                    commitment := CommitmentDerivationAlgorithm.None,
-                                                                    signature := SignatureAlgorithm.None
+    messageVersion := 1,
+    id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256,
+    encrypt := AES_128_GCM_IV12_TAG16,
+    kdf := HKDF_SHA_256(Bits128),
+    commitment := CommitmentDerivationAlgorithm.None,
+    signature := SignatureAlgorithm.None
   )
   const ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                                    messageVersion := 1,
-                                                                    id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256,
-                                                                    encrypt := AES_192_GCM_IV12_TAG16,
-                                                                    kdf := HKDF_SHA_256(Bits192),
-                                                                    commitment := CommitmentDerivationAlgorithm.None,
-                                                                    signature := SignatureAlgorithm.None
+    messageVersion := 1,
+    id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256,
+    encrypt := AES_192_GCM_IV12_TAG16,
+    kdf := HKDF_SHA_256(Bits192),
+    commitment := CommitmentDerivationAlgorithm.None,
+    signature := SignatureAlgorithm.None
   )
   const ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                                    messageVersion := 1,
-                                                                    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
-                                                                    encrypt := AES_256_GCM_IV12_TAG16,
-                                                                    kdf := HKDF_SHA_256(Bits256),
-                                                                    commitment := CommitmentDerivationAlgorithm.None,
-                                                                    signature := SignatureAlgorithm.None
+    messageVersion := 1,
+    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
+    encrypt := AES_256_GCM_IV12_TAG16,
+    kdf := HKDF_SHA_256(Bits256),
+    commitment := CommitmentDerivationAlgorithm.None,
+    signature := SignatureAlgorithm.None
   )
 
   //Signature KDF suites
   const ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                                               messageVersion := 1,
-                                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
-                                                                               encrypt := AES_128_GCM_IV12_TAG16,
-                                                                               kdf := HKDF_SHA_256(Bits128),
-                                                                               commitment := CommitmentDerivationAlgorithm.None,
-                                                                               signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P256)
+    messageVersion := 1,
+    id := Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
+    encrypt := AES_128_GCM_IV12_TAG16,
+    kdf := HKDF_SHA_256(Bits128),
+    commitment := CommitmentDerivationAlgorithm.None,
+    signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P256)
   )
   const ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-                                                                               messageVersion := 1,
-                                                                               encrypt := AES_192_GCM_IV12_TAG16,
-                                                                               kdf := HKDF_SHA_384(Bits192),
-                                                                               commitment := CommitmentDerivationAlgorithm.None,
-                                                                               signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
+    id := Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+    messageVersion := 1,
+    encrypt := AES_192_GCM_IV12_TAG16,
+    kdf := HKDF_SHA_384(Bits192),
+    commitment := CommitmentDerivationAlgorithm.None,
+    signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
   )
   const ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                                               messageVersion := 1,
-                                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
-                                                                               encrypt := AES_256_GCM_IV12_TAG16,
-                                                                               kdf := HKDF_SHA_384(Bits256),
-                                                                               commitment := CommitmentDerivationAlgorithm.None,
-                                                                               signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
+    messageVersion := 1,
+    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384,
+    encrypt := AES_256_GCM_IV12_TAG16,
+    kdf := HKDF_SHA_384(Bits256),
+    commitment := CommitmentDerivationAlgorithm.None,
+    signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
   )
 
   // Commitment Suites
   const ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                                    messageVersion := 2,
-                                                                    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY,
-                                                                    encrypt := AES_256_GCM_IV12_TAG16,
-                                                                    kdf := HKDF_SHA_512(Bits256),
-                                                                    commitment := HKDF_SHA_512(Bits256),
-                                                                    signature := SignatureAlgorithm.None
+    messageVersion := 2,
+    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY,
+    encrypt := AES_256_GCM_IV12_TAG16,
+    kdf := HKDF_SHA_512(Bits256),
+    commitment := HKDF_SHA_512(Bits256),
+    signature := SignatureAlgorithm.None
   )
   const ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384: AlgorithmSuite := AlgorithmSuiteInfo(
-                                                                               messageVersion := 2,
-                                                                               id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384,
-                                                                               encrypt := AES_256_GCM_IV12_TAG16,
-                                                                               kdf := HKDF_SHA_512(Bits256),
-                                                                               commitment := HKDF_SHA_512(Bits256),
-                                                                               signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
+    messageVersion := 2,
+    id := Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384,
+    encrypt := AES_256_GCM_IV12_TAG16,
+    kdf := HKDF_SHA_512(Bits256),
+    commitment := HKDF_SHA_512(Bits256),
+    signature := SignatureAlgorithm.ECDSA(curve := Signature.ECDSAParams.ECDSA_P384)
   )
 
   const SupportedAlgorithmSuites: map<Crypto.AlgorithmSuiteId, AlgorithmSuite> := map[

--- a/src/AwsCryptographicMaterialProviders/CMM.dfy
+++ b/src/AwsCryptographicMaterialProviders/CMM.dfy
@@ -19,13 +19,13 @@ module
     method GetEncryptionMaterials(input: Crypto.GetEncryptionMaterialsInput)
       returns (res: Result<Crypto.GetEncryptionMaterialsOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.EncryptionMaterialsWithPlaintextDataKey(res.value.encryptionMaterials)
+              ==>
+                && Materials.EncryptionMaterialsWithPlaintextDataKey(res.value.encryptionMaterials)
 
     method DecryptMaterials(input: Crypto.DecryptMaterialsInput)
       returns (res: Result<Crypto.DecryptMaterialsOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.DecryptionMaterialsWithPlaintextDataKey(res.value.decryptionMaterials)
+              ==>
+                && Materials.DecryptionMaterialsWithPlaintextDataKey(res.value.decryptionMaterials)
   }
 }

--- a/src/AwsCryptographicMaterialProviders/CMMs/DefaultCMM.dfy
+++ b/src/AwsCryptographicMaterialProviders/CMMs/DefaultCMM.dfy
@@ -116,31 +116,31 @@ module
       }
 
       var validateCommitmentPolicyResult := Commitment.ValidateCommitmentPolicyOnEncrypt(
-                                              algorithmId, input.commitmentPolicy
-                                            );
+        algorithmId, input.commitmentPolicy
+      );
       var _ :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-                 validateCommitmentPolicyResult);
+        validateCommitmentPolicyResult);
 
       var suite := AlgorithmSuites.GetSuite(algorithmId);
       var initializeMaterialsResult := InitializeEncryptionMaterials(
-                                         suite,
-                                         input.encryptionContext
-                                       );
+        suite,
+        input.encryptionContext
+      );
       var materials :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(initializeMaterialsResult);
 
       var result :- keyring.OnEncrypt(Crypto.OnEncryptInput(materials:=materials));
       :- Crypto.Need(
-           && result.materials.plaintextDataKey.Some?
-           && |result.materials.encryptedDataKeys| > 0,
-           "Could not retrieve materials required for encryption");
+        && result.materials.plaintextDataKey.Some?
+        && |result.materials.encryptedDataKeys| > 0,
+        "Could not retrieve materials required for encryption");
 
       // For Dafny keyrings this is a trivial statement
       // because they implement a trait that ensures this.
       // However not all keyrings are Dafny keyrings.
       // Customers can create custom keyrings.
       :- Crypto.Need(
-           Materials.EncryptionMaterialsTransitionIsValid(materials, result.materials),
-           "Keyring returned an invalid response");
+        Materials.EncryptionMaterialsTransitionIsValid(materials, result.materials),
+        "Keyring returned an invalid response");
 
       AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(result.materials.algorithmSuiteId, suite);
       return Success(Crypto.GetEncryptionMaterialsOutput(encryptionMaterials:=result.materials));
@@ -177,15 +177,15 @@ module
                 res.Failure?
     {
       var validateCommitmentPolicyResult := Commitment.ValidateCommitmentPolicyOnDecrypt(
-                                              input.algorithmSuiteId, input.commitmentPolicy
-                                            );
+        input.algorithmSuiteId, input.commitmentPolicy
+      );
       var _ :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-                 validateCommitmentPolicyResult);
+        validateCommitmentPolicyResult);
 
       var initializeMaterialsResult := InitializeDecryptionMaterials(
-                                         AlgorithmSuites.GetSuite(input.algorithmSuiteId),
-                                         input.encryptionContext
-                                       );
+        AlgorithmSuites.GetSuite(input.algorithmSuiteId),
+        input.encryptionContext
+      );
       var materials :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(initializeMaterialsResult);
 
       var result :- keyring.OnDecrypt(Crypto.OnDecryptInput(
@@ -198,8 +198,8 @@ module
       // However not all keyrings are Dafny keyrings.
       // Customers can create custom keyrings.
       :- Crypto.Need(
-           Materials.DecryptionMaterialsTransitionIsValid(materials, result.materials),
-           "Keyring.OnDecrypt failed to decrypt the plaintext data key.");
+        Materials.DecryptionMaterialsTransitionIsValid(materials, result.materials),
+        "Keyring.OnDecrypt failed to decrypt the plaintext data key.");
 
       return Success(Crypto.DecryptMaterialsOutput(decryptionMaterials:=result.materials));
     }
@@ -227,12 +227,12 @@ module
     match suite.signature
     case None =>
       var mat := Crypto.EncryptionMaterials(
-                   encryptionContext := encryptionContext,
-                   algorithmSuiteId := suite.id,
-                   plaintextDataKey := None(),
-                   encryptedDataKeys := [],
-                   signingKey := None()
-                 );
+        encryptionContext := encryptionContext,
+        algorithmSuiteId := suite.id,
+        plaintextDataKey := None(),
+        encryptedDataKeys := [],
+        signingKey := None()
+      );
       AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
       return Success(mat);
     case ECDSA(curve) =>
@@ -246,12 +246,12 @@ module
       assert Signature.IsValidSignatureKeyPair(signatureKeys);
       var enc_vk :- UTF8.Encode(Base64.Encode(signatureKeys.verificationKey));
       var mat := Crypto.EncryptionMaterials(
-                   encryptionContext := encryptionContext[Materials.EC_PUBLIC_KEY_FIELD := enc_vk],
-                   algorithmSuiteId := suite.id,
-                   plaintextDataKey := None(),
-                   encryptedDataKeys := [],
-                   signingKey := Some(signatureKeys.signingKey)
-                 );
+        encryptionContext := encryptionContext[Materials.EC_PUBLIC_KEY_FIELD := enc_vk],
+        algorithmSuiteId := suite.id,
+        plaintextDataKey := None(),
+        encryptedDataKeys := [],
+        signingKey := Some(signatureKeys.signingKey)
+      );
       AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
       return Success(mat);
   }
@@ -288,27 +288,27 @@ module
     match suite.signature
     case None =>
       :- Need(
-           Materials.EC_PUBLIC_KEY_FIELD !in encryptionContext,
-           "Verification key can not exist in non-signed Algorithm Suites.");
+        Materials.EC_PUBLIC_KEY_FIELD !in encryptionContext,
+        "Verification key can not exist in non-signed Algorithm Suites.");
       var mat := Crypto.DecryptionMaterials(
-                   encryptionContext := encryptionContext,
-                   algorithmSuiteId := suite.id,
-                   plaintextDataKey := None(),
-                   verificationKey := None()
-                 );
+        encryptionContext := encryptionContext,
+        algorithmSuiteId := suite.id,
+        plaintextDataKey := None(),
+        verificationKey := None()
+      );
       AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
       return Success(mat);
     case ECDSA(curve) =>
       :- Need(
-           Materials.EC_PUBLIC_KEY_FIELD in encryptionContext,
-           "Encryption Context missing verification key.");
+        Materials.EC_PUBLIC_KEY_FIELD in encryptionContext,
+        "Encryption Context missing verification key.");
       var verificationKey :- DecodeVerificationKey(encryptionContext[Materials.EC_PUBLIC_KEY_FIELD]);
       var mat := Crypto.DecryptionMaterials(
-                   encryptionContext := encryptionContext,
-                   algorithmSuiteId := suite.id,
-                   plaintextDataKey := None(),
-                   verificationKey := Some(verificationKey)
-                 );
+        encryptionContext := encryptionContext,
+        algorithmSuiteId := suite.id,
+        plaintextDataKey := None(),
+        verificationKey := Some(verificationKey)
+      );
       AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
       return Success(mat);
   }

--- a/src/AwsCryptographicMaterialProviders/CMMs/DefaultCMM.dfy
+++ b/src/AwsCryptographicMaterialProviders/CMMs/DefaultCMM.dfy
@@ -44,53 +44,53 @@ module
     )
       returns (res: Result<Crypto.GetEncryptionMaterialsOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.EncryptionMaterialsWithPlaintextDataKey(res.value.encryptionMaterials)
-        && (
-          AlgorithmSuites.GetSuite(res.value.encryptionMaterials.algorithmSuiteId).signature.ECDSA?
-        <==>
-          Materials.EC_PUBLIC_KEY_FIELD in res.value.encryptionMaterials.encryptionContext
-        )
+              ==>
+                && Materials.EncryptionMaterialsWithPlaintextDataKey(res.value.encryptionMaterials)
+                && (
+                     AlgorithmSuites.GetSuite(res.value.encryptionMaterials.algorithmSuiteId).signature.ECDSA?
+                     <==>
+                     Materials.EC_PUBLIC_KEY_FIELD in res.value.encryptionMaterials.encryptionContext
+                   )
       ensures Materials.EC_PUBLIC_KEY_FIELD in input.encryptionContext ==> res.Failure?
 
       // Make sure that we returned the correct algorithm suite, either as specified in
       // the input or, if that was not given, the default for the provided commitment policy
       ensures
         && res.Success?
-      ==>
-        || (
-            //= compliance/framework/default-cmm.txt#2.6.1
-            //= type=implication
-            //# *  If the encryption materials request (cmm-interface.md#encryption-
-            //# materials-request) does contain an algorithm suite, the encryption
-            //# materials returned MUST contain the same algorithm suite.
-            && input.algorithmSuiteId.Some?
-            && res.value.encryptionMaterials.algorithmSuiteId == input.algorithmSuiteId.value
-           )
-        || (
-            //= compliance/framework/default-cmm.txt#2.6.1
-            //= type=implication
-            //# *  If the encryption materials request (cmm-interface.md#encryption-
-            //# materials-request) does not contain an algorithm suite, the
-            //# operation MUST add the default algorithm suite for the commitment
-            //# policy (../client-apis/client.md#commitment-policy) as the
-            //# algorithm suite in the encryption materials returned.
-            //
-            //= compliance/client-apis/client.txt#2.4.2.1
-            //= type=implication
-            //# *  "03 78" MUST be the default algorithm suite
-            //
-            //= compliance/client-apis/client.txt#2.4.2.2
-            //= type=implication
-            //# *  "05 78" MUST be the default algorithm suite
-            //
-            //= compliance/client-apis/client.txt#2.4.2.3
-            //= type=implication
-            //# *  "05 78" MUST be the default algorithm suite
-            && input.algorithmSuiteId.None?
-            && var selectedAlgorithm := Defaults.GetAlgorithmSuiteForCommitmentPolicy(input.commitmentPolicy);
-            && res.value.encryptionMaterials.algorithmSuiteId == selectedAlgorithm
-           )
+        ==>
+          || (
+               //= compliance/framework/default-cmm.txt#2.6.1
+               //= type=implication
+               //# *  If the encryption materials request (cmm-interface.md#encryption-
+               //# materials-request) does contain an algorithm suite, the encryption
+               //# materials returned MUST contain the same algorithm suite.
+               && input.algorithmSuiteId.Some?
+               && res.value.encryptionMaterials.algorithmSuiteId == input.algorithmSuiteId.value
+             )
+          || (
+               //= compliance/framework/default-cmm.txt#2.6.1
+               //= type=implication
+               //# *  If the encryption materials request (cmm-interface.md#encryption-
+               //# materials-request) does not contain an algorithm suite, the
+               //# operation MUST add the default algorithm suite for the commitment
+               //# policy (../client-apis/client.md#commitment-policy) as the
+               //# algorithm suite in the encryption materials returned.
+               //
+               //= compliance/client-apis/client.txt#2.4.2.1
+               //= type=implication
+               //# *  "03 78" MUST be the default algorithm suite
+               //
+               //= compliance/client-apis/client.txt#2.4.2.2
+               //= type=implication
+               //# *  "05 78" MUST be the default algorithm suite
+               //
+               //= compliance/client-apis/client.txt#2.4.2.3
+               //= type=implication
+               //# *  "05 78" MUST be the default algorithm suite
+               && input.algorithmSuiteId.None?
+               && var selectedAlgorithm := Defaults.GetAlgorithmSuiteForCommitmentPolicy(input.commitmentPolicy);
+               && res.value.encryptionMaterials.algorithmSuiteId == selectedAlgorithm
+             )
 
       //= compliance/framework/default-cmm.txt#2.6.1
       //= type=implication
@@ -102,11 +102,11 @@ module
       ensures
         && input.algorithmSuiteId.Some?
         && Commitment.ValidateCommitmentPolicyOnEncrypt(input.algorithmSuiteId.value, input.commitmentPolicy).Failure?
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
     {
       :- Crypto.Need(Materials.EC_PUBLIC_KEY_FIELD !in input.encryptionContext,
-        "Reserved Field found in EncryptionContext keys.");
+                     "Reserved Field found in EncryptionContext keys.");
 
       var algorithmId : Crypto.AlgorithmSuiteId;
       if input.algorithmSuiteId.Some? {
@@ -116,31 +116,31 @@ module
       }
 
       var validateCommitmentPolicyResult := Commitment.ValidateCommitmentPolicyOnEncrypt(
-        algorithmId, input.commitmentPolicy
-      );
+                                              algorithmId, input.commitmentPolicy
+                                            );
       var _ :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-        validateCommitmentPolicyResult);
+                 validateCommitmentPolicyResult);
 
       var suite := AlgorithmSuites.GetSuite(algorithmId);
       var initializeMaterialsResult := InitializeEncryptionMaterials(
-        suite,
-        input.encryptionContext
-      );
+                                         suite,
+                                         input.encryptionContext
+                                       );
       var materials :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(initializeMaterialsResult);
 
       var result :- keyring.OnEncrypt(Crypto.OnEncryptInput(materials:=materials));
       :- Crypto.Need(
-        && result.materials.plaintextDataKey.Some?
-        && |result.materials.encryptedDataKeys| > 0,
-        "Could not retrieve materials required for encryption");
+           && result.materials.plaintextDataKey.Some?
+           && |result.materials.encryptedDataKeys| > 0,
+           "Could not retrieve materials required for encryption");
 
       // For Dafny keyrings this is a trivial statement
       // because they implement a trait that ensures this.
       // However not all keyrings are Dafny keyrings.
       // Customers can create custom keyrings.
       :- Crypto.Need(
-        Materials.EncryptionMaterialsTransitionIsValid(materials, result.materials),
-        "Keyring returned an invalid response");
+           Materials.EncryptionMaterialsTransitionIsValid(materials, result.materials),
+           "Keyring returned an invalid response");
 
       AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(result.materials.algorithmSuiteId, suite);
       return Success(Crypto.GetEncryptionMaterialsOutput(encryptionMaterials:=result.materials));
@@ -151,8 +151,8 @@ module
     )
       returns (res: Result<Crypto.DecryptMaterialsOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.DecryptionMaterialsWithPlaintextDataKey(res.value.decryptionMaterials)
+              ==>
+                && Materials.DecryptionMaterialsWithPlaintextDataKey(res.value.decryptionMaterials)
 
       // If the input has either
       //   (a) an unsigned algorithm suite and the aws-crypto-public-key encryption context key
@@ -173,33 +173,33 @@ module
       //# supported by the commitment policy (../client-apis/
       //# client.md#commitment-policy) on the request.
       ensures Commitment.ValidateCommitmentPolicyOnDecrypt(input.algorithmSuiteId, input.commitmentPolicy).Failure?
-      ==>
-        res.Failure?
+              ==>
+                res.Failure?
     {
       var validateCommitmentPolicyResult := Commitment.ValidateCommitmentPolicyOnDecrypt(
-        input.algorithmSuiteId, input.commitmentPolicy
-      );
+                                              input.algorithmSuiteId, input.commitmentPolicy
+                                            );
       var _ :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-        validateCommitmentPolicyResult);
+                 validateCommitmentPolicyResult);
 
       var initializeMaterialsResult := InitializeDecryptionMaterials(
-        AlgorithmSuites.GetSuite(input.algorithmSuiteId),
-        input.encryptionContext
-      );
+                                         AlgorithmSuites.GetSuite(input.algorithmSuiteId),
+                                         input.encryptionContext
+                                       );
       var materials :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(initializeMaterialsResult);
 
       var result :- keyring.OnDecrypt(Crypto.OnDecryptInput(
-        materials:=materials,
-        encryptedDataKeys:=input.encryptedDataKeys
-      ));
+                                        materials:=materials,
+                                        encryptedDataKeys:=input.encryptedDataKeys
+                                      ));
 
       // For Dafny keyrings this is a trivial statement
       // because they implement a trait that ensures this.
       // However not all keyrings are Dafny keyrings.
       // Customers can create custom keyrings.
       :- Crypto.Need(
-        Materials.DecryptionMaterialsTransitionIsValid(materials, result.materials),
-        "Keyring.OnDecrypt failed to decrypt the plaintext data key.");
+           Materials.DecryptionMaterialsTransitionIsValid(materials, result.materials),
+           "Keyring.OnDecrypt failed to decrypt the plaintext data key.");
 
       return Success(Crypto.DecryptMaterialsOutput(decryptionMaterials:=result.materials));
     }
@@ -213,111 +213,111 @@ module
     requires Materials.EC_PUBLIC_KEY_FIELD !in encryptionContext
     ensures
       && res.Success?
-    ==>
-      && Materials.ValidEncryptionMaterials(res.value)
-      && res.value.algorithmSuiteId == suite.id
-      && (!suite.signature.None? <==> Materials.EC_PUBLIC_KEY_FIELD in res.value.encryptionContext)
-      //= compliance/framework/structures.txt#2.3.3.2.5
-      //= type=implication
-      //# If the
-      //# algorithm suite does not contain a signing algorithm, the signing key
-      //# MUST NOT be present.
-      && (suite.signature.None? <==> res.value.signingKey.None?)
+      ==>
+        && Materials.ValidEncryptionMaterials(res.value)
+        && res.value.algorithmSuiteId == suite.id
+        && (!suite.signature.None? <==> Materials.EC_PUBLIC_KEY_FIELD in res.value.encryptionContext)
+           //= compliance/framework/structures.txt#2.3.3.2.5
+           //= type=implication
+           //# If the
+           //# algorithm suite does not contain a signing algorithm, the signing key
+           //# MUST NOT be present.
+        && (suite.signature.None? <==> res.value.signingKey.None?)
   {
     match suite.signature
-      case None =>
-        var mat := Crypto.EncryptionMaterials(
-          encryptionContext := encryptionContext,
-          algorithmSuiteId := suite.id,
-          plaintextDataKey := None(),
-          encryptedDataKeys := [],
-          signingKey := None()
-        );
-        AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
-        return Success(mat);
-      case ECDSA(curve) =>
-        var signatureKeys :- Signature.KeyGen(curve);
-        //= compliance/framework/structures.txt#2.3.3.2.3
-        //= type=implication
-        //# The mapped value
-        //# from the reserved key "aws-crypto-public-key" SHOULD be the signature
-        //# verification key corresponding to the signing key (Section 2.3.3.2.5)
-        //# stored on the encryption material (Section 2.3.3).
-        assert Signature.IsValidSignatureKeyPair(signatureKeys);
-        var enc_vk :- UTF8.Encode(Base64.Encode(signatureKeys.verificationKey));
-        var mat := Crypto.EncryptionMaterials(
-          encryptionContext := encryptionContext[Materials.EC_PUBLIC_KEY_FIELD := enc_vk],
-          algorithmSuiteId := suite.id,
-          plaintextDataKey := None(),
-          encryptedDataKeys := [],
-          signingKey := Some(signatureKeys.signingKey)
-        );
-        AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
-        return Success(mat);
+    case None =>
+      var mat := Crypto.EncryptionMaterials(
+                   encryptionContext := encryptionContext,
+                   algorithmSuiteId := suite.id,
+                   plaintextDataKey := None(),
+                   encryptedDataKeys := [],
+                   signingKey := None()
+                 );
+      AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
+      return Success(mat);
+    case ECDSA(curve) =>
+      var signatureKeys :- Signature.KeyGen(curve);
+      //= compliance/framework/structures.txt#2.3.3.2.3
+      //= type=implication
+      //# The mapped value
+      //# from the reserved key "aws-crypto-public-key" SHOULD be the signature
+      //# verification key corresponding to the signing key (Section 2.3.3.2.5)
+      //# stored on the encryption material (Section 2.3.3).
+      assert Signature.IsValidSignatureKeyPair(signatureKeys);
+      var enc_vk :- UTF8.Encode(Base64.Encode(signatureKeys.verificationKey));
+      var mat := Crypto.EncryptionMaterials(
+                   encryptionContext := encryptionContext[Materials.EC_PUBLIC_KEY_FIELD := enc_vk],
+                   algorithmSuiteId := suite.id,
+                   plaintextDataKey := None(),
+                   encryptedDataKeys := [],
+                   signingKey := Some(signatureKeys.signingKey)
+                 );
+      AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
+      return Success(mat);
   }
 
   method InitializeDecryptionMaterials(
-      suite: AlgorithmSuites.AlgorithmSuite,
-      encryptionContext: Crypto.EncryptionContext
-    )
-      returns (res: Result<Crypto.DecryptionMaterials, string>)
-      ensures
-        && res.Success?
+    suite: AlgorithmSuites.AlgorithmSuite,
+    encryptionContext: Crypto.EncryptionContext
+  )
+    returns (res: Result<Crypto.DecryptionMaterials, string>)
+    ensures
+      && res.Success?
       ==>
         && Materials.ValidDecryptionMaterials(res.value)
         && res.value.algorithmSuiteId == suite.id
         && (suite.signature.None? <==> Materials.EC_PUBLIC_KEY_FIELD !in encryptionContext)
-        //= compliance/framework/structures.txt#2.3.4.2.2
-        //= type=implication
-        //# The mapped value
-        //# from the reserved key "aws-crypto-public-key" SHOULD be the signature
-        //# verification key stored on the decryption materials (Section 2.3.4).
+           //= compliance/framework/structures.txt#2.3.4.2.2
+           //= type=implication
+           //# The mapped value
+           //# from the reserved key "aws-crypto-public-key" SHOULD be the signature
+           //# verification key stored on the decryption materials (Section 2.3.4).
         && var verificationKey := if suite.signature.None?
-          then None
-          else Some(DecodeVerificationKey(encryptionContext[Materials.EC_PUBLIC_KEY_FIELD]));
+                                  then None
+                                  else Some(DecodeVerificationKey(encryptionContext[Materials.EC_PUBLIC_KEY_FIELD]));
         && (
           verificationKey.Some? && verificationKey.value.Success?
-        ==>
-          res.value.verificationKey == Some(verificationKey.value.value)
+          ==>
+            res.value.verificationKey == Some(verificationKey.value.value)
         )
-      ensures
-        (suite.signature.None? <==> Materials.EC_PUBLIC_KEY_FIELD in encryptionContext)
+    ensures
+      (suite.signature.None? <==> Materials.EC_PUBLIC_KEY_FIELD in encryptionContext)
       ==>
         res.Failure?
-    {
-      match suite.signature
-        case None =>
-          :- Need(
-            Materials.EC_PUBLIC_KEY_FIELD !in encryptionContext,
-            "Verification key can not exist in non-signed Algorithm Suites.");
-          var mat := Crypto.DecryptionMaterials(
-            encryptionContext := encryptionContext,
-            algorithmSuiteId := suite.id,
-            plaintextDataKey := None(),
-            verificationKey := None()
-          );
-        AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
-        return Success(mat);
-        case ECDSA(curve) =>
-          :- Need(
-            Materials.EC_PUBLIC_KEY_FIELD in encryptionContext,
-            "Encryption Context missing verification key.");
-          var verificationKey :- DecodeVerificationKey(encryptionContext[Materials.EC_PUBLIC_KEY_FIELD]);
-          var mat := Crypto.DecryptionMaterials(
-            encryptionContext := encryptionContext,
-            algorithmSuiteId := suite.id,
-            plaintextDataKey := None(),
-            verificationKey := Some(verificationKey)
-          );
-          AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
-          return Success(mat);
-    }
+  {
+    match suite.signature
+    case None =>
+      :- Need(
+           Materials.EC_PUBLIC_KEY_FIELD !in encryptionContext,
+           "Verification key can not exist in non-signed Algorithm Suites.");
+      var mat := Crypto.DecryptionMaterials(
+                   encryptionContext := encryptionContext,
+                   algorithmSuiteId := suite.id,
+                   plaintextDataKey := None(),
+                   verificationKey := None()
+                 );
+      AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
+      return Success(mat);
+    case ECDSA(curve) =>
+      :- Need(
+           Materials.EC_PUBLIC_KEY_FIELD in encryptionContext,
+           "Encryption Context missing verification key.");
+      var verificationKey :- DecodeVerificationKey(encryptionContext[Materials.EC_PUBLIC_KEY_FIELD]);
+      var mat := Crypto.DecryptionMaterials(
+                   encryptionContext := encryptionContext,
+                   algorithmSuiteId := suite.id,
+                   plaintextDataKey := None(),
+                   verificationKey := Some(verificationKey)
+                 );
+      AlgorithmSuites.LemmaAlgorithmSuiteIdImpliesEquality(mat.algorithmSuiteId, suite);
+      return Success(mat);
+  }
 
-    function method DecodeVerificationKey(utf8Key: UTF8.ValidUTF8Bytes):
-      (res: Result<seq<uint8>, string>)
-    {
-      var base64Key :- UTF8.Decode(utf8Key);
-      var key :- Base64.Decode(base64Key);
-      Success(key)
-    }
+  function method DecodeVerificationKey(utf8Key: UTF8.ValidUTF8Bytes):
+    (res: Result<seq<uint8>, string>)
+  {
+    var base64Key :- UTF8.Decode(utf8Key);
+    var key :- Base64.Decode(base64Key);
+    Success(key)
+  }
 }

--- a/src/AwsCryptographicMaterialProviders/Client.dfy
+++ b/src/AwsCryptographicMaterialProviders/Client.dfy
@@ -65,16 +65,16 @@ module
   export
     // Modules
     provides Crypto, AlgorithmSuites, Materials, Wrappers
-    // Class
+             // Class
     reveals AwsCryptographicMaterialProviders
-    // Functions
+            // Functions
     reveals
       SpecificationClient,
       SpecificationClient.GetSuite
     provides
       SpecificationClient.ValidateCommitmentPolicyOnEncrypt,
       SpecificationClient.ValidateCommitmentPolicyOnDecrypt
-    // Class Members
+      // Class Members
     provides
       AwsCryptographicMaterialProviders.CreateAwsKmsDiscoveryKeyring,
       AwsCryptographicMaterialProviders.CreateDefaultClientSupplier,
@@ -91,8 +91,8 @@ module
       AwsCryptographicMaterialProviders.CreateAwsKmsKeyring
 
   datatype SpecificationClient = SpecificationClient(
-    // Whatever top level closure is added to the constructor needs to be added here
-  )
+                                   // Whatever top level closure is added to the constructor needs to be added here
+                                 )
   {
     function method GetSuite(
       id: Crypto.AlgorithmSuiteId
@@ -137,36 +137,36 @@ module
       //# -  Raw AES keyring MUST NOT accept a key namespace of "aws-kms".
       ensures
         input.keyNamespace == "aws-kms"
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
     {
       :- Crypto.Need(input.keyNamespace != "aws-kms",
-        "keyNamespace must not be `aws-kms`");
-        
+                     "keyNamespace must not be `aws-kms`");
+
       var wrappingAlg:AESEncryption.AES_GCM := match input.wrappingAlg
-        case ALG_AES128_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
-            keyLength := 16 as AESEncryption.KeyLength,
-            tagLength := 16 as AESEncryption.TagLength,
-            ivLength := 12 as AESEncryption.IVLength
-          )
-        case ALG_AES192_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
-            keyLength := 24 as AESEncryption.KeyLength,
-            tagLength := 16 as AESEncryption.TagLength,
-            ivLength := 12 as AESEncryption.IVLength
-          )
-        case ALG_AES256_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
-            keyLength := 32 as AESEncryption.KeyLength,
-            tagLength := 16 as AESEncryption.TagLength,
-            ivLength := 12 as AESEncryption.IVLength
-          );
+                                               case ALG_AES128_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
+                                                                                   keyLength := 16 as AESEncryption.KeyLength,
+                                                                                   tagLength := 16 as AESEncryption.TagLength,
+                                                                                   ivLength := 12 as AESEncryption.IVLength
+                                                                                 )
+                                               case ALG_AES192_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
+                                                                                   keyLength := 24 as AESEncryption.KeyLength,
+                                                                                   tagLength := 16 as AESEncryption.TagLength,
+                                                                                   ivLength := 12 as AESEncryption.IVLength
+                                                                                 )
+                                               case ALG_AES256_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
+                                                                                   keyLength := 32 as AESEncryption.KeyLength,
+                                                                                   tagLength := 16 as AESEncryption.TagLength,
+                                                                                   ivLength := 12 as AESEncryption.IVLength
+                                                                                 );
 
       var namespaceAndName :- ParseKeyNamespaceAndName(input.keyNamespace, input.keyName);
       var (namespace, name) := namespaceAndName;
 
       :- Crypto.Need(|input.wrappingKey| == 16 || |input.wrappingKey| == 24 || |input.wrappingKey| == 32,
-        "Invalid wrapping key length");
+                     "Invalid wrapping key length");
       :- Crypto.Need(|input.wrappingKey| == wrappingAlg.keyLength as int,
-        "Wrapping key length does not match specified wrapping algorithm");
+                     "Wrapping key length does not match specified wrapping algorithm");
 
       var keyring := new RawAESKeyring.RawAESKeyring(namespace, name, input.wrappingKey, wrappingAlg);
       return Success(keyring);
@@ -175,8 +175,8 @@ module
     method CreateDefaultCryptographicMaterialsManager(input: Crypto.CreateDefaultCryptographicMaterialsManagerInput)
       returns (res: Result<Crypto.ICryptographicMaterialsManager, Crypto.IAwsCryptographicMaterialProvidersException>)
     {
-        var cmm := new DefaultCMM.DefaultCMM.OfKeyring(input.keyring);
-        return Success(cmm);
+      var cmm := new DefaultCMM.DefaultCMM.OfKeyring(input.keyring);
+      return Success(cmm);
     }
 
     method CreateAwsKmsKeyring(input: Crypto.CreateAwsKmsKeyringInput)
@@ -233,7 +233,7 @@ module
     {
       if input.generator.None? && |input.childKeyrings| == 0 {
         var error := new Crypto.AwsCryptographicMaterialProvidersException(
-          "Must include a generator keyring and/or at least one child keyring");
+              "Must include a generator keyring and/or at least one child keyring");
         return Failure(error);
       }
 
@@ -248,25 +248,25 @@ module
       //# -  Raw RSA keyring MUST NOT accept a key namespace of "aws-kms".
       ensures
         input.keyNamespace == "aws-kms"
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
       ensures
         input.publicKey.None? && input.privateKey.None?
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
     {
       :- Crypto.Need(input.keyNamespace != "aws-kms",
-          "keyNamespace must not be `aws-kms`");
+                     "keyNamespace must not be `aws-kms`");
       :- Crypto.Need(input.publicKey.Some? || input.privateKey.Some?,
-          "A publicKey or a privateKey is required");
+                     "A publicKey or a privateKey is required");
 
       var padding: RSAEncryption.PaddingMode := match input.paddingScheme
-        case PKCS1 => RSAEncryption.PaddingMode.PKCS1
-        case OAEP_SHA1_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA1
-        case OAEP_SHA256_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA256
-        case OAEP_SHA384_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA384
-        case OAEP_SHA512_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA512
-      ;
+                                                case PKCS1 => RSAEncryption.PaddingMode.PKCS1
+                                                case OAEP_SHA1_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA1
+                                                case OAEP_SHA256_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA256
+                                                case OAEP_SHA384_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA384
+                                                case OAEP_SHA512_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA512
+        ;
 
       var namespaceAndName :- ParseKeyNamespaceAndName(input.keyNamespace, input.keyName);
       var (namespace, name) := namespaceAndName;
@@ -292,11 +292,11 @@ module
         clientSupplier := input.clientSupplier.value;
       }
       res := MrkAwareStrictMultiKeyring(
-        input.generator,
-        input.kmsKeyIds,
-        clientSupplier,
-        Option.Some(grantTokens)
-      );
+               input.generator,
+               input.kmsKeyIds,
+               clientSupplier,
+               Option.Some(grantTokens)
+             );
     }
 
     method MrkAwareStrictMultiKeyring(
@@ -317,8 +317,8 @@ module
       ensures
         || (generator.Some? && generator.value == "")
         || (awsKmsKeys.Some? && (exists k | k in awsKmsKeys.value :: k == ""))
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.5
       //= type=implication
@@ -328,14 +328,14 @@ module
       //# success otherwise this MUST fail.
       ensures
         var allStrings := if generator.Some? then
-          [generator.value] + awsKmsKeys.UnwrapOr([])
-        else
-          awsKmsKeys.UnwrapOr([]);
+                            [generator.value] + awsKmsKeys.UnwrapOr([])
+                          else
+                            awsKmsKeys.UnwrapOr([]);
         var allIdentifiers := Seq.MapWithResult(AwsKmsArnParsing.IsAwsKmsIdentifierString, allStrings);
         || allIdentifiers.Failure?
         || (allIdentifiers.Success? && AwsKmsMrkAreUnique.AwsKmsMrkAreUnique(allIdentifiers.value).Fail?)
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.5
       //= type=implication
@@ -347,68 +347,68 @@ module
       //# Keyring MUST be this functions output.
       ensures
         && res.Success?
-      ==>
-        //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.5
-        //= type=implication
-        //# If there is a generator input then the generator keyring MUST be a
-        //# AWS KMS MRK Keyring (aws-kms-mrk-keyring.md) initialized with
-        && (generator.Some?
         ==>
-          && res.value.generatorKeyring.Some?
-          && res.value.generatorKeyring.value is AwsKmsMrkKeyring.AwsKmsMrkKeyring
-          && var g := res.value.generatorKeyring.value as AwsKmsMrkKeyring.AwsKmsMrkKeyring;
-          && g.awsKmsKey == generator.value
-          && (grantTokens.Some? ==> g.grantTokens == grantTokens.value))
-        && (generator.None?
-        ==>
-          && res.value.generatorKeyring.None?)
-        //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.5
-        //= type=implication
-        //# If there is a set of child identifiers then a set of AWS KMS MRK
-        //# Keyring (aws-kms-mrk-keyring.md) MUST be created for each AWS KMS key
-        //# identifier by initialized each keyring with
-        && (awsKmsKeys.Some?
-        ==>
-          && |awsKmsKeys.value| == |res.value.childKeyrings|
-          && forall index | 0 <= index < |awsKmsKeys.value| ::
-            // AWS KMS MRK Aware Symmetric Keying must be created for each AWS KMS Key identifier
-            && var childKeyring: Crypto.IKeyring := res.value.childKeyrings[index];
-            && childKeyring is AwsKmsMrkKeyring.AwsKmsMrkKeyring
-            && var awsKmsChild := childKeyring as AwsKmsMrkKeyring.AwsKmsMrkKeyring;
-            // AWS KMS key identifier
-            && awsKmsChild.awsKmsKey == awsKmsKeys.value[index]
-            // The input list of AWS KMS grant tokens
-            && (grantTokens.Some? ==> awsKmsChild.grantTokens == grantTokens.value))
-        && (awsKmsKeys.None?
-        ==>
-          && res.value.childKeyrings == [])
+          //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.5
+          //= type=implication
+          //# If there is a generator input then the generator keyring MUST be a
+          //# AWS KMS MRK Keyring (aws-kms-mrk-keyring.md) initialized with
+          && (generator.Some?
+              ==>
+                && res.value.generatorKeyring.Some?
+                && res.value.generatorKeyring.value is AwsKmsMrkKeyring.AwsKmsMrkKeyring
+                && var g := res.value.generatorKeyring.value as AwsKmsMrkKeyring.AwsKmsMrkKeyring;
+                && g.awsKmsKey == generator.value
+                && (grantTokens.Some? ==> g.grantTokens == grantTokens.value))
+          && (generator.None?
+              ==>
+                && res.value.generatorKeyring.None?)
+             //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.5
+             //= type=implication
+             //# If there is a set of child identifiers then a set of AWS KMS MRK
+             //# Keyring (aws-kms-mrk-keyring.md) MUST be created for each AWS KMS key
+             //# identifier by initialized each keyring with
+          && (awsKmsKeys.Some?
+              ==>
+                && |awsKmsKeys.value| == |res.value.childKeyrings|
+                && forall index | 0 <= index < |awsKmsKeys.value| ::
+                     // AWS KMS MRK Aware Symmetric Keying must be created for each AWS KMS Key identifier
+                     && var childKeyring: Crypto.IKeyring := res.value.childKeyrings[index];
+                     && childKeyring is AwsKmsMrkKeyring.AwsKmsMrkKeyring
+                     && var awsKmsChild := childKeyring as AwsKmsMrkKeyring.AwsKmsMrkKeyring;
+                     // AWS KMS key identifier
+                     && awsKmsChild.awsKmsKey == awsKmsKeys.value[index]
+                        // The input list of AWS KMS grant tokens
+                     && (grantTokens.Some? ==> awsKmsChild.grantTokens == grantTokens.value))
+          && (awsKmsKeys.None?
+              ==>
+                && res.value.childKeyrings == [])
     {
       var allStrings := match (generator) {
-        case Some(g) => [g] + awsKmsKeys.UnwrapOr([])
-        case None => awsKmsKeys.UnwrapOr([])
-      };
+                          case Some(g) => [g] + awsKmsKeys.UnwrapOr([])
+                          case None => awsKmsKeys.UnwrapOr([])
+                        };
       assert generator.Some? ==> generator.value in allStrings;
       assert awsKmsKeys.Some? ==> forall k | k in awsKmsKeys.value :: k in allStrings;
 
       var allIdentifiersResults := Seq.MapWithResult(
-        AwsKmsArnParsing.IsAwsKmsIdentifierString,
-        allStrings
-      );
+                                     AwsKmsArnParsing.IsAwsKmsIdentifierString,
+                                     allStrings
+                                   );
       var allIdentifiers :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-        allIdentifiersResults
-      );
+                              allIdentifiersResults
+                            );
       var mrkAreUniqueRes := AwsKmsMrkAreUnique.AwsKmsMrkAreUnique(allIdentifiers);
       :- Crypto.AwsCryptographicMaterialProvidersException.WrapOutcomeString(
-        mrkAreUniqueRes
-      );
+           mrkAreUniqueRes
+         );
 
       var generatorKeyring : Option<AwsKmsMrkKeyring.AwsKmsMrkKeyring>;
       match generator {
         case Some(generatorIdentifier) =>
           var arnRes := AwsKmsArnParsing.IsAwsKmsIdentifierString(generatorIdentifier);
           var arn :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-            arnRes
-          );
+                       arnRes
+                     );
           var region := AwsKmsArnParsing.GetRegion(arn);
           //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.5
           //= type=implication
@@ -418,10 +418,10 @@ module
           // I assume that the SDK will use the default region or throw an error
           var client :- clientSupplier.GetClient(Crypto.GetClientInput(region.UnwrapOr("")));
           var g := new AwsKmsMrkKeyring.AwsKmsMrkKeyring(
-            client,
-            generatorIdentifier,
-            grantTokens.UnwrapOr([])
-          );
+                client,
+                generatorIdentifier,
+                grantTokens.UnwrapOr([])
+              );
           generatorKeyring := Some(g);
         case None() => generatorKeyring := None();
       }
@@ -433,24 +433,24 @@ module
           for index := 0 to |childIdentifiers|
             invariant |awsKmsKeys.value[..index]| == |children|
             invariant forall index | 0 <= index < |children|
-            ::
-              && children[index].awsKmsKey == awsKmsKeys.value[index]
-              && (grantTokens.Some? ==> children[index].grantTokens == grantTokens.value)
+              ::
+                && children[index].awsKmsKey == awsKmsKeys.value[index]
+                && (grantTokens.Some? ==> children[index].grantTokens == grantTokens.value)
           {
             var childIdentifier := childIdentifiers[index];
             var infoRes := AwsKmsArnParsing.IsAwsKmsIdentifierString(childIdentifier);
             var info :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-              infoRes
-            );
+                          infoRes
+                        );
             var region := AwsKmsArnParsing.GetRegion(info);
             //Question: What should the behavior be if there is no region supplied?
             // I assume that the SDK will use the default region or throw an error
             var client :- clientSupplier.GetClient(Crypto.GetClientInput(region.UnwrapOr("")));
             var keyring := new AwsKmsMrkKeyring.AwsKmsMrkKeyring(
-              client,
-              childIdentifier,
-              grantTokens.UnwrapOr([])
-            );
+                  client,
+                  childIdentifier,
+                  grantTokens.UnwrapOr([])
+                );
             // Order is important
             children := children + [keyring];
           }
@@ -459,13 +459,13 @@ module
       }
 
       :- Crypto.Need(
-        generatorKeyring.Some? || |children| > 0,
-        "generatorKeyring or child Keyrings needed to create a multi keyring"
-      );
+           generatorKeyring.Some? || |children| > 0,
+           "generatorKeyring or child Keyrings needed to create a multi keyring"
+         );
       var keyring := new MultiKeyring.MultiKeyring(
-        generatorKeyring,
-        children
-      );
+            generatorKeyring,
+            children
+          );
 
       return Success(keyring);
     }
@@ -487,11 +487,11 @@ module
         clientSupplier := input.clientSupplier.value;
       }
       res := MrkAwareDiscoveryMultiKeyring(
-        input.regions,
-        input.discoveryFilter,
-        clientSupplier,
-        Option.Some(grantTokens)
-      );
+               input.regions,
+               input.discoveryFilter,
+               clientSupplier,
+               Option.Some(grantTokens)
+             );
     }
 
     //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.6
@@ -518,14 +518,14 @@ module
         //= type=implication
         //# If an empty set of Region is provided this function MUST fail.
         || |regions| == 0
-        //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.6
-        //= type=implication
-        //# If
-        //# any element of the set of regions is null or an empty string this
-        //# function MUST fail.
+           //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.6
+           //= type=implication
+           //# If
+           //# any element of the set of regions is null or an empty string this
+           //# function MUST fail.
         || (exists r | r in regions :: r == "")
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.6
       //= type=implication
@@ -536,25 +536,25 @@ module
       //# this functions output.
       ensures
         && res.Success?
-      ==>
-        && res.value.generatorKeyring.None?
-        && |regions| == |res.value.childKeyrings|
-        && forall i | 0 <= i < |regions|
-        ::
-          && var k: Crypto.IKeyring := res.value.childKeyrings[i];
-          && k is AwsKmsMrkDiscoveryKeyring.AwsKmsMrkDiscoveryKeyring
-          && var c := k as AwsKmsMrkDiscoveryKeyring.AwsKmsMrkDiscoveryKeyring;
-          //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.6
-          //= type=implication
-          //# Then a set of AWS KMS MRK Discovery Keyring (aws-kms-mrk-discovery-
-          //# keyring.md) MUST be created for each AWS KMS client by initializing
-          //# each keyring with
-          //#*  The AWS KMS client
-          //#*  The input discovery filter
-          //#*  The input AWS KMS grant tokens
-          && c.region == regions[i]
-          && (discoveryFilter.Some? ==> c.discoveryFilter == discoveryFilter)
-          && (grantTokens.Some? ==> c.grantTokens == grantTokens.value)
+        ==>
+          && res.value.generatorKeyring.None?
+          && |regions| == |res.value.childKeyrings|
+          && forall i | 0 <= i < |regions|
+             ::
+               && var k: Crypto.IKeyring := res.value.childKeyrings[i];
+               && k is AwsKmsMrkDiscoveryKeyring.AwsKmsMrkDiscoveryKeyring
+               && var c := k as AwsKmsMrkDiscoveryKeyring.AwsKmsMrkDiscoveryKeyring;
+               //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.6
+               //= type=implication
+               //# Then a set of AWS KMS MRK Discovery Keyring (aws-kms-mrk-discovery-
+               //# keyring.md) MUST be created for each AWS KMS client by initializing
+               //# each keyring with
+               //#*  The AWS KMS client
+               //#*  The input discovery filter
+               //#*  The input AWS KMS grant tokens
+               && c.region == regions[i]
+               && (discoveryFilter.Some? ==> c.discoveryFilter == discoveryFilter)
+               && (grantTokens.Some? ==> c.grantTokens == grantTokens.value)
     {
       :- Crypto.Need(|regions| > 0, "No regions passed.");
       :- Crypto.Need(Seq.IndexOfOption(regions, "").None?, "Empty string is not a valid region.");
@@ -562,36 +562,36 @@ module
       var children : seq<AwsKmsMrkDiscoveryKeyring.AwsKmsMrkDiscoveryKeyring> := [];
 
       for i := 0 to |regions|
-          invariant |regions[..i]| == |children|
-          invariant forall i | 0 <= i < |children|
+        invariant |regions[..i]| == |children|
+        invariant forall i | 0 <= i < |children|
           ::
             && children[i].region == regions[i]
             && (discoveryFilter.Some? ==> children[i].discoveryFilter == discoveryFilter)
             && (grantTokens.Some? ==> children[i].grantTokens == grantTokens.value)
-        {
-          var region := regions[i];
-          //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.6
-          //# A set of AWS KMS clients MUST be created by calling regional client
-          //# supplier for each region in the input set of regions.
-          var client :- clientSupplier.GetClient(Crypto.GetClientInput(region));
-          // :- Crypto.Need(
-          //   AwsKmsUtils.RegionMatch(client, region),
-          //   "The region for the client did not match the requested region"
-          // );
-          var keyring := new AwsKmsMrkDiscoveryKeyring.AwsKmsMrkDiscoveryKeyring(
-            client,
-            region,
-            discoveryFilter,
-            grantTokens.UnwrapOr([])
-          );
-          // Order is important
-          children := children + [keyring];
-        }
+      {
+        var region := regions[i];
+        //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.6
+        //# A set of AWS KMS clients MUST be created by calling regional client
+        //# supplier for each region in the input set of regions.
+        var client :- clientSupplier.GetClient(Crypto.GetClientInput(region));
+        // :- Crypto.Need(
+        //   AwsKmsUtils.RegionMatch(client, region),
+        //   "The region for the client did not match the requested region"
+        // );
+        var keyring := new AwsKmsMrkDiscoveryKeyring.AwsKmsMrkDiscoveryKeyring(
+              client,
+              region,
+              discoveryFilter,
+              grantTokens.UnwrapOr([])
+            );
+        // Order is important
+        children := children + [keyring];
+      }
 
       var keyring := new MultiKeyring.MultiKeyring(
-        None(),
-        children
-      );
+            None(),
+            children
+          );
 
       return Success(keyring);
     }
@@ -613,11 +613,11 @@ module
         clientSupplier := input.clientSupplier.value;
       }
       res := StrictMultiKeyring(
-        input.generator,
-        input.kmsKeyIds,
-        clientSupplier,
-        Option.Some(grantTokens)
-      );
+               input.generator,
+               input.kmsKeyIds,
+               clientSupplier,
+               Option.Some(grantTokens)
+             );
     }
 
     method StrictMultiKeyring(
@@ -631,8 +631,8 @@ module
       ensures
         || (generator.Some? && generator.value == "")
         || (awsKmsKeys.Some? && (exists k | k in awsKmsKeys.value :: k == ""))
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.5
       //= type=implication
@@ -640,13 +640,13 @@ module
       //# (aws-kms-key-arn.md#a-valid-aws-kms-arn), this function MUST fail.
       ensures
         var allStrings := if generator.Some? then
-          [generator.value] + awsKmsKeys.UnwrapOr([])
-        else
-          awsKmsKeys.UnwrapOr([]);
+                            [generator.value] + awsKmsKeys.UnwrapOr([])
+                          else
+                            awsKmsKeys.UnwrapOr([]);
         var allIdentifiers := Seq.MapWithResult(AwsKmsArnParsing.IsAwsKmsIdentifierString, allStrings);
         && allIdentifiers.Failure?
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.5
       //= type=implication
@@ -661,64 +661,64 @@ module
       //# Keyring MUST be this function's output.
       ensures
         && res.Success?
-      ==>
-        //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.5
-        //= type=implication
-        //# If there is a generator input then the generator keyring MUST be a
-        //# AWS KMS Keyring (aws-kms-keyring.md) initialized with
-        && (generator.Some?
         ==>
-          && res.value.generatorKeyring.Some?
-          && res.value.generatorKeyring.value is AwsKmsKeyring.AwsKmsKeyring
-          && var g := res.value.generatorKeyring.value as AwsKmsKeyring.AwsKmsKeyring;
-          && g.awsKmsKey == generator.value
-          && (grantTokens.Some? ==> g.grantTokens == grantTokens.value))
-        && (generator.None?
-        ==>
-          && res.value.generatorKeyring.None?)
-        //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.5
-        //= type=implication
-        //# If there is a set of child identifiers then a set of AWS KMS Keyring
-        //# (aws-kms-keyring.md) MUST be created for each AWS KMS key identifier
-        //# by initializing each keyring with
-        && (awsKmsKeys.Some?
-        ==>
-          && |awsKmsKeys.value| == |res.value.childKeyrings|
-          && forall index | 0 <= index < |awsKmsKeys.value| ::
-            // AWS KMS Keyring must be created for each AWS KMS Key identifier
-            && var childKeyring: Crypto.IKeyring := res.value.childKeyrings[index];
-            && childKeyring is AwsKmsKeyring.AwsKmsKeyring
-            && var awsKmsChild := childKeyring as AwsKmsKeyring.AwsKmsKeyring;
-            // AWS KMS key identifier
-            && awsKmsChild.awsKmsKey == awsKmsKeys.value[index]
-            // The input list of AWS KMS grant tokens
-            && (grantTokens.Some? ==> awsKmsChild.grantTokens == grantTokens.value))
-        && (awsKmsKeys.None?
-        ==>
-          && res.value.childKeyrings == [])
+          //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.5
+          //= type=implication
+          //# If there is a generator input then the generator keyring MUST be a
+          //# AWS KMS Keyring (aws-kms-keyring.md) initialized with
+          && (generator.Some?
+              ==>
+                && res.value.generatorKeyring.Some?
+                && res.value.generatorKeyring.value is AwsKmsKeyring.AwsKmsKeyring
+                && var g := res.value.generatorKeyring.value as AwsKmsKeyring.AwsKmsKeyring;
+                && g.awsKmsKey == generator.value
+                && (grantTokens.Some? ==> g.grantTokens == grantTokens.value))
+          && (generator.None?
+              ==>
+                && res.value.generatorKeyring.None?)
+             //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.5
+             //= type=implication
+             //# If there is a set of child identifiers then a set of AWS KMS Keyring
+             //# (aws-kms-keyring.md) MUST be created for each AWS KMS key identifier
+             //# by initializing each keyring with
+          && (awsKmsKeys.Some?
+              ==>
+                && |awsKmsKeys.value| == |res.value.childKeyrings|
+                && forall index | 0 <= index < |awsKmsKeys.value| ::
+                     // AWS KMS Keyring must be created for each AWS KMS Key identifier
+                     && var childKeyring: Crypto.IKeyring := res.value.childKeyrings[index];
+                     && childKeyring is AwsKmsKeyring.AwsKmsKeyring
+                     && var awsKmsChild := childKeyring as AwsKmsKeyring.AwsKmsKeyring;
+                     // AWS KMS key identifier
+                     && awsKmsChild.awsKmsKey == awsKmsKeys.value[index]
+                        // The input list of AWS KMS grant tokens
+                     && (grantTokens.Some? ==> awsKmsChild.grantTokens == grantTokens.value))
+          && (awsKmsKeys.None?
+              ==>
+                && res.value.childKeyrings == [])
     {
       var allStrings := match (generator) {
-        case Some(g) => [g] + awsKmsKeys.UnwrapOr([])
-        case None => awsKmsKeys.UnwrapOr([])
-      };
+                          case Some(g) => [g] + awsKmsKeys.UnwrapOr([])
+                          case None => awsKmsKeys.UnwrapOr([])
+                        };
       assert generator.Some? ==> generator.value in allStrings;
       assert awsKmsKeys.Some? ==> forall k | k in awsKmsKeys.value :: k in allStrings;
 
       var allIdentifiersResults := Seq.MapWithResult(
-        AwsKmsArnParsing.IsAwsKmsIdentifierString,
-        allStrings
-      );
+                                     AwsKmsArnParsing.IsAwsKmsIdentifierString,
+                                     allStrings
+                                   );
       var allIdentifiers :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-        allIdentifiersResults
-      );
+                              allIdentifiersResults
+                            );
 
       var generatorKeyring : Option<AwsKmsKeyring.AwsKmsKeyring>;
       match generator {
         case Some(generatorIdentifier) =>
           var arnRes := AwsKmsArnParsing.IsAwsKmsIdentifierString(generatorIdentifier);
           var arn :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-            arnRes
-          );
+                       arnRes
+                     );
           var region := AwsKmsArnParsing.GetRegion(arn);
           //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.5
           //= type=implication
@@ -726,10 +726,10 @@ module
           //# default region.
           var client :- clientSupplier.GetClient(Crypto.GetClientInput(region.UnwrapOr("")));
           var g := new AwsKmsKeyring.AwsKmsKeyring(
-            client,
-            generatorIdentifier,
-            grantTokens.UnwrapOr([])
-          );
+                client,
+                generatorIdentifier,
+                grantTokens.UnwrapOr([])
+              );
           generatorKeyring := Some(g);
         case None() => generatorKeyring := None();
       }
@@ -741,24 +741,24 @@ module
           for index := 0 to |childIdentifiers|
             invariant |awsKmsKeys.value[..index]| == |children|
             invariant forall index | 0 <= index < |children|
-            ::
-              && children[index].awsKmsKey == awsKmsKeys.value[index]
-              && (grantTokens.Some? ==> children[index].grantTokens == grantTokens.value)
+              ::
+                && children[index].awsKmsKey == awsKmsKeys.value[index]
+                && (grantTokens.Some? ==> children[index].grantTokens == grantTokens.value)
           {
             var childIdentifier := childIdentifiers[index];
             var infoRes := AwsKmsArnParsing.IsAwsKmsIdentifierString(childIdentifier);
             var info :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-              infoRes
-            );
+                          infoRes
+                        );
             var region := AwsKmsArnParsing.GetRegion(info);
             //Question: What should the behavior be if there is no region supplied?
             // I assume that the SDK will use the default region or throw an error
             var client :- clientSupplier.GetClient(Crypto.GetClientInput(region.UnwrapOr("")));
             var keyring := new AwsKmsKeyring.AwsKmsKeyring(
-              client,
-              childIdentifier,
-              grantTokens.UnwrapOr([])
-            );
+                  client,
+                  childIdentifier,
+                  grantTokens.UnwrapOr([])
+                );
             // Order is important
             children := children + [keyring];
           }
@@ -767,13 +767,13 @@ module
       }
 
       :- Crypto.Need(
-        generatorKeyring.Some? || |children| > 0,
-        "generatorKeyring or child Keryings needed to create a multi keyring"
-      );
+           generatorKeyring.Some? || |children| > 0,
+           "generatorKeyring or child Keryings needed to create a multi keyring"
+         );
       var keyring := new MultiKeyring.MultiKeyring(
-        generatorKeyring,
-        children
-      );
+            generatorKeyring,
+            children
+          );
 
       return Success(keyring);
     }
@@ -795,11 +795,11 @@ module
         clientSupplier := input.clientSupplier.value;
       }
       res := DiscoveryMultiKeyring(
-        input.regions,
-        input.discoveryFilter,
-        clientSupplier,
-        Option.Some(grantTokens)
-      );
+               input.regions,
+               input.discoveryFilter,
+               clientSupplier,
+               Option.Some(grantTokens)
+             );
     }
 
     //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.6
@@ -826,14 +826,14 @@ module
         //= type=implication
         //# If an empty set of Region is provided this function MUST fail.
         || |regions| == 0
-        //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.6
-        //= type=implication
-        //# If
-        //# any element of the set of regions is null or an empty string this
-        //# function MUST fail.
+           //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.6
+           //= type=implication
+           //# If
+           //# any element of the set of regions is null or an empty string this
+           //# function MUST fail.
         || (exists r | r in regions :: r == "")
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.6
       //= type=implication
@@ -844,24 +844,24 @@ module
       //# this functions output.
       ensures
         && res.Success?
-      ==>
-        && res.value.generatorKeyring.None?
-        && |regions| == |res.value.childKeyrings|
-        && forall i | 0 <= i < |regions|
-        ::
-          && var k: Crypto.IKeyring := res.value.childKeyrings[i];
-          && k is AwsKmsDiscoveryKeyring.AwsKmsDiscoveryKeyring
-          && var c := k as AwsKmsDiscoveryKeyring.AwsKmsDiscoveryKeyring;
-          //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.6
-          //= type=implication
-          //# Then a set of AWS KMS Discovery Keyring (aws-kms-discovery-
-          //# keyring.md) MUST be created for each AWS KMS client by initializing
-          //# each keyring with
-          //#*  The AWS KMS client
-          //#*  The input discovery filter
-          //#*  The input AWS KMS grant tokens
-          && (discoveryFilter.Some? ==> c.discoveryFilter == discoveryFilter)
-          && (grantTokens.Some? ==> c.grantTokens == grantTokens.value)
+        ==>
+          && res.value.generatorKeyring.None?
+          && |regions| == |res.value.childKeyrings|
+          && forall i | 0 <= i < |regions|
+             ::
+               && var k: Crypto.IKeyring := res.value.childKeyrings[i];
+               && k is AwsKmsDiscoveryKeyring.AwsKmsDiscoveryKeyring
+               && var c := k as AwsKmsDiscoveryKeyring.AwsKmsDiscoveryKeyring;
+               //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.6
+               //= type=implication
+               //# Then a set of AWS KMS Discovery Keyring (aws-kms-discovery-
+               //# keyring.md) MUST be created for each AWS KMS client by initializing
+               //# each keyring with
+               //#*  The AWS KMS client
+               //#*  The input discovery filter
+               //#*  The input AWS KMS grant tokens
+               && (discoveryFilter.Some? ==> c.discoveryFilter == discoveryFilter)
+               && (grantTokens.Some? ==> c.grantTokens == grantTokens.value)
     {
 
       :- Crypto.Need(|regions| > 0, "No regions passed.");
@@ -870,34 +870,34 @@ module
       var children : seq<AwsKmsDiscoveryKeyring.AwsKmsDiscoveryKeyring> := [];
 
       for i := 0 to |regions|
-          invariant |regions[..i]| == |children|
-          invariant forall i | 0 <= i < |children|
+        invariant |regions[..i]| == |children|
+        invariant forall i | 0 <= i < |children|
           ::
             && (discoveryFilter.Some? ==> children[i].discoveryFilter == discoveryFilter)
             && (grantTokens.Some? ==> children[i].grantTokens == grantTokens.value)
-        {
-          var region := regions[i];
-          //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.6
-          //# A set of AWS KMS clients MUST be created by calling regional client
-          //# supplier for each region in the input set of regions.
-          var client :- clientSupplier.GetClient(Crypto.GetClientInput(region));
-          // :- Crypto.Need(
-          //   AwsKmsUtils.RegionMatch(client, region),
-          //   "The region for the client did not match the requested region"
-          // );
-          var keyring := new AwsKmsDiscoveryKeyring.AwsKmsDiscoveryKeyring(
-            client,
-            discoveryFilter,
-            grantTokens.UnwrapOr([])
-          );
-          // Order is important
-          children := children + [keyring];
-        }
+      {
+        var region := regions[i];
+        //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.6
+        //# A set of AWS KMS clients MUST be created by calling regional client
+        //# supplier for each region in the input set of regions.
+        var client :- clientSupplier.GetClient(Crypto.GetClientInput(region));
+        // :- Crypto.Need(
+        //   AwsKmsUtils.RegionMatch(client, region),
+        //   "The region for the client did not match the requested region"
+        // );
+        var keyring := new AwsKmsDiscoveryKeyring.AwsKmsDiscoveryKeyring(
+              client,
+              discoveryFilter,
+              grantTokens.UnwrapOr([])
+            );
+        // Order is important
+        children := children + [keyring];
+      }
 
       var keyring := new MultiKeyring.MultiKeyring(
-        None(),
-        children
-      );
+            None(),
+            children
+          );
 
       return Success(keyring);
     }
@@ -913,12 +913,12 @@ module
   method ValidateKmsKeyId(keyId: string)
     returns (res: Result<(), Crypto.IAwsCryptographicMaterialProvidersException>)
     ensures res.Success? ==>
-      && AwsKmsArnParsing.ParseAwsKmsIdentifier(keyId).Success?
-      && UTF8.IsASCIIString(keyId)
-      && 0 < |keyId| <= AwsKmsArnParsing.MAX_AWS_KMS_IDENTIFIER_LENGTH
+              && AwsKmsArnParsing.ParseAwsKmsIdentifier(keyId).Success?
+              && UTF8.IsASCIIString(keyId)
+              && 0 < |keyId| <= AwsKmsArnParsing.MAX_AWS_KMS_IDENTIFIER_LENGTH
   {
     var _ :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-      AwsKmsArnParsing.ParseAwsKmsIdentifier(keyId));
+               AwsKmsArnParsing.ParseAwsKmsIdentifier(keyId));
     :- Crypto.Need(UTF8.IsASCIIString(keyId), "Key identifier is not ASCII");
     :- Crypto.Need(0 < |keyId| <= AwsKmsArnParsing.MAX_AWS_KMS_IDENTIFIER_LENGTH, "Key identifier is too long");
     res := Success(());
@@ -927,24 +927,24 @@ module
   method GetValidGrantTokens(grantTokens: Option<Crypto.GrantTokenList>)
     returns (res: Result<Crypto.GrantTokenList, Crypto.IAwsCryptographicMaterialProvidersException>)
     ensures res.Success? ==>
-      var tokens := res.value;
-      && 0 <= |tokens| <= 10
-      && forall token | token in tokens :: 1 <= |token| <= 8192
+              var tokens := res.value;
+              && 0 <= |tokens| <= 10
+              && forall token | token in tokens :: 1 <= |token| <= 8192
     ensures res.Success? && grantTokens.Some? ==> res.value == grantTokens.value
   {
     var tokens: Crypto.GrantTokenList := grantTokens.UnwrapOr([]);
     :- Crypto.Need(0 <= |tokens| <= 10, "Grant token list can have no more than 10 tokens");
     :- Crypto.Need(forall token | token in tokens :: 1 <= |token| <= 8192,
-      "Grant token list contains a grant token with invalid length");
+                   "Grant token list contains a grant token with invalid length");
     return Success(tokens);
   }
 
   method ParseKeyNamespaceAndName(keyNamespace: string, keyName: string)
     returns (res: Result<(UTF8.ValidUTF8Bytes, UTF8.ValidUTF8Bytes), Crypto.IAwsCryptographicMaterialProvidersException>)
     ensures res.Success? ==>
-      var (namespace, name) := res.value;
-      && |namespace| < UINT16_LIMIT
-      && |name| < UINT16_LIMIT
+              var (namespace, name) := res.value;
+              && |namespace| < UINT16_LIMIT
+              && |name| < UINT16_LIMIT
   {
     var namespaceRes := UTF8.Encode(keyNamespace);
     :- Crypto.Need(namespaceRes.Success?, "Key namespace could not be UTF8-encoded");
@@ -962,13 +962,13 @@ module
   method ValidateDiscoveryFilter(filter: Crypto.DiscoveryFilter)
     returns (res: Result<(), Crypto.IAwsCryptographicMaterialProvidersException>)
     ensures res.Success? ==>
-      && |filter.accountIds| > 0
-      && (forall accountId | accountId in filter.accountIds :: |accountId| > 0)
-      && |filter.partition| > 0
+              && |filter.accountIds| > 0
+              && (forall accountId | accountId in filter.accountIds :: |accountId| > 0)
+              && |filter.partition| > 0
   {
     :- Crypto.Need(|filter.accountIds| > 0, "Discovery filter must have at least one account ID");
     :- Crypto.Need(forall accountId | accountId in filter.accountIds :: |accountId| > 0,
-      "Discovery filter account IDs cannot be blank");
+                   "Discovery filter account IDs cannot be blank");
     :- Crypto.Need(|filter.partition| > 0, "Discovery filter partition cannot be blank");
     return Success(());
   }

--- a/src/AwsCryptographicMaterialProviders/Client.dfy
+++ b/src/AwsCryptographicMaterialProviders/Client.dfy
@@ -144,21 +144,21 @@ module
                      "keyNamespace must not be `aws-kms`");
 
       var wrappingAlg:AESEncryption.AES_GCM := match input.wrappingAlg
-                                               case ALG_AES128_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
-                                                                                   keyLength := 16 as AESEncryption.KeyLength,
-                                                                                   tagLength := 16 as AESEncryption.TagLength,
-                                                                                   ivLength := 12 as AESEncryption.IVLength
-                                                                                 )
-                                               case ALG_AES192_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
-                                                                                   keyLength := 24 as AESEncryption.KeyLength,
-                                                                                   tagLength := 16 as AESEncryption.TagLength,
-                                                                                   ivLength := 12 as AESEncryption.IVLength
-                                                                                 )
-                                               case ALG_AES256_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
-                                                                                   keyLength := 32 as AESEncryption.KeyLength,
-                                                                                   tagLength := 16 as AESEncryption.TagLength,
-                                                                                   ivLength := 12 as AESEncryption.IVLength
-                                                                                 );
+        case ALG_AES128_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
+          keyLength := 16 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+        )
+        case ALG_AES192_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
+          keyLength := 24 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+        )
+        case ALG_AES256_GCM_IV12_TAG16 => AESEncryption.AES_GCM(
+          keyLength := 32 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+        );
 
       var namespaceAndName :- ParseKeyNamespaceAndName(input.keyNamespace, input.keyName);
       var (namespace, name) := namespaceAndName;
@@ -261,11 +261,11 @@ module
                      "A publicKey or a privateKey is required");
 
       var padding: RSAEncryption.PaddingMode := match input.paddingScheme
-                                                case PKCS1 => RSAEncryption.PaddingMode.PKCS1
-                                                case OAEP_SHA1_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA1
-                                                case OAEP_SHA256_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA256
-                                                case OAEP_SHA384_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA384
-                                                case OAEP_SHA512_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA512
+        case PKCS1 => RSAEncryption.PaddingMode.PKCS1
+        case OAEP_SHA1_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA1
+        case OAEP_SHA256_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA256
+        case OAEP_SHA384_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA384
+        case OAEP_SHA512_MGF1 => RSAEncryption.PaddingMode.OAEP_SHA512
         ;
 
       var namespaceAndName :- ParseKeyNamespaceAndName(input.keyNamespace, input.keyName);
@@ -384,9 +384,9 @@ module
                 && res.value.childKeyrings == [])
     {
       var allStrings := match (generator) {
-                          case Some(g) => [g] + awsKmsKeys.UnwrapOr([])
-                          case None => awsKmsKeys.UnwrapOr([])
-                        };
+        case Some(g) => [g] + awsKmsKeys.UnwrapOr([])
+        case None => awsKmsKeys.UnwrapOr([])
+      };
       assert generator.Some? ==> generator.value in allStrings;
       assert awsKmsKeys.Some? ==> forall k | k in awsKmsKeys.value :: k in allStrings;
 
@@ -698,9 +698,9 @@ module
                 && res.value.childKeyrings == [])
     {
       var allStrings := match (generator) {
-                          case Some(g) => [g] + awsKmsKeys.UnwrapOr([])
-                          case None => awsKmsKeys.UnwrapOr([])
-                        };
+        case Some(g) => [g] + awsKmsKeys.UnwrapOr([])
+        case None => awsKmsKeys.UnwrapOr([])
+      };
       assert generator.Some? ==> generator.value in allStrings;
       assert awsKmsKeys.Some? ==> forall k | k in awsKmsKeys.value :: k in allStrings;
 

--- a/src/AwsCryptographicMaterialProviders/Client.dfy
+++ b/src/AwsCryptographicMaterialProviders/Client.dfy
@@ -233,7 +233,7 @@ module
     {
       if input.generator.None? && |input.childKeyrings| == 0 {
         var error := new Crypto.AwsCryptographicMaterialProvidersException(
-              "Must include a generator keyring and/or at least one child keyring");
+          "Must include a generator keyring and/or at least one child keyring");
         return Failure(error);
       }
 
@@ -292,11 +292,11 @@ module
         clientSupplier := input.clientSupplier.value;
       }
       res := MrkAwareStrictMultiKeyring(
-               input.generator,
-               input.kmsKeyIds,
-               clientSupplier,
-               Option.Some(grantTokens)
-             );
+        input.generator,
+        input.kmsKeyIds,
+        clientSupplier,
+        Option.Some(grantTokens)
+      );
     }
 
     method MrkAwareStrictMultiKeyring(
@@ -391,24 +391,24 @@ module
       assert awsKmsKeys.Some? ==> forall k | k in awsKmsKeys.value :: k in allStrings;
 
       var allIdentifiersResults := Seq.MapWithResult(
-                                     AwsKmsArnParsing.IsAwsKmsIdentifierString,
-                                     allStrings
-                                   );
+        AwsKmsArnParsing.IsAwsKmsIdentifierString,
+        allStrings
+      );
       var allIdentifiers :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-                              allIdentifiersResults
-                            );
+        allIdentifiersResults
+      );
       var mrkAreUniqueRes := AwsKmsMrkAreUnique.AwsKmsMrkAreUnique(allIdentifiers);
       :- Crypto.AwsCryptographicMaterialProvidersException.WrapOutcomeString(
-           mrkAreUniqueRes
-         );
+        mrkAreUniqueRes
+      );
 
       var generatorKeyring : Option<AwsKmsMrkKeyring.AwsKmsMrkKeyring>;
       match generator {
         case Some(generatorIdentifier) =>
           var arnRes := AwsKmsArnParsing.IsAwsKmsIdentifierString(generatorIdentifier);
           var arn :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-                       arnRes
-                     );
+            arnRes
+          );
           var region := AwsKmsArnParsing.GetRegion(arn);
           //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.5
           //= type=implication
@@ -418,10 +418,10 @@ module
           // I assume that the SDK will use the default region or throw an error
           var client :- clientSupplier.GetClient(Crypto.GetClientInput(region.UnwrapOr("")));
           var g := new AwsKmsMrkKeyring.AwsKmsMrkKeyring(
-                client,
-                generatorIdentifier,
-                grantTokens.UnwrapOr([])
-              );
+            client,
+            generatorIdentifier,
+            grantTokens.UnwrapOr([])
+          );
           generatorKeyring := Some(g);
         case None() => generatorKeyring := None();
       }
@@ -440,17 +440,17 @@ module
             var childIdentifier := childIdentifiers[index];
             var infoRes := AwsKmsArnParsing.IsAwsKmsIdentifierString(childIdentifier);
             var info :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-                          infoRes
-                        );
+              infoRes
+            );
             var region := AwsKmsArnParsing.GetRegion(info);
             //Question: What should the behavior be if there is no region supplied?
             // I assume that the SDK will use the default region or throw an error
             var client :- clientSupplier.GetClient(Crypto.GetClientInput(region.UnwrapOr("")));
             var keyring := new AwsKmsMrkKeyring.AwsKmsMrkKeyring(
-                  client,
-                  childIdentifier,
-                  grantTokens.UnwrapOr([])
-                );
+              client,
+              childIdentifier,
+              grantTokens.UnwrapOr([])
+            );
             // Order is important
             children := children + [keyring];
           }
@@ -459,13 +459,13 @@ module
       }
 
       :- Crypto.Need(
-           generatorKeyring.Some? || |children| > 0,
-           "generatorKeyring or child Keyrings needed to create a multi keyring"
-         );
+        generatorKeyring.Some? || |children| > 0,
+        "generatorKeyring or child Keyrings needed to create a multi keyring"
+      );
       var keyring := new MultiKeyring.MultiKeyring(
-            generatorKeyring,
-            children
-          );
+        generatorKeyring,
+        children
+      );
 
       return Success(keyring);
     }
@@ -487,11 +487,11 @@ module
         clientSupplier := input.clientSupplier.value;
       }
       res := MrkAwareDiscoveryMultiKeyring(
-               input.regions,
-               input.discoveryFilter,
-               clientSupplier,
-               Option.Some(grantTokens)
-             );
+        input.regions,
+        input.discoveryFilter,
+        clientSupplier,
+        Option.Some(grantTokens)
+      );
     }
 
     //= compliance/framework/aws-kms/aws-kms-mrk-multi-keyrings.txt#2.6
@@ -579,19 +579,19 @@ module
         //   "The region for the client did not match the requested region"
         // );
         var keyring := new AwsKmsMrkDiscoveryKeyring.AwsKmsMrkDiscoveryKeyring(
-              client,
-              region,
-              discoveryFilter,
-              grantTokens.UnwrapOr([])
-            );
+          client,
+          region,
+          discoveryFilter,
+          grantTokens.UnwrapOr([])
+        );
         // Order is important
         children := children + [keyring];
       }
 
       var keyring := new MultiKeyring.MultiKeyring(
-            None(),
-            children
-          );
+        None(),
+        children
+      );
 
       return Success(keyring);
     }
@@ -613,11 +613,11 @@ module
         clientSupplier := input.clientSupplier.value;
       }
       res := StrictMultiKeyring(
-               input.generator,
-               input.kmsKeyIds,
-               clientSupplier,
-               Option.Some(grantTokens)
-             );
+        input.generator,
+        input.kmsKeyIds,
+        clientSupplier,
+        Option.Some(grantTokens)
+      );
     }
 
     method StrictMultiKeyring(
@@ -705,20 +705,20 @@ module
       assert awsKmsKeys.Some? ==> forall k | k in awsKmsKeys.value :: k in allStrings;
 
       var allIdentifiersResults := Seq.MapWithResult(
-                                     AwsKmsArnParsing.IsAwsKmsIdentifierString,
-                                     allStrings
-                                   );
+        AwsKmsArnParsing.IsAwsKmsIdentifierString,
+        allStrings
+      );
       var allIdentifiers :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-                              allIdentifiersResults
-                            );
+        allIdentifiersResults
+      );
 
       var generatorKeyring : Option<AwsKmsKeyring.AwsKmsKeyring>;
       match generator {
         case Some(generatorIdentifier) =>
           var arnRes := AwsKmsArnParsing.IsAwsKmsIdentifierString(generatorIdentifier);
           var arn :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-                       arnRes
-                     );
+            arnRes
+          );
           var region := AwsKmsArnParsing.GetRegion(arn);
           //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.5
           //= type=implication
@@ -726,10 +726,10 @@ module
           //# default region.
           var client :- clientSupplier.GetClient(Crypto.GetClientInput(region.UnwrapOr("")));
           var g := new AwsKmsKeyring.AwsKmsKeyring(
-                client,
-                generatorIdentifier,
-                grantTokens.UnwrapOr([])
-              );
+            client,
+            generatorIdentifier,
+            grantTokens.UnwrapOr([])
+          );
           generatorKeyring := Some(g);
         case None() => generatorKeyring := None();
       }
@@ -748,17 +748,17 @@ module
             var childIdentifier := childIdentifiers[index];
             var infoRes := AwsKmsArnParsing.IsAwsKmsIdentifierString(childIdentifier);
             var info :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-                          infoRes
-                        );
+              infoRes
+            );
             var region := AwsKmsArnParsing.GetRegion(info);
             //Question: What should the behavior be if there is no region supplied?
             // I assume that the SDK will use the default region or throw an error
             var client :- clientSupplier.GetClient(Crypto.GetClientInput(region.UnwrapOr("")));
             var keyring := new AwsKmsKeyring.AwsKmsKeyring(
-                  client,
-                  childIdentifier,
-                  grantTokens.UnwrapOr([])
-                );
+              client,
+              childIdentifier,
+              grantTokens.UnwrapOr([])
+            );
             // Order is important
             children := children + [keyring];
           }
@@ -767,13 +767,13 @@ module
       }
 
       :- Crypto.Need(
-           generatorKeyring.Some? || |children| > 0,
-           "generatorKeyring or child Keryings needed to create a multi keyring"
-         );
+        generatorKeyring.Some? || |children| > 0,
+        "generatorKeyring or child Keryings needed to create a multi keyring"
+      );
       var keyring := new MultiKeyring.MultiKeyring(
-            generatorKeyring,
-            children
-          );
+        generatorKeyring,
+        children
+      );
 
       return Success(keyring);
     }
@@ -795,11 +795,11 @@ module
         clientSupplier := input.clientSupplier.value;
       }
       res := DiscoveryMultiKeyring(
-               input.regions,
-               input.discoveryFilter,
-               clientSupplier,
-               Option.Some(grantTokens)
-             );
+        input.regions,
+        input.discoveryFilter,
+        clientSupplier,
+        Option.Some(grantTokens)
+      );
     }
 
     //= compliance/framework/aws-kms/aws-kms-multi-keyrings.txt#2.6
@@ -886,18 +886,18 @@ module
         //   "The region for the client did not match the requested region"
         // );
         var keyring := new AwsKmsDiscoveryKeyring.AwsKmsDiscoveryKeyring(
-              client,
-              discoveryFilter,
-              grantTokens.UnwrapOr([])
-            );
+          client,
+          discoveryFilter,
+          grantTokens.UnwrapOr([])
+        );
         // Order is important
         children := children + [keyring];
       }
 
       var keyring := new MultiKeyring.MultiKeyring(
-            None(),
-            children
-          );
+        None(),
+        children
+      );
 
       return Success(keyring);
     }
@@ -918,7 +918,7 @@ module
               && 0 < |keyId| <= AwsKmsArnParsing.MAX_AWS_KMS_IDENTIFIER_LENGTH
   {
     var _ :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-               AwsKmsArnParsing.ParseAwsKmsIdentifier(keyId));
+      AwsKmsArnParsing.ParseAwsKmsIdentifier(keyId));
     :- Crypto.Need(UTF8.IsASCIIString(keyId), "Key identifier is not ASCII");
     :- Crypto.Need(0 < |keyId| <= AwsKmsArnParsing.MAX_AWS_KMS_IDENTIFIER_LENGTH, "Key identifier is too long");
     res := Success(());

--- a/src/AwsCryptographicMaterialProviders/ClientFactory.dfy
+++ b/src/AwsCryptographicMaterialProviders/ClientFactory.dfy
@@ -18,10 +18,10 @@ module {:extern "Dafny.Aws.EncryptionSdk.Core.AwsCryptographicMaterialProvidersF
     constructor() {}
 
     method CreateDefaultAwsCryptographicMaterialProviders()
-          returns (res: Result<Crypto.IAwsCryptographicMaterialProviders, Crypto.IAwsCryptographicMaterialProvidersException>)
+      returns (res: Result<Crypto.IAwsCryptographicMaterialProviders, Crypto.IAwsCryptographicMaterialProvidersException>)
     {
-        var client := new Client.AwsCryptographicMaterialProviders();
-        return Success(client);
+      var client := new Client.AwsCryptographicMaterialProviders();
+      return Success(client);
     }
   }
 }

--- a/src/AwsCryptographicMaterialProviders/Commitment.dfy
+++ b/src/AwsCryptographicMaterialProviders/Commitment.dfy
@@ -32,36 +32,36 @@ module {:extern "Dafny.Aws.EncryptionSdk.Core.Commitment"} MaterialProviders.Com
         && var suite := AlgorithmSuites.GetSuite(algorithm);
         && !suite.commitment.None?
       )
-    ==>
-      res.Failure?
+      ==>
+        res.Failure?
 
     // Failure: Commitment policy requires encrypting with commitment but the
     // algorithm does not provide it
     ensures
       (
         && (
-          || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT
-          || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-        )
+             || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT
+             || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+           )
         && var suite := AlgorithmSuites.GetSuite(algorithm);
         && suite.commitment.None?
       )
-    ==>
-      res.Failure?
+      ==>
+        res.Failure?
 
     // Success: Commitment policy requires encrypting with commitment and the
     // algorithm provides it
     ensures
       (
         && (
-          || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT
-          || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-        )
+             || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT
+             || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+           )
         && var suite := AlgorithmSuites.GetSuite(algorithm);
         && !suite.commitment.None?
       )
-    ==>
-      res.Success?
+      ==>
+        res.Success?
 
     // Success: Commitment policy forbids encrypting with commitment and the
     // algorithm does not provide it
@@ -71,8 +71,8 @@ module {:extern "Dafny.Aws.EncryptionSdk.Core.Commitment"} MaterialProviders.Com
         && var suite := AlgorithmSuites.GetSuite(algorithm);
         && suite.commitment.None?
       )
-    ==>
-      res.Success?
+      ==>
+        res.Success?
   {
     var suite := AlgorithmSuites.GetSuite(algorithm);
     if
@@ -81,15 +81,15 @@ module {:extern "Dafny.Aws.EncryptionSdk.Core.Commitment"} MaterialProviders.Com
     then
       Failure("Configuration conflict. Commitment policy requires only non-committing algorithm suites")
     else if
-      && (
-          || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT
-          || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-         )
-      && suite.commitment.None?
-    then
-      Failure("Configuration conflict. Commitment policy requires only committing algorithm suites")
-    else
-      Success(())
+        && (
+             || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT
+             || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+           )
+        && suite.commitment.None?
+      then
+        Failure("Configuration conflict. Commitment policy requires only committing algorithm suites")
+      else
+        Success(())
   }
 
   /*
@@ -112,8 +112,8 @@ module {:extern "Dafny.Aws.EncryptionSdk.Core.Commitment"} MaterialProviders.Com
         && var suite := AlgorithmSuites.GetSuite(algorithm);
         && suite.commitment.None?
       )
-    ==>
-      res.Failure?
+      ==>
+        res.Failure?
 
     // Success: Commitment policy requires decrypting with commitment and
     // our algorithm provides it
@@ -123,22 +123,22 @@ module {:extern "Dafny.Aws.EncryptionSdk.Core.Commitment"} MaterialProviders.Com
         && var suite := AlgorithmSuites.GetSuite(algorithm);
         && !suite.commitment.None?
       )
-    ==>
-      res.Success?
+      ==>
+        res.Success?
 
     // Success: Commitment policy does not require decrypting with commitment and
     // our algorithm does not provide it
     ensures
       (
         && (
-            || commitmentPolicy == Crypto.FORBID_ENCRYPT_ALLOW_DECRYPT
-            || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT
+             || commitmentPolicy == Crypto.FORBID_ENCRYPT_ALLOW_DECRYPT
+             || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT
            )
         && var suite := AlgorithmSuites.GetSuite(algorithm);
         && suite.commitment.None?
       )
-    ==>
-      res.Success?
+      ==>
+        res.Success?
 
   {
     var suite := AlgorithmSuites.GetSuite(algorithm);

--- a/src/AwsCryptographicMaterialProviders/DefaultClientSupplier.dfy
+++ b/src/AwsCryptographicMaterialProviders/DefaultClientSupplier.dfy
@@ -8,11 +8,11 @@ include "../Generated/AwsCryptographicMaterialProviders.dfy"
 module
   {:extern "DefaultClientSupplier"}
   MaterialProviders.DefaultClientSupplier
- {
+{
   import KMS = Com.Amazonaws.Kms
   import Aws.Crypto
-  import opened Wrappers  
-    
+  import opened Wrappers
+
   class DefaultClientSupplier
     extends Crypto.IClientSupplier
   {
@@ -20,7 +20,7 @@ module
     constructor(){}
 
     method {:extern "DefaultClientSupplier.DefaultClientSupplier", "GetClient"} GetClient(input: Crypto.GetClientInput)
-      returns (res: Result<KMS.IKeyManagementServiceClient, Crypto.IAwsCryptographicMaterialProvidersException>) 
-    
+      returns (res: Result<KMS.IKeyManagementServiceClient, Crypto.IAwsCryptographicMaterialProvidersException>)
+
   }
 }

--- a/src/AwsCryptographicMaterialProviders/Defaults.dfy
+++ b/src/AwsCryptographicMaterialProviders/Defaults.dfy
@@ -14,16 +14,16 @@ module {:extern "Defaults"} Defaults {
     ensures
       commitmentPolicy == Crypto.FORBID_ENCRYPT_ALLOW_DECRYPT
       ==>
-      res == Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384
+        res == Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384
 
     ensures
       || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT
       || commitmentPolicy == Crypto.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
       ==>
-      res == Crypto.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
+        res == Crypto.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
   {
     if commitmentPolicy == Crypto.FORBID_ENCRYPT_ALLOW_DECRYPT then
       Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 else
-      Crypto.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
+                                                                 Crypto.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
   }
 }

--- a/src/AwsCryptographicMaterialProviders/Keyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyring.dfy
@@ -19,19 +19,19 @@ module
     method OnEncrypt(input: Crypto.OnEncryptInput)
       returns (res: Result<Crypto.OnEncryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.EncryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+              ==>
+                && Materials.EncryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
 
     method OnDecrypt(input: Crypto.OnDecryptInput)
       returns (res: Result<Crypto.OnDecryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.DecryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+              ==>
+                && Materials.DecryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
   }
 }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsArnParsing.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsArnParsing.dfy
@@ -63,15 +63,15 @@ module  AwsKmsArnParsing {
       match customRegion {
         case None => ToArnString(Some(region))
         case Some(customRegion) => Join(
-                                     [
-                                       arnLiteral,
-                                       partition,
-                                       service,
-                                       customRegion,
-                                       account,
-                                       resource.ToString()
-                                     ],
-                                     ":")
+          [
+            arnLiteral,
+            partition,
+            service,
+            customRegion,
+            account,
+            resource.ToString()
+          ],
+          ":")
       }
     }
   }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsArnParsing.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsArnParsing.dfy
@@ -15,9 +15,9 @@ module  AwsKmsArnParsing {
   const MAX_AWS_KMS_IDENTIFIER_LENGTH := 2048
 
   datatype AwsResource = AwsResource(
-    resourceType: string,
-    value: string
-  ) {
+                           resourceType: string,
+                           value: string
+                         ) {
     predicate method Valid()
     {
       && 0 < |value|
@@ -33,13 +33,13 @@ module  AwsKmsArnParsing {
   }
 
   datatype AwsArn = AwsArn(
-    arnLiteral: string,
-    partition: string,
-    service: string,
-    region: string,
-    account: string,
-    resource: AwsResource
-  ) {
+                      arnLiteral: string,
+                      partition: string,
+                      service: string,
+                      region: string,
+                      account: string,
+                      resource: AwsResource
+                    ) {
     predicate method Valid()
     {
       && arnLiteral == "arn"
@@ -63,15 +63,15 @@ module  AwsKmsArnParsing {
       match customRegion {
         case None => ToArnString(Some(region))
         case Some(customRegion) => Join(
-          [
-            arnLiteral,
-            partition,
-            service,
-            customRegion,
-            account,
-            resource.ToString()
-          ],
-          ":")
+                                     [
+                                       arnLiteral,
+                                       partition,
+                                       service,
+                                       customRegion,
+                                       account,
+                                       resource.ToString()
+                                     ],
+                                     ":")
       }
     }
   }
@@ -80,9 +80,9 @@ module  AwsKmsArnParsing {
   {
     && resource.Valid()
     && (
-      || resource.resourceType == "key"
-      || resource.resourceType == "alias"
-      )
+         || resource.resourceType == "key"
+         || resource.resourceType == "alias"
+       )
   }
 
   predicate method ValidAwsKmsArn(arn: AwsArn)
@@ -145,22 +145,22 @@ module  AwsKmsArnParsing {
     //# The resource section MUST be non-empty and MUST be split by a
     //# single "/" any additional "/" are included in the resource id
     ensures ParseAwsKmsResources(identifier).Success? ==>
-      var info := Split(identifier, '/');
-      var r := ParseAwsKmsResources(identifier);
-      && |info| > 1
-      && Join([r.value.resourceType, r.value.value], "/") == identifier
+              var info := Split(identifier, '/');
+              var r := ParseAwsKmsResources(identifier);
+              && |info| > 1
+              && Join([r.value.resourceType, r.value.value], "/") == identifier
     //= compliance/framework/aws-kms/aws-kms-key-arn.txt#2.5
     //= type=implication
     //# The resource type MUST be either "alias" or "key"
     ensures ParseAwsKmsResources(identifier).Success? ==>
-      var resourceType := Split(identifier, '/')[0];
-      "key" == resourceType || "alias" == resourceType
+              var resourceType := Split(identifier, '/')[0];
+              "key" == resourceType || "alias" == resourceType
     //= compliance/framework/aws-kms/aws-kms-key-arn.txt#2.5
     //= type=implication
     //# The resource id MUST be a non-empty string
     ensures ParseAwsKmsResources(identifier).Success? ==>
-      var info := Split(identifier, '/');
-      |Join(info[1..], "/")| > 0
+              var info := Split(identifier, '/');
+              |Join(info[1..], "/")| > 0
   {}
 
   function method ParseAwsKmsArn(identifier: string): (result: Result<AwsKmsArn, string>)
@@ -172,13 +172,13 @@ module  AwsKmsArnParsing {
     var resource :- ParseAwsKmsResources(components[5]);
 
     var arn := AwsArn(
-      components[0],
-      components[1],
-      components[2],
-      components[3],
-      components[4],
-      resource
-    );
+                 components[0],
+                 components[1],
+                 components[2],
+                 components[3],
+                 components[4],
+                 resource
+               );
 
     :- Need(ValidAwsKmsArn(arn), "Malformed Arn:" + identifier);
 
@@ -244,15 +244,15 @@ module  AwsKmsArnParsing {
     //# If resource type is "key" and resource ID does not start with "mrk-",
     //# this is a (single-region) AWS KMS key ARN and MUST return false.
     ensures !IsMultiRegionAwsKmsArn(arn) <==
-        && arn.resource.resourceType == "key"
-        && !("mrk-" <= arn.resource.value)
+            && arn.resource.resourceType == "key"
+            && !("mrk-" <= arn.resource.value)
     //= compliance/framework/aws-kms/aws-kms-key-arn.txt#2.8
     //= type=implication
     //# If resource type is "key" and resource ID starts with
     //# "mrk-", this is a AWS KMS multi-Region key ARN and MUST return true.
     ensures IsMultiRegionAwsKmsArn(arn) <==
-      && arn.resource.resourceType == "key"
-      && "mrk-" <= arn.resource.value
+            && arn.resource.resourceType == "key"
+            && "mrk-" <= arn.resource.value
   {
   }
 
@@ -277,43 +277,43 @@ module  AwsKmsArnParsing {
     //# arn.md#identifying-an-an-aws-kms-multi-region-arn) called with this
     //# input.
     ensures "arn:" <= s && ParseAwsKmsArn(s).Success?
-      ==>
-        var arn := ParseAwsKmsArn(s);
-        var arnIdentifier := AwsKmsArnIdentifier(arn.value);
-        IsMultiRegionAwsKmsIdentifier(arnIdentifier) == IsMultiRegionAwsKmsArn(arn.value)
+            ==>
+              var arn := ParseAwsKmsArn(s);
+              var arnIdentifier := AwsKmsArnIdentifier(arn.value);
+              IsMultiRegionAwsKmsIdentifier(arnIdentifier) == IsMultiRegionAwsKmsArn(arn.value)
 
     //= compliance/framework/aws-kms/aws-kms-key-arn.txt#2.9
     //= type=implication
     //# If the input starts with "alias/", this an AWS KMS alias and
     //# not a multi-Region key id and MUST return false.
     ensures "alias/" <= s && ParseAwsKmsResources(s).Success?
-      ==>
-        var resource := ParseAwsKmsResources(s);
-        var resourceIdentifier := AwsKmsRawResourceIdentifier(resource.value);
-        !IsMultiRegionAwsKmsIdentifier(resourceIdentifier)
+            ==>
+              var resource := ParseAwsKmsResources(s);
+              var resourceIdentifier := AwsKmsRawResourceIdentifier(resource.value);
+              !IsMultiRegionAwsKmsIdentifier(resourceIdentifier)
     //= compliance/framework/aws-kms/aws-kms-key-arn.txt#2.9
     //= type=implication
     //# If the input starts
     //# with "mrk-", this is a multi-Region key id and MUST return true.
     ensures "mrk-" <= s && ParseAwsKmsResources(s).Success?
-      ==>
-        var resource := ParseAwsKmsResources(s);
-        var resourceIdentifier := AwsKmsRawResourceIdentifier(resource.value);
-        IsMultiRegionAwsKmsIdentifier(resourceIdentifier)
+            ==>
+              var resource := ParseAwsKmsResources(s);
+              var resourceIdentifier := AwsKmsRawResourceIdentifier(resource.value);
+              IsMultiRegionAwsKmsIdentifier(resourceIdentifier)
     //= compliance/framework/aws-kms/aws-kms-key-arn.txt#2.9
     //= type=implication
     //# If
     //# the input does not start with any of the above, this is not a multi-
     //# Region key id and MUST return false.
     ensures (
-        && !("arn:" <= s )
-        && !("alias/" <= s )
-        && !("mrk-" <= s )
-        && ParseAwsKmsIdentifier(s).Success?
-      )
-      ==>
-        var resourceIdentifier := ParseAwsKmsIdentifier(s);
-        !IsMultiRegionAwsKmsIdentifier(resourceIdentifier.value)
+              && !("arn:" <= s )
+              && !("alias/" <= s )
+              && !("mrk-" <= s )
+              && ParseAwsKmsIdentifier(s).Success?
+            )
+            ==>
+              var resourceIdentifier := ParseAwsKmsIdentifier(s);
+              !IsMultiRegionAwsKmsIdentifier(resourceIdentifier.value)
   {}
 
   predicate method IsMultiRegionAwsKmsResource(resource: AwsKmsResource)
@@ -341,7 +341,7 @@ module  AwsKmsArnParsing {
   }
 
   type AwsKmsIdentifierString = s: string |
-    IsAwsKmsIdentifierString(s).Success?
+      IsAwsKmsIdentifierString(s).Success?
     witness *
 
 }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsArnParsing.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsArnParsing.dfy
@@ -15,9 +15,9 @@ module  AwsKmsArnParsing {
   const MAX_AWS_KMS_IDENTIFIER_LENGTH := 2048
 
   datatype AwsResource = AwsResource(
-                           resourceType: string,
-                           value: string
-                         ) {
+    resourceType: string,
+    value: string
+  ) {
     predicate method Valid()
     {
       && 0 < |value|
@@ -33,13 +33,13 @@ module  AwsKmsArnParsing {
   }
 
   datatype AwsArn = AwsArn(
-                      arnLiteral: string,
-                      partition: string,
-                      service: string,
-                      region: string,
-                      account: string,
-                      resource: AwsResource
-                    ) {
+    arnLiteral: string,
+    partition: string,
+    service: string,
+    region: string,
+    account: string,
+    resource: AwsResource
+  ) {
     predicate method Valid()
     {
       && arnLiteral == "arn"

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsArnParsing.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsArnParsing.dfy
@@ -172,13 +172,13 @@ module  AwsKmsArnParsing {
     var resource :- ParseAwsKmsResources(components[5]);
 
     var arn := AwsArn(
-                 components[0],
-                 components[1],
-                 components[2],
-                 components[3],
-                 components[4],
-                 resource
-               );
+      components[0],
+      components[1],
+      components[2],
+      components[3],
+      components[4],
+      resource
+    );
 
     :- Need(ValidAwsKmsArn(arn), "Malformed Arn:" + identifier);
 

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeyring.dfy
@@ -54,7 +54,7 @@ module
       discoveryFilter: Option<Crypto.DiscoveryFilter>,
       grantTokens: KMS.GrantTokenList
     )
-    ensures
+      ensures
         && this.client          == client
         && this.discoveryFilter == discoveryFilter
         && this.grantTokens     == grantTokens
@@ -74,7 +74,7 @@ module
       ensures res.Failure?
     {
       var exception := new Crypto.AwsCryptographicMaterialProvidersException(
-        "Encryption is not supported with a Discovery Keyring.");
+            "Encryption is not supported with a Discovery Keyring.");
       return Failure(exception);
     }
 
@@ -88,11 +88,11 @@ module
     )
       returns (res: Result<Crypto.OnDecryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.DecryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+              ==>
+                && Materials.DecryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
 
       //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
       //= type=implication
@@ -102,16 +102,16 @@ module
       //# (../structures.md#decryption-materials).
       ensures
         input.materials.plaintextDataKey.Some?
-      ==>
-        && res.Failure?
+        ==>
+          && res.Failure?
 
       // If we could not convert the encryption context into a form understandable
       // by KMS, the result must be failure
       // TODO: add this to the spec
       ensures
         StringifyEncryptionContext(input.materials.encryptionContext).Failure?
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       // The primary purpose of this post-condition is to make assertions about how
       // we called KMS; specifically, that we constructed a response to KMS
@@ -119,58 +119,58 @@ module
       // response in our own output.
       ensures
         res.Success?
-      ==>
-        && var stringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext).Extract();
-        && exists edk: Crypto.EncryptedDataKey, awsKmsKey: string
-        |
-          && edk in input.encryptedDataKeys
-        ::
-          //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-          //= type=implication
-          //# *  Its provider ID MUST exactly match the value "aws-kms".
-          && edk.keyProviderId == PROVIDER_ID
-          && KMS.IsValid_CiphertextType(edk.ciphertext)
-          && KMS.IsValid_KeyIdType(awsKmsKey)
-          && var request := KMS.DecryptRequest(
-            KeyId := Option.Some(awsKmsKey),
-            CiphertextBlob :=  edk.ciphertext,
-            EncryptionContext := Option.Some(stringifiedEncCtx),
-            GrantTokens := Option.Some(grantTokens),
-            EncryptionAlgorithm := Option.None()
-          );
-          //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-          //= type=implication
-          //# To attempt to decrypt a particular encrypted data key
-          //# (../structures.md#encrypted-data-key), OnDecrypt MUST call AWS KMS
-          //# Decrypt (https://docs.aws.amazon.com/kms/latest/APIReference/
-          //# API_Decrypt.html) with the configured AWS KMS client.
-          && client.DecryptCalledWith(
+        ==>
+          && var stringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext).Extract();
+          && exists edk: Crypto.EncryptedDataKey, awsKmsKey: string
+            |
+            && edk in input.encryptedDataKeys
+          ::
             //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
             //= type=implication
-            //# When calling AWS KMS Decrypt
-            //# (https://docs.aws.amazon.com/kms/latest/APIReference/
-            //# API_Decrypt.html), the keyring MUST call with a request constructed
-            //# as follows:
-            request)
-          //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-          //= type=implication
-          //# If the response does satisfy these requirements then OnDecrypt MUST
-          //# do the following with the response:
-          && exists returnedKeyId, returnedEncryptionAlgorithm ::
-            && var response := KMS.DecryptResponse(
-              KeyId := returnedKeyId,
-              Plaintext := res.value.materials.plaintextDataKey,
-              EncryptionAlgorithm := returnedEncryptionAlgorithm
-            );
-            && client.DecryptSucceededWith(request, response)
-          //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-          //= type=implication
-          //# *  The length of the response's "Plaintext" MUST equal the key
-          //# derivation input length (../algorithm-suites.md#key-derivation-
-          //# input-length) specified by the algorithm suite (../algorithm-
-          //# suites.md) included in the input decryption materials
-          //# (../structures.md#decryption-materials).
-          && Materials.DecryptionMaterialsWithPlaintextDataKey(res.value.materials)
+            //# *  Its provider ID MUST exactly match the value "aws-kms".
+            && edk.keyProviderId == PROVIDER_ID
+            && KMS.IsValid_CiphertextType(edk.ciphertext)
+            && KMS.IsValid_KeyIdType(awsKmsKey)
+            && var request := KMS.DecryptRequest(
+                                KeyId := Option.Some(awsKmsKey),
+                                CiphertextBlob :=  edk.ciphertext,
+                                EncryptionContext := Option.Some(stringifiedEncCtx),
+                                GrantTokens := Option.Some(grantTokens),
+                                EncryptionAlgorithm := Option.None()
+                              );
+            //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+            //= type=implication
+            //# To attempt to decrypt a particular encrypted data key
+            //# (../structures.md#encrypted-data-key), OnDecrypt MUST call AWS KMS
+            //# Decrypt (https://docs.aws.amazon.com/kms/latest/APIReference/
+            //# API_Decrypt.html) with the configured AWS KMS client.
+            && client.DecryptCalledWith(
+                 //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+                 //= type=implication
+                 //# When calling AWS KMS Decrypt
+                 //# (https://docs.aws.amazon.com/kms/latest/APIReference/
+                 //# API_Decrypt.html), the keyring MUST call with a request constructed
+                 //# as follows:
+                 request)
+               //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+               //= type=implication
+               //# If the response does satisfy these requirements then OnDecrypt MUST
+               //# do the following with the response:
+            && exists returnedKeyId, returnedEncryptionAlgorithm ::
+                 && var response := KMS.DecryptResponse(
+                                      KeyId := returnedKeyId,
+                                      Plaintext := res.value.materials.plaintextDataKey,
+                                      EncryptionAlgorithm := returnedEncryptionAlgorithm
+                                    );
+                 && client.DecryptSucceededWith(request, response)
+                    //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+                    //= type=implication
+                    //# *  The length of the response's "Plaintext" MUST equal the key
+                    //# derivation input length (../algorithm-suites.md#key-derivation-
+                    //# input-length) specified by the algorithm suite (../algorithm-
+                    //# suites.md) included in the input decryption materials
+                    //# (../structures.md#decryption-materials).
+                 && Materials.DecryptionMaterialsWithPlaintextDataKey(res.value.materials)
     {
 
       var materials := input.materials;
@@ -178,8 +178,8 @@ module
       var suite := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
 
       :- Crypto.Need(
-        Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
-        "Keyring received decryption materials that already contain a plaintext data key.");
+           Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
+           "Keyring received decryption materials that already contain a plaintext data key.");
 
       //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
       //# The set of encrypted data keys MUST first be filtered to match this
@@ -193,7 +193,7 @@ module
       var edkTransform : AwsKmsEncryptedDataKeyTransformer := new AwsKmsEncryptedDataKeyTransformer();
       var edkTransformResult, parts := Actions.FlatMapWithResult(edkTransform, matchingEdks);
       var edksToAttempt :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-        edkTransformResult);
+                             edkTransformResult);
 
       // We want to make sure that the set of EDKs we're about to attempt
       // to decrypt all actually came from the original set of EDKs. This is useful
@@ -210,43 +210,43 @@ module
       //# For each encrypted data key in the filtered set, one at a time, the
       //# OnDecrypt MUST attempt to decrypt the data key.
       var decryptAction: AwsKmsEncryptedDataKeyDecryptor := new AwsKmsEncryptedDataKeyDecryptor(
-        materials,
-        client,
-        grantTokens
-      );
+            materials,
+            client,
+            grantTokens
+          );
       //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
       //# If the response does not satisfy these requirements then an error
       //# is collected and the next encrypted data key in the filtered set MUST
       //# be attempted.
       var outcome := Actions.ReduceToSuccess(
-        decryptAction,
-        edksToAttempt
-      );
+                       decryptAction,
+                       edksToAttempt
+                     );
 
       var result := match outcome {
-        case Success(mat) =>
-          assert exists helper: AwsKmsEdkHelper | helper in edksToAttempt
-          ::
-            && helper.edk in encryptedDataKeys
-            && decryptAction.Ensures(helper, Success(mat));
-          Success(Crypto.OnDecryptOutput(materials := mat))
+                      case Success(mat) =>
+                        assert exists helper: AwsKmsEdkHelper | helper in edksToAttempt
+                          ::
+                            && helper.edk in encryptedDataKeys
+                            && decryptAction.Ensures(helper, Success(mat));
+                        Success(Crypto.OnDecryptOutput(materials := mat))
 
-        //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-        //# If OnDecrypt fails to successfully decrypt any encrypted data key
-        //# (../structures.md#encrypted-data-key), then it MUST yield an error that
-        //# includes all collected errors.
-        case Failure(errors) =>
-          if |errors| == 0 then
-            Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
-          else
-            var concatString := (s, a) => a + "\n" + s;
-            var error := Seq.FoldRight(
-              concatString,
-              errors,
-              "Unable to decrypt data key:\n"
-            );
-            Failure(error)
-      };
+                      //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+                      //# If OnDecrypt fails to successfully decrypt any encrypted data key
+                      //# (../structures.md#encrypted-data-key), then it MUST yield an error that
+                      //# includes all collected errors.
+                      case Failure(errors) =>
+                        if |errors| == 0 then
+                          Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
+                        else
+                          var concatString := (s, a) => a + "\n" + s;
+                          var error := Seq.FoldRight(
+                                         concatString,
+                                         errors,
+                                         "Unable to decrypt data key:\n"
+                                       );
+                          Failure(error)
+                    };
       var wrappedResult := Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(result);
       return wrappedResult;
     }
@@ -258,9 +258,9 @@ module
    */
   class AwsKmsEncryptedDataKeyFilter
     extends ActionWithResult<
-      Crypto.EncryptedDataKey,
-      bool,
-      string
+    Crypto.EncryptedDataKey,
+    bool,
+    string
     >
   {
     const discoveryFilter: Option<Crypto.DiscoveryFilter>
@@ -344,9 +344,9 @@ module
    */
   class AwsKmsEncryptedDataKeyTransformer
     extends ActionWithResult<
-      Crypto.EncryptedDataKey,
-      seq<AwsKmsEdkHelper>,
-      string
+    Crypto.EncryptedDataKey,
+    seq<AwsKmsEdkHelper>,
+    string
     >
   {
     constructor() {}
@@ -397,9 +397,9 @@ module
    */
   class AwsKmsEncryptedDataKeyDecryptor
     extends ActionWithResult<
-      AwsKmsEdkHelper,
-      Materials.SealedDecryptionMaterials,
-      string>
+    AwsKmsEdkHelper,
+    Materials.SealedDecryptionMaterials,
+    string>
   {
     const materials: Materials.DecryptionMaterialsPendingPlaintextDataKey
     const client: KMS.IKeyManagementServiceClient
@@ -411,9 +411,9 @@ module
       grantTokens: KMS.GrantTokenList
     )
       ensures
-      && this.materials == materials
-      && this.client == client
-      && this.grantTokens == grantTokens
+        && this.materials == materials
+        && this.client == client
+        && this.grantTokens == grantTokens
     {
       this.materials := materials;
       this.client := client;
@@ -440,25 +440,25 @@ module
         // Confirm that we called KMS in the right way and correctly returned the values
         // it gave us
         && var request := KMS.DecryptRequest(
-            KeyId := Option.Some(keyArn),
-            CiphertextBlob := helper.edk.ciphertext,
-            EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
-            GrantTokens := Option.Some(grantTokens),
-            EncryptionAlgorithm := Option.None()
-          );
+                            KeyId := Option.Some(keyArn),
+                            CiphertextBlob := helper.edk.ciphertext,
+                            EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
+                            GrantTokens := Option.Some(grantTokens),
+                            EncryptionAlgorithm := Option.None()
+                          );
         && client.DecryptCalledWith(request)
         && exists returnedKeyId, returnedEncryptionAlgorithm ::
-          && var response := KMS.DecryptResponse(
-            KeyId := returnedKeyId,
-            Plaintext := Option.Some(res.value.plaintextDataKey.value),
-            EncryptionAlgorithm := returnedEncryptionAlgorithm
-          );
-          && client.DecryptSucceededWith(request, response)
-          //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-          //= type=implication
-          //# *  The "KeyId" field in the response MUST equal the AWS KMS ARN from
-          //# the provider info
-          && returnedKeyId == Option.Some(keyArn)
+             && var response := KMS.DecryptResponse(
+                                  KeyId := returnedKeyId,
+                                  Plaintext := Option.Some(res.value.plaintextDataKey.value),
+                                  EncryptionAlgorithm := returnedEncryptionAlgorithm
+                                );
+             && client.DecryptSucceededWith(request, response)
+                //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+                //= type=implication
+                //# *  The "KeyId" field in the response MUST equal the AWS KMS ARN from
+                //# the provider info
+             && returnedKeyId == Option.Some(keyArn)
     }
 
     method Invoke(
@@ -475,12 +475,12 @@ module
       var stringifiedEncCtx :- StringifyEncryptionContext(materials.encryptionContext);
 
       var decryptRequest := KMS.DecryptRequest(
-        KeyId := Option.Some(awsKmsKey),
-        CiphertextBlob := helper.edk.ciphertext,
-        EncryptionContext := Option.Some(stringifiedEncCtx),
-        GrantTokens := Option.Some(grantTokens),
-        EncryptionAlgorithm := Option.None()
-      );
+                              KeyId := Option.Some(awsKmsKey),
+                              CiphertextBlob := helper.edk.ciphertext,
+                              EncryptionContext := Option.Some(stringifiedEncCtx),
+                              GrantTokens := Option.Some(grantTokens),
+                              EncryptionAlgorithm := Option.None()
+                            );
 
       var maybeDecryptResponse := client.Decrypt(decryptRequest);
       if maybeDecryptResponse.Failure? {
@@ -490,14 +490,14 @@ module
       var decryptResponse := maybeDecryptResponse.value;
       var algId := AlgorithmSuites.GetSuite(materials.algorithmSuiteId);
       :- Need(
-        //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-        //# *  The "KeyId" field in the response MUST equal the AWS KMS ARN from
-        //# the provider info
-        && decryptResponse.KeyId.Some?
-        && decryptResponse.KeyId.value == awsKmsKey
-        && decryptResponse.Plaintext.Some?
-        && algId.encrypt.keyLength as int == |decryptResponse.Plaintext.value|
-        , "Invalid response from KMS Decrypt");
+           //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+           //# *  The "KeyId" field in the response MUST equal the AWS KMS ARN from
+           //# the provider info
+           && decryptResponse.KeyId.Some?
+           && decryptResponse.KeyId.value == awsKmsKey
+           && decryptResponse.Plaintext.Some?
+           && algId.encrypt.keyLength as int == |decryptResponse.Plaintext.value|
+         , "Invalid response from KMS Decrypt");
 
       var result :- Materials.DecryptionMaterialsAddDataKey(materials, decryptResponse.Plaintext.value);
       return Success(result);
@@ -512,17 +512,17 @@ module
     ensures
       && discoveryFilter.Some?
       && res
-    ==>
-      //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-      //= type=implication
-      //# *  If a discovery filter is configured, its partition and the
-      //# provider info partition MUST match.
-      && discoveryFilter.value.partition == arn.partition
-      //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-      //= type=implication
-      //# *  If a discovery filter is configured, its set of accounts MUST
-      //# contain the provider info account.
-      && discoveryFilter.value.accountIds <= [arn.account]
+      ==>
+        //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+        //= type=implication
+        //# *  If a discovery filter is configured, its partition and the
+        //# provider info partition MUST match.
+        && discoveryFilter.value.partition == arn.partition
+           //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+           //= type=implication
+           //# *  If a discovery filter is configured, its set of accounts MUST
+           //# contain the provider info account.
+        && discoveryFilter.value.accountIds <= [arn.account]
   {
     && match discoveryFilter {
       case Some(filter) =>
@@ -539,13 +539,13 @@ module
   lemma LemmaFlattenMembership<T>(parts: seq<seq<T>>, flat: seq<T>)
     requires Seq.Flatten(parts) == flat
     ensures forall index
-    | 0 <= index < |parts|
-    :: multiset(parts[index]) <= multiset(flat)
+              | 0 <= index < |parts|
+            :: multiset(parts[index]) <= multiset(flat)
     ensures multiset(Seq.Flatten(parts)) == multiset(flat)
     ensures forall part | part in parts
-    :: (forall i | i in part :: i in flat)
+            :: (forall i | i in part :: i in flat)
     ensures forall i | i in flat
-    :: (exists part | part in parts :: i in part)
+            :: (exists part | part in parts :: i in part)
   {
     if |parts| == 0 {
     } else {

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeyring.dfy
@@ -224,29 +224,29 @@ module
       );
 
       var result := match outcome {
-                      case Success(mat) =>
-                        assert exists helper: AwsKmsEdkHelper | helper in edksToAttempt
-                          ::
-                            && helper.edk in encryptedDataKeys
-                            && decryptAction.Ensures(helper, Success(mat));
-                        Success(Crypto.OnDecryptOutput(materials := mat))
+        case Success(mat) =>
+          assert exists helper: AwsKmsEdkHelper | helper in edksToAttempt
+            ::
+              && helper.edk in encryptedDataKeys
+              && decryptAction.Ensures(helper, Success(mat));
+          Success(Crypto.OnDecryptOutput(materials := mat))
 
-                      //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-                      //# If OnDecrypt fails to successfully decrypt any encrypted data key
-                      //# (../structures.md#encrypted-data-key), then it MUST yield an error that
-                      //# includes all collected errors.
-                      case Failure(errors) =>
-                        if |errors| == 0 then
-                          Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
-                        else
-                          var concatString := (s, a) => a + "\n" + s;
-                          var error := Seq.FoldRight(
-                            concatString,
-                            errors,
-                            "Unable to decrypt data key:\n"
-                          );
-                          Failure(error)
-                    };
+        //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+        //# If OnDecrypt fails to successfully decrypt any encrypted data key
+        //# (../structures.md#encrypted-data-key), then it MUST yield an error that
+        //# includes all collected errors.
+        case Failure(errors) =>
+          if |errors| == 0 then
+            Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
+          else
+            var concatString := (s, a) => a + "\n" + s;
+            var error := Seq.FoldRight(
+              concatString,
+              errors,
+              "Unable to decrypt data key:\n"
+            );
+            Failure(error)
+      };
       var wrappedResult := Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(result);
       return wrappedResult;
     }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeyring.dfy
@@ -74,7 +74,7 @@ module
       ensures res.Failure?
     {
       var exception := new Crypto.AwsCryptographicMaterialProvidersException(
-            "Encryption is not supported with a Discovery Keyring.");
+        "Encryption is not supported with a Discovery Keyring.");
       return Failure(exception);
     }
 
@@ -132,12 +132,12 @@ module
             && KMS.IsValid_CiphertextType(edk.ciphertext)
             && KMS.IsValid_KeyIdType(awsKmsKey)
             && var request := KMS.DecryptRequest(
-                                KeyId := Option.Some(awsKmsKey),
-                                CiphertextBlob :=  edk.ciphertext,
-                                EncryptionContext := Option.Some(stringifiedEncCtx),
-                                GrantTokens := Option.Some(grantTokens),
-                                EncryptionAlgorithm := Option.None()
-                              );
+                 KeyId := Option.Some(awsKmsKey),
+                 CiphertextBlob :=  edk.ciphertext,
+                 EncryptionContext := Option.Some(stringifiedEncCtx),
+                 GrantTokens := Option.Some(grantTokens),
+                 EncryptionAlgorithm := Option.None()
+               );
             //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
             //= type=implication
             //# To attempt to decrypt a particular encrypted data key
@@ -158,10 +158,10 @@ module
                //# do the following with the response:
             && exists returnedKeyId, returnedEncryptionAlgorithm ::
                  && var response := KMS.DecryptResponse(
-                                      KeyId := returnedKeyId,
-                                      Plaintext := res.value.materials.plaintextDataKey,
-                                      EncryptionAlgorithm := returnedEncryptionAlgorithm
-                                    );
+                   KeyId := returnedKeyId,
+                   Plaintext := res.value.materials.plaintextDataKey,
+                   EncryptionAlgorithm := returnedEncryptionAlgorithm
+                 );
                  && client.DecryptSucceededWith(request, response)
                     //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
                     //= type=implication
@@ -178,8 +178,8 @@ module
       var suite := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
 
       :- Crypto.Need(
-           Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
-           "Keyring received decryption materials that already contain a plaintext data key.");
+        Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
+        "Keyring received decryption materials that already contain a plaintext data key.");
 
       //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
       //# The set of encrypted data keys MUST first be filtered to match this
@@ -193,7 +193,7 @@ module
       var edkTransform : AwsKmsEncryptedDataKeyTransformer := new AwsKmsEncryptedDataKeyTransformer();
       var edkTransformResult, parts := Actions.FlatMapWithResult(edkTransform, matchingEdks);
       var edksToAttempt :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-                             edkTransformResult);
+        edkTransformResult);
 
       // We want to make sure that the set of EDKs we're about to attempt
       // to decrypt all actually came from the original set of EDKs. This is useful
@@ -210,18 +210,18 @@ module
       //# For each encrypted data key in the filtered set, one at a time, the
       //# OnDecrypt MUST attempt to decrypt the data key.
       var decryptAction: AwsKmsEncryptedDataKeyDecryptor := new AwsKmsEncryptedDataKeyDecryptor(
-            materials,
-            client,
-            grantTokens
-          );
+        materials,
+        client,
+        grantTokens
+      );
       //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
       //# If the response does not satisfy these requirements then an error
       //# is collected and the next encrypted data key in the filtered set MUST
       //# be attempted.
       var outcome := Actions.ReduceToSuccess(
-                       decryptAction,
-                       edksToAttempt
-                     );
+        decryptAction,
+        edksToAttempt
+      );
 
       var result := match outcome {
                       case Success(mat) =>
@@ -241,10 +241,10 @@ module
                         else
                           var concatString := (s, a) => a + "\n" + s;
                           var error := Seq.FoldRight(
-                                         concatString,
-                                         errors,
-                                         "Unable to decrypt data key:\n"
-                                       );
+                            concatString,
+                            errors,
+                            "Unable to decrypt data key:\n"
+                          );
                           Failure(error)
                     };
       var wrappedResult := Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(result);
@@ -440,19 +440,19 @@ module
         // Confirm that we called KMS in the right way and correctly returned the values
         // it gave us
         && var request := KMS.DecryptRequest(
-                            KeyId := Option.Some(keyArn),
-                            CiphertextBlob := helper.edk.ciphertext,
-                            EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
-                            GrantTokens := Option.Some(grantTokens),
-                            EncryptionAlgorithm := Option.None()
-                          );
+             KeyId := Option.Some(keyArn),
+             CiphertextBlob := helper.edk.ciphertext,
+             EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
+             GrantTokens := Option.Some(grantTokens),
+             EncryptionAlgorithm := Option.None()
+           );
         && client.DecryptCalledWith(request)
         && exists returnedKeyId, returnedEncryptionAlgorithm ::
              && var response := KMS.DecryptResponse(
-                                  KeyId := returnedKeyId,
-                                  Plaintext := Option.Some(res.value.plaintextDataKey.value),
-                                  EncryptionAlgorithm := returnedEncryptionAlgorithm
-                                );
+               KeyId := returnedKeyId,
+               Plaintext := Option.Some(res.value.plaintextDataKey.value),
+               EncryptionAlgorithm := returnedEncryptionAlgorithm
+             );
              && client.DecryptSucceededWith(request, response)
                 //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
                 //= type=implication
@@ -475,12 +475,12 @@ module
       var stringifiedEncCtx :- StringifyEncryptionContext(materials.encryptionContext);
 
       var decryptRequest := KMS.DecryptRequest(
-                              KeyId := Option.Some(awsKmsKey),
-                              CiphertextBlob := helper.edk.ciphertext,
-                              EncryptionContext := Option.Some(stringifiedEncCtx),
-                              GrantTokens := Option.Some(grantTokens),
-                              EncryptionAlgorithm := Option.None()
-                            );
+        KeyId := Option.Some(awsKmsKey),
+        CiphertextBlob := helper.edk.ciphertext,
+        EncryptionContext := Option.Some(stringifiedEncCtx),
+        GrantTokens := Option.Some(grantTokens),
+        EncryptionAlgorithm := Option.None()
+      );
 
       var maybeDecryptResponse := client.Decrypt(decryptRequest);
       if maybeDecryptResponse.Failure? {
@@ -490,14 +490,14 @@ module
       var decryptResponse := maybeDecryptResponse.value;
       var algId := AlgorithmSuites.GetSuite(materials.algorithmSuiteId);
       :- Need(
-           //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
-           //# *  The "KeyId" field in the response MUST equal the AWS KMS ARN from
-           //# the provider info
-           && decryptResponse.KeyId.Some?
-           && decryptResponse.KeyId.value == awsKmsKey
-           && decryptResponse.Plaintext.Some?
-           && algId.encrypt.keyLength as int == |decryptResponse.Plaintext.value|
-         , "Invalid response from KMS Decrypt");
+        //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
+        //# *  The "KeyId" field in the response MUST equal the AWS KMS ARN from
+        //# the provider info
+        && decryptResponse.KeyId.Some?
+        && decryptResponse.KeyId.value == awsKmsKey
+        && decryptResponse.Plaintext.Some?
+        && algId.encrypt.keyLength as int == |decryptResponse.Plaintext.value|
+      , "Invalid response from KMS Decrypt");
 
       var result :- Materials.DecryptionMaterialsAddDataKey(materials, decryptResponse.Plaintext.value);
       return Success(result);

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeyring.dfy
@@ -258,9 +258,9 @@ module
    */
   class AwsKmsEncryptedDataKeyFilter
     extends ActionWithResult<
-    Crypto.EncryptedDataKey,
-    bool,
-    string
+      Crypto.EncryptedDataKey,
+      bool,
+      string
     >
   {
     const discoveryFilter: Option<Crypto.DiscoveryFilter>
@@ -344,9 +344,9 @@ module
    */
   class AwsKmsEncryptedDataKeyTransformer
     extends ActionWithResult<
-    Crypto.EncryptedDataKey,
-    seq<AwsKmsEdkHelper>,
-    string
+      Crypto.EncryptedDataKey,
+      seq<AwsKmsEdkHelper>,
+      string
     >
   {
     constructor() {}
@@ -397,9 +397,9 @@ module
    */
   class AwsKmsEncryptedDataKeyDecryptor
     extends ActionWithResult<
-    AwsKmsEdkHelper,
-    Materials.SealedDecryptionMaterials,
-    string>
+      AwsKmsEdkHelper,
+      Materials.SealedDecryptionMaterials,
+      string>
   {
     const materials: Materials.DecryptionMaterialsPendingPlaintextDataKey
     const client: KMS.IKeyManagementServiceClient

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsKeyring.dfy
@@ -566,31 +566,31 @@ module
       ghost var stringifiedEncCtx :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
         stringifiedEncCtxResult);
       var result := match outcome {
-                      case Success(mat) =>
-                        assert exists edk | edk in edksToAttempt
-                          ::
-                            && edk in input.encryptedDataKeys
-                            && filter.Ensures(edk, Success(true))
-                            && decryptClosure.Ensures(edk, Success(mat));
-                        Success(Crypto.OnDecryptOutput(
-                                  materials := mat
-                                ))
-                      //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-                      //# If OnDecrypt fails to successfully decrypt any encrypted data key
-                      //# (../structures.md#encrypted-data-key), then it MUST yield an error
-                      //# that includes all the collected errors.
-                      case Failure(errors) =>
-                        if |errors| == 0 then
-                          Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
-                        else
-                          var concatString := (s, a) => a + "\n" + s;
-                          var error := Seq.FoldRight(
-                            concatString,
-                            errors,
-                            "Unable to decrypt data key:\n"
-                          );
-                          Failure(error)
-                    };
+        case Success(mat) =>
+          assert exists edk | edk in edksToAttempt
+            ::
+              && edk in input.encryptedDataKeys
+              && filter.Ensures(edk, Success(true))
+              && decryptClosure.Ensures(edk, Success(mat));
+          Success(Crypto.OnDecryptOutput(
+                    materials := mat
+                  ))
+        //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+        //# If OnDecrypt fails to successfully decrypt any encrypted data key
+        //# (../structures.md#encrypted-data-key), then it MUST yield an error
+        //# that includes all the collected errors.
+        case Failure(errors) =>
+          if |errors| == 0 then
+            Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
+          else
+            var concatString := (s, a) => a + "\n" + s;
+            var error := Seq.FoldRight(
+              concatString,
+              errors,
+              "Unable to decrypt data key:\n"
+            );
+            Failure(error)
+      };
       var wrapped := Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(result);
       return wrapped;
     }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsKeyring.dfy
@@ -648,9 +648,9 @@ module
 
   class DecryptSingleEncryptedDataKey
     extends ActionWithResult<
-    Crypto.EncryptedDataKey,
-    Materials.SealedDecryptionMaterials,
-    string>
+      Crypto.EncryptedDataKey,
+      Materials.SealedDecryptionMaterials,
+      string>
   {
     const materials: Materials.DecryptionMaterialsPendingPlaintextDataKey
     const client: KMS.IKeyManagementServiceClient

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsKeyring.dfy
@@ -95,25 +95,25 @@ module
     method OnEncrypt(input: Crypto.OnEncryptInput)
       returns (res: Result<Crypto.OnEncryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.EncryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+              ==>
+                && Materials.EncryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
 
       ensures StringifyEncryptionContext(input.materials.encryptionContext).Failure?
-      ==>
-        res.Failure?
+              ==>
+                res.Failure?
 
       ensures !KMS.IsValid_KeyIdType(awsKmsKey)
-      ==>
-        res.Failure?
+              ==>
+                res.Failure?
 
       ensures
         && input.materials.plaintextDataKey.Some?
         && !KMS.IsValid_PlaintextType(input.materials.plaintextDataKey.value)
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
       //= type=implication
@@ -127,42 +127,42 @@ module
         && var maybeStringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext);
         && input.materials.plaintextDataKey.None?
         && maybeStringifiedEncCtx.Success?
-      ==>
-        //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-        //= type=implication
-        //# If the keyring calls AWS KMS GenerateDataKeys, it MUST use the
-        //# configured AWS KMS client to make the call.
-        client.GenerateDataKeyCalledWith(
+        ==>
           //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
           //= type=implication
-          //# The keyring MUST call
-          //# AWS KMS GenerateDataKeys with a request constructed as follows:
-          KMS.GenerateDataKeyRequest(
+          //# If the keyring calls AWS KMS GenerateDataKeys, it MUST use the
+          //# configured AWS KMS client to make the call.
+          client.GenerateDataKeyCalledWith(
             //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
             //= type=implication
-            //# *  "EncryptionContext" MUST be the encryption context
-            //# (../structures.md#encryption-context) included in the input
-            //# encryption materials (../structures.md#encryption-materials).
-            EncryptionContext := Some(maybeStringifiedEncCtx.value),
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-            //= type=implication
-            //# *  "GrantTokens" MUST be this keyring's grant tokens
-            //# (https://docs.aws.amazon.com/kms/latest/developerguide/
-            //# concepts.html#grant_token).
-            GrantTokens := Some(grantTokens),
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-            //= type=implication
-            //# *  "KeyId" MUST be the keyring's KMS key identifier.
-            KeyId := awsKmsKey,
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-            //= type=implication
-            //# *  "NumberOfBytes" MUST be the key derivation input length
-            //# (../algorithm-suites.md#key-derivation-input-length) specified by
-            //# the algorithm suite (../algorithm-suites.md) included in the input
-            //# encryption materials (../structures.md#encryption-materials).
-            NumberOfBytes := Some(AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId).encrypt.keyLength as int32),
-            KeySpec := None
-          ))
+            //# The keyring MUST call
+            //# AWS KMS GenerateDataKeys with a request constructed as follows:
+            KMS.GenerateDataKeyRequest(
+              //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+              //= type=implication
+              //# *  "EncryptionContext" MUST be the encryption context
+              //# (../structures.md#encryption-context) included in the input
+              //# encryption materials (../structures.md#encryption-materials).
+              EncryptionContext := Some(maybeStringifiedEncCtx.value),
+              //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+              //= type=implication
+              //# *  "GrantTokens" MUST be this keyring's grant tokens
+              //# (https://docs.aws.amazon.com/kms/latest/developerguide/
+              //# concepts.html#grant_token).
+              GrantTokens := Some(grantTokens),
+              //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+              //= type=implication
+              //# *  "KeyId" MUST be the keyring's KMS key identifier.
+              KeyId := awsKmsKey,
+              //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+              //= type=implication
+              //# *  "NumberOfBytes" MUST be the key derivation input length
+              //# (../algorithm-suites.md#key-derivation-input-length) specified by
+              //# the algorithm suite (../algorithm-suites.md) included in the input
+              //# encryption materials (../structures.md#encryption-materials).
+              NumberOfBytes := Some(AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId).encrypt.keyLength as int32),
+              KeySpec := None
+            ))
 
       //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
       //= type=implication
@@ -171,34 +171,34 @@ module
       ensures
         && input.materials.plaintextDataKey.None?
         && res.Success?
-      ==>
-        && res.value.materials.plaintextDataKey.Some?
-        && |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
-        && KMS.IsValid_CiphertextType(Last(res.value.materials.encryptedDataKeys).ciphertext)
-        && var algSuite := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
-        //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-        //= type=implication
-        //# If the Generate Data Key call succeeds, OnEncrypt MUST verify that
-        //# the response "Plaintext" length matches the specification of the
-        //# algorithm suite (../algorithm-suites.md)'s Key Derivation Input
-        //# Length field.
-        && algSuite.encrypt.keyLength as int == |res.value.materials.plaintextDataKey.value|
-        && exists returnedKeyId ::
-          client.GenerateDataKeySucceededWith(
-            input := KMS.GenerateDataKeyRequest(
-              KeyId := awsKmsKey,
-              EncryptionContext := Some(StringifyEncryptionContext(input.materials.encryptionContext).Extract()),
-              GrantTokens := Some(grantTokens),
-              NumberOfBytes := Some(algSuite.encrypt.keyLength as int32),
-              KeySpec := None
-            ),
-            output := KMS.GenerateDataKeyResponse(
-              KeyId := returnedKeyId,
-              // The last data key is the one just added and what should be the result of the KMS call
-              CiphertextBlob := Some(Last(res.value.materials.encryptedDataKeys).ciphertext),
-              Plaintext := Some(res.value.materials.plaintextDataKey.value)
-            )
-          )
+        ==>
+          && res.value.materials.plaintextDataKey.Some?
+          && |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
+          && KMS.IsValid_CiphertextType(Last(res.value.materials.encryptedDataKeys).ciphertext)
+          && var algSuite := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
+          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+          //= type=implication
+          //# If the Generate Data Key call succeeds, OnEncrypt MUST verify that
+          //# the response "Plaintext" length matches the specification of the
+          //# algorithm suite (../algorithm-suites.md)'s Key Derivation Input
+          //# Length field.
+          && algSuite.encrypt.keyLength as int == |res.value.materials.plaintextDataKey.value|
+          && exists returnedKeyId ::
+               client.GenerateDataKeySucceededWith(
+                 input := KMS.GenerateDataKeyRequest(
+                            KeyId := awsKmsKey,
+                            EncryptionContext := Some(StringifyEncryptionContext(input.materials.encryptionContext).Extract()),
+                            GrantTokens := Some(grantTokens),
+                            NumberOfBytes := Some(algSuite.encrypt.keyLength as int32),
+                            KeySpec := None
+                          ),
+                 output := KMS.GenerateDataKeyResponse(
+                             KeyId := returnedKeyId,
+                             // The last data key is the one just added and what should be the result of the KMS call
+                             CiphertextBlob := Some(Last(res.value.materials.encryptedDataKeys).ciphertext),
+                             Plaintext := Some(res.value.materials.plaintextDataKey.value)
+                           )
+               )
 
       //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
       //= type=implication
@@ -208,44 +208,44 @@ module
       //# identifier.
       ensures
         && input.materials.plaintextDataKey.Some?
-        // These already-ensured clauses are required because we cannot depend on a res.Success? or res.Failure? to verify
-        // that the client was called as it may be called on both paths
+           // These already-ensured clauses are required because we cannot depend on a res.Success? or res.Failure? to verify
+           // that the client was called as it may be called on both paths
         && KMS.IsValid_PlaintextType(input.materials.plaintextDataKey.value)
         && StringifyEncryptionContext(input.materials.encryptionContext).Success?
-      ==>
-        && var stringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext).Extract();
-        //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-        //= type=implication
-        //# The keyring MUST call AWS KMS Encrypt
-        //# (https://docs.aws.amazon.com/kms/latest/APIReference/
-        //# API_Encrypt.html) using the configured AWS KMS client.
-        && client.EncryptCalledWith(
+        ==>
+          && var stringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext).Extract();
           //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
           //= type=implication
-          //# The keyring
-          //# MUST AWS KMS Encrypt call with a request constructed as follows:
-          KMS.EncryptRequest(
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-            //# *  "EncryptionContext" MUST be the encryption context
-            //# (../structures.md#encryption-context) included in the input
-            //# encryption materials (../structures.md#encryption-materials).
-            EncryptionContext := Some(stringifiedEncCtx),
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-            //# *  "GrantTokens" MUST be this keyring's grant tokens
-            //# (https://docs.aws.amazon.com/kms/latest/developerguide/
-            //# concepts.html#grant_token).
-            GrantTokens := Some(grantTokens),
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-            //= type=implication
-            //# *  "KeyId" MUST be the configured AWS KMS key identifier.
-            KeyId := awsKmsKey,
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-            //= type=implication
-            //# *  "PlaintextDataKey" MUST be the plaintext data key in the
-            //# encryption materials (../structures.md#encryption-materials).
-            Plaintext := input.materials.plaintextDataKey.value,
-            EncryptionAlgorithm := None
-          ))
+          //# The keyring MUST call AWS KMS Encrypt
+          //# (https://docs.aws.amazon.com/kms/latest/APIReference/
+          //# API_Encrypt.html) using the configured AWS KMS client.
+          && client.EncryptCalledWith(
+               //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+               //= type=implication
+               //# The keyring
+               //# MUST AWS KMS Encrypt call with a request constructed as follows:
+               KMS.EncryptRequest(
+                 //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+                 //# *  "EncryptionContext" MUST be the encryption context
+                 //# (../structures.md#encryption-context) included in the input
+                 //# encryption materials (../structures.md#encryption-materials).
+                 EncryptionContext := Some(stringifiedEncCtx),
+                 //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+                 //# *  "GrantTokens" MUST be this keyring's grant tokens
+                 //# (https://docs.aws.amazon.com/kms/latest/developerguide/
+                 //# concepts.html#grant_token).
+                 GrantTokens := Some(grantTokens),
+                 //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+                 //= type=implication
+                 //# *  "KeyId" MUST be the configured AWS KMS key identifier.
+                 KeyId := awsKmsKey,
+                 //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+                 //= type=implication
+                 //# *  "PlaintextDataKey" MUST be the plaintext data key in the
+                 //# encryption materials (../structures.md#encryption-materials).
+                 Plaintext := input.materials.plaintextDataKey.value,
+                 EncryptionAlgorithm := None
+               ))
 
       //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
       //= type=implication
@@ -254,46 +254,46 @@ module
       ensures
         && input.materials.plaintextDataKey.Some?
         && res.Success?
-      ==>
-        //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-        //= type=implication
-        //# If
-        //# verified, OnEncrypt MUST append a new encrypted data key
-        //# (../structures.md#encrypted-data-key) to the encrypted data key list
-        //# in the encryption materials (../structures.md#encryption-materials),
-        //# constructed as follows:
-        && |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
-        && KMS.IsValid_CiphertextType(Last(res.value.materials.encryptedDataKeys).ciphertext)
-        && exists returnedKeyId, returnedEncryptionAlgorithm ::
-          client.EncryptSucceededWith(
-            input := KMS.EncryptRequest(
-              KeyId := awsKmsKey,
-              Plaintext := input.materials.plaintextDataKey.value,
-              EncryptionContext := Some(StringifyEncryptionContext(input.materials.encryptionContext).Extract()),
-              GrantTokens := Some(grantTokens),
-              EncryptionAlgorithm := None
-            ),
-            output := KMS.EncryptResponse(
-              CiphertextBlob := Some(Last(res.value.materials.encryptedDataKeys).ciphertext),
-              KeyId := returnedKeyId,
-              EncryptionAlgorithm := returnedEncryptionAlgorithm
-            )
-          )
+        ==>
+          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+          //= type=implication
+          //# If
+          //# verified, OnEncrypt MUST append a new encrypted data key
+          //# (../structures.md#encrypted-data-key) to the encrypted data key list
+          //# in the encryption materials (../structures.md#encryption-materials),
+          //# constructed as follows:
+          && |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
+          && KMS.IsValid_CiphertextType(Last(res.value.materials.encryptedDataKeys).ciphertext)
+          && exists returnedKeyId, returnedEncryptionAlgorithm ::
+               client.EncryptSucceededWith(
+                 input := KMS.EncryptRequest(
+                            KeyId := awsKmsKey,
+                            Plaintext := input.materials.plaintextDataKey.value,
+                            EncryptionContext := Some(StringifyEncryptionContext(input.materials.encryptionContext).Extract()),
+                            GrantTokens := Some(grantTokens),
+                            EncryptionAlgorithm := None
+                          ),
+                 output := KMS.EncryptResponse(
+                             CiphertextBlob := Some(Last(res.value.materials.encryptedDataKeys).ciphertext),
+                             KeyId := returnedKeyId,
+                             EncryptionAlgorithm := returnedEncryptionAlgorithm
+                           )
+               )
     {
       var materials := input.materials;
       var suite := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
       var stringifiedEncCtxResult := StringifyEncryptionContext(input.materials.encryptionContext);
       var stringifiedEncCtx :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-        stringifiedEncCtxResult);
+                                 stringifiedEncCtxResult);
 
       if materials.plaintextDataKey.None? {
         var generatorRequest := KMS.GenerateDataKeyRequest(
-          EncryptionContext := Some(stringifiedEncCtx),
-          GrantTokens := Some(grantTokens),
-          KeyId := awsKmsKey,
-          NumberOfBytes := Some(suite.encrypt.keyLength as int32),
-          KeySpec := None
-        );
+                                  EncryptionContext := Some(stringifiedEncCtx),
+                                  GrantTokens := Some(grantTokens),
+                                  KeyId := awsKmsKey,
+                                  NumberOfBytes := Some(suite.encrypt.keyLength as int32),
+                                  KeySpec := None
+                                );
 
         var maybeGenerateResponse := client.GenerateDataKey(generatorRequest);
 
@@ -314,40 +314,40 @@ module
         //# The Generate Data Key response's "KeyId" MUST be a
         //# valid AWS KMS key ARN (aws-kms-key-arn.md#a-valid-aws-kms-arn).
         :- Crypto.Need(
-          && generateResponse.KeyId.Some?
-          && ParseAwsKmsIdentifier(generateResponse.KeyId.value).Success?,
-          "Invalid response from KMS GenerateDataKey:: Invalid Key Id"
-        );
+             && generateResponse.KeyId.Some?
+             && ParseAwsKmsIdentifier(generateResponse.KeyId.value).Success?,
+             "Invalid response from KMS GenerateDataKey:: Invalid Key Id"
+           );
         :- Crypto.Need(
-          && generateResponse.Plaintext.Some?
-          && suite.encrypt.keyLength as int == |generateResponse.Plaintext.value|,
-          "Invalid response from AWS KMS GenerateDataKey: Invalid data key"
-        );
+             && generateResponse.Plaintext.Some?
+             && suite.encrypt.keyLength as int == |generateResponse.Plaintext.value|,
+             "Invalid response from AWS KMS GenerateDataKey: Invalid data key"
+           );
 
         var providerInfoResult := UTF8.Encode(generateResponse.KeyId.value);
         var providerInfo :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(providerInfoResult);
         :- Crypto.Need(|providerInfo| < UINT16_LIMIT, "Invalid response from AWS KMS GenerateDataKey: Key ID too long.");
 
         :- Crypto.Need(
-          && generateResponse.CiphertextBlob.Some?
-          && KMS.IsValid_CiphertextType(generateResponse.CiphertextBlob.value),
-          "Invalid response from AWS KMS GeneratedDataKey: Invalid ciphertext"
-        );
+             && generateResponse.CiphertextBlob.Some?
+             && KMS.IsValid_CiphertextType(generateResponse.CiphertextBlob.value),
+             "Invalid response from AWS KMS GeneratedDataKey: Invalid ciphertext"
+           );
 
         var edk := Crypto.EncryptedDataKey(
-          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-          //# -  the key provider id (../structures.md#key-provider-id) MUST be
-          //# "aws-kms".
-          keyProviderId := PROVIDER_ID,
-          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-          //# -  the key provider information (../structures.md#key-provider-
-          //# information) MUST be the response "KeyId".
-          keyProviderInfo := providerInfo,
-          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-          //# -  the ciphertext (../structures.md#ciphertext) MUST be the
-          //# response "CiphertextBlob".
-          ciphertext := generateResponse.CiphertextBlob.value
-        );
+                     //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+                     //# -  the key provider id (../structures.md#key-provider-id) MUST be
+                     //# "aws-kms".
+                     keyProviderId := PROVIDER_ID,
+                     //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+                     //# -  the key provider information (../structures.md#key-provider-
+                     //# information) MUST be the response "KeyId".
+                     keyProviderInfo := providerInfo,
+                     //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+                     //# -  the ciphertext (../structures.md#ciphertext) MUST be the
+                     //# response "CiphertextBlob".
+                     ciphertext := generateResponse.CiphertextBlob.value
+                   );
         //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
         //# *  MUST set the plaintext data key on the encryption materials
         //# (../structures.md#encryption-materials) as the response
@@ -362,18 +362,18 @@ module
         var addKeyResult := Materials.EncryptionMaterialAddDataKey(materials, plaintextDataKey, [edk]);
         var result :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(addKeyResult);
         return Success(Crypto.OnEncryptOutput(
-          materials := result
-        ));
+                         materials := result
+                       ));
       } else {
         :- Crypto.Need(KMS.IsValid_PlaintextType(materials.plaintextDataKey.value), "PlaintextDataKey is invalid");
 
         var encryptRequest := KMS.EncryptRequest(
-          EncryptionContext := Some(stringifiedEncCtx),
-          GrantTokens := Some(grantTokens),
-          KeyId := awsKmsKey,
-          Plaintext := materials.plaintextDataKey.value,
-          EncryptionAlgorithm := None
-        );
+                                EncryptionContext := Some(stringifiedEncCtx),
+                                GrantTokens := Some(grantTokens),
+                                KeyId := awsKmsKey,
+                                Plaintext := materials.plaintextDataKey.value,
+                                EncryptionAlgorithm := None
+                              );
         var maybeEncryptResponse := client.Encrypt(encryptRequest);
 
         //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
@@ -393,40 +393,40 @@ module
         //# If the Encrypt call succeeds the response's "KeyId" MUST be A valid
         //# AWS KMS key ARN (aws-kms-key-arn.md#a-valid-aws-kms-arn).
         :- Crypto.Need(
-          && encryptResponse.KeyId.Some?
-          && ParseAwsKmsIdentifier(encryptResponse.KeyId.value).Success?,
-          "Invalid response from AWS KMS Encrypt:: Invalid Key Id"
-        );
+             && encryptResponse.KeyId.Some?
+             && ParseAwsKmsIdentifier(encryptResponse.KeyId.value).Success?,
+             "Invalid response from AWS KMS Encrypt:: Invalid Key Id"
+           );
 
         var providerInfoResult := UTF8.Encode(encryptResponse.KeyId.value);
         var providerInfo :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(providerInfoResult);
         :- Crypto.Need(|providerInfo| < UINT16_LIMIT, "AWS KMS Key ID too long.");
 
         :- Crypto.Need(encryptResponse.CiphertextBlob.Some?,
-          "Invalid response from AWS KMS Encrypt: Invalid Ciphertext Blob"
-        );
+                       "Invalid response from AWS KMS Encrypt: Invalid Ciphertext Blob"
+           );
 
         var edk := Crypto.EncryptedDataKey(
-          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-          //# *  The key provider id (../structures.md#key-provider-id) MUST be
-          //# "aws-kms".
-          keyProviderId := PROVIDER_ID,
-          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-          //# *  The key provider information (../structures.md#key-provider-
-          //# information) MUST be the response "KeyId".  Note that the "KeyId"
-          //# in the response is always in key ARN format.
-          keyProviderInfo := providerInfo,
-          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
-          //# *  The ciphertext (../structures.md#ciphertext) MUST be the response
-          //# "CiphertextBlob".
-          ciphertext := encryptResponse.CiphertextBlob.value
-        );
+                     //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+                     //# *  The key provider id (../structures.md#key-provider-id) MUST be
+                     //# "aws-kms".
+                     keyProviderId := PROVIDER_ID,
+                     //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+                     //# *  The key provider information (../structures.md#key-provider-
+                     //# information) MUST be the response "KeyId".  Note that the "KeyId"
+                     //# in the response is always in key ARN format.
+                     keyProviderInfo := providerInfo,
+                     //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.7
+                     //# *  The ciphertext (../structures.md#ciphertext) MUST be the response
+                     //# "CiphertextBlob".
+                     ciphertext := encryptResponse.CiphertextBlob.value
+                   );
 
         var addKeyResult := Materials.EncryptionMaterialAddEncryptedDataKeys(materials, [edk]);
         var result :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(addKeyResult);
         return Success(Crypto.OnEncryptOutput(
-          materials := result
-        ));
+                         materials := result
+                       ));
       }
     }
 
@@ -440,11 +440,11 @@ module
     )
       returns (res: Result<Crypto.OnDecryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.DecryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+              ==>
+                && Materials.DecryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
 
       //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
       //= type=implication
@@ -455,84 +455,84 @@ module
 
       ensures
         && res.Success?
-      ==>
-        && var maybeStringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext);
-        && maybeStringifiedEncCtx.Success?
-        && exists edk | edk in input.encryptedDataKeys
-        ::
-          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-          //= type=implication
-          //# *  Its provider ID MUST exactly match the value "aws-kms".
-          && edk.keyProviderId == PROVIDER_ID
-          && KMS.IsValid_CiphertextType(edk.ciphertext)
-          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-          //= type=implication
-          //# When calling AWS KMS Decrypt
-          //# (https://docs.aws.amazon.com/kms/latest/APIReference/
-          //# API_Decrypt.html), the keyring MUST call with a request constructed
-          //# as follows:
-          && var request := KMS.DecryptRequest(
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-            //= type=implication
-            //# *  "KeyId" MUST be the configured AWS KMS key identifier.
-            KeyId := Some(awsKmsKey),
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-            //= type=implication
-            //# *  "CiphertextBlob" MUST be the encrypted data key ciphertext
-            //# (../structures.md#ciphertext).
-            CiphertextBlob := edk.ciphertext,
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-            //= type=implication
-            //# *  "EncryptionContext" MUST be the encryption context
-            //# (../structures.md#encryption-context) included in the input
-            //# decryption materials (../structures.md#decryption-materials).
-            EncryptionContext := Some(maybeStringifiedEncCtx.value),
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-            //= type=implication
-            //# *  "GrantTokens" MUST be this keyring's grant tokens
-            //# (https://docs.aws.amazon.com/kms/latest/developerguide/
-            //# concepts.html#grant_token).
-            GrantTokens := Some(grantTokens),
-            EncryptionAlgorithm := None
-          );
-          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-          //= type=implication
-          //# To attempt to decrypt a particular encrypted data key
-          //# (../structures.md#encrypted-data-key), OnDecrypt MUST call AWS KMS
-          //# Decrypt (https://docs.aws.amazon.com/kms/latest/APIReference/
-          //# API_Decrypt.html) with the configured AWS KMS client.
-          && client.DecryptCalledWith(request)
-          && exists returnedEncryptionAlgorithm ::
-            && var response := KMS.DecryptResponse(
-              //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-              //= type=implication
-              //# *  The "KeyId" field in the response MUST equal the configured AWS
-              //# KMS key identifier.
-              KeyId := Some(awsKmsKey),
-              Plaintext := res.value.materials.plaintextDataKey,
-              EncryptionAlgorithm := returnedEncryptionAlgorithm
-            );
-            //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-            //= type=implication
-            //# *  MUST immediately return the modified decryption materials
-            //# (../structures.md#decryption-materials).
-            && client.DecryptSucceededWith(request, response)
-          //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-          //= type=implication
-          //# *  The length of the response's "Plaintext" MUST equal the key
-          //# derivation input length (../algorithm-suites.md#key-derivation-
-          //# input-length) specified by the algorithm suite (../algorithm-
-          //# suites.md) included in the input decryption materials
-          //# (../structures.md#decryption-materials).
-          && AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId).encrypt.keyLength as int == |res.value.materials.plaintextDataKey.value|
+        ==>
+          && var maybeStringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext);
+          && maybeStringifiedEncCtx.Success?
+          && exists edk | edk in input.encryptedDataKeys
+             ::
+               //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+               //= type=implication
+               //# *  Its provider ID MUST exactly match the value "aws-kms".
+               && edk.keyProviderId == PROVIDER_ID
+               && KMS.IsValid_CiphertextType(edk.ciphertext)
+                  //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+                  //= type=implication
+                  //# When calling AWS KMS Decrypt
+                  //# (https://docs.aws.amazon.com/kms/latest/APIReference/
+                  //# API_Decrypt.html), the keyring MUST call with a request constructed
+                  //# as follows:
+               && var request := KMS.DecryptRequest(
+                                   //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+                                   //= type=implication
+                                   //# *  "KeyId" MUST be the configured AWS KMS key identifier.
+                                   KeyId := Some(awsKmsKey),
+                                   //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+                                   //= type=implication
+                                   //# *  "CiphertextBlob" MUST be the encrypted data key ciphertext
+                                   //# (../structures.md#ciphertext).
+                                   CiphertextBlob := edk.ciphertext,
+                                   //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+                                   //= type=implication
+                                   //# *  "EncryptionContext" MUST be the encryption context
+                                   //# (../structures.md#encryption-context) included in the input
+                                   //# decryption materials (../structures.md#decryption-materials).
+                                   EncryptionContext := Some(maybeStringifiedEncCtx.value),
+                                   //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+                                   //= type=implication
+                                   //# *  "GrantTokens" MUST be this keyring's grant tokens
+                                   //# (https://docs.aws.amazon.com/kms/latest/developerguide/
+                                   //# concepts.html#grant_token).
+                                   GrantTokens := Some(grantTokens),
+                                   EncryptionAlgorithm := None
+                                 );
+               //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+               //= type=implication
+               //# To attempt to decrypt a particular encrypted data key
+               //# (../structures.md#encrypted-data-key), OnDecrypt MUST call AWS KMS
+               //# Decrypt (https://docs.aws.amazon.com/kms/latest/APIReference/
+               //# API_Decrypt.html) with the configured AWS KMS client.
+               && client.DecryptCalledWith(request)
+               && exists returnedEncryptionAlgorithm ::
+                    && var response := KMS.DecryptResponse(
+                                         //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+                                         //= type=implication
+                                         //# *  The "KeyId" field in the response MUST equal the configured AWS
+                                         //# KMS key identifier.
+                                         KeyId := Some(awsKmsKey),
+                                         Plaintext := res.value.materials.plaintextDataKey,
+                                         EncryptionAlgorithm := returnedEncryptionAlgorithm
+                                       );
+                    //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+                    //= type=implication
+                    //# *  MUST immediately return the modified decryption materials
+                    //# (../structures.md#decryption-materials).
+                    && client.DecryptSucceededWith(request, response)
+                       //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+                       //= type=implication
+                       //# *  The length of the response's "Plaintext" MUST equal the key
+                       //# derivation input length (../algorithm-suites.md#key-derivation-
+                       //# input-length) specified by the algorithm suite (../algorithm-
+                       //# suites.md) included in the input decryption materials
+                       //# (../structures.md#decryption-materials).
+                    && AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId).encrypt.keyLength as int == |res.value.materials.plaintextDataKey.value|
     {
 
       var materials := input.materials;
       var suite := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
 
       :- Crypto.Need(
-        Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
-        "Keyring recieved decryption materials that already contain a plaintext data key.");
+           Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
+           "Keyring recieved decryption materials that already contain a plaintext data key.");
 
       //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
       //# The set of encrypted data keys MUST first be filtered to match this
@@ -547,50 +547,50 @@ module
       //# If this attempt
       //# results in an error, then these errors MUST be collected.
       var decryptClosure := new DecryptSingleEncryptedDataKey(
-        materials,
-        client,
-        awsKmsKey,
-        grantTokens
-      );
+            materials,
+            client,
+            awsKmsKey,
+            grantTokens
+          );
 
       //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
       //# If the response does not satisfies these requirements then an error
       //# MUST be collected and the next encrypted data key in the filtered set
       //# MUST be attempted.
       var outcome := ReduceToSuccess(
-        decryptClosure,
-        edksToAttempt
-      );
+                       decryptClosure,
+                       edksToAttempt
+                     );
 
       var stringifiedEncCtxResult := StringifyEncryptionContext(materials.encryptionContext);
       ghost var stringifiedEncCtx :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-        stringifiedEncCtxResult);
+                                       stringifiedEncCtxResult);
       var result := match outcome {
-        case Success(mat) =>
-          assert exists edk | edk in edksToAttempt
-          ::
-            && edk in input.encryptedDataKeys
-            && filter.Ensures(edk, Success(true))
-            && decryptClosure.Ensures(edk, Success(mat));
-          Success(Crypto.OnDecryptOutput(
-            materials := mat
-          ))
-        //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
-        //# If OnDecrypt fails to successfully decrypt any encrypted data key
-        //# (../structures.md#encrypted-data-key), then it MUST yield an error
-        //# that includes all the collected errors.
-        case Failure(errors) =>
-          if |errors| == 0 then
-            Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
-          else
-            var concatString := (s, a) => a + "\n" + s;
-            var error := Seq.FoldRight(
-              concatString,
-              errors,
-              "Unable to decrypt data key:\n"
-            );
-            Failure(error)
-      };
+                      case Success(mat) =>
+                        assert exists edk | edk in edksToAttempt
+                          ::
+                            && edk in input.encryptedDataKeys
+                            && filter.Ensures(edk, Success(true))
+                            && decryptClosure.Ensures(edk, Success(mat));
+                        Success(Crypto.OnDecryptOutput(
+                                  materials := mat
+                                ))
+                      //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
+                      //# If OnDecrypt fails to successfully decrypt any encrypted data key
+                      //# (../structures.md#encrypted-data-key), then it MUST yield an error
+                      //# that includes all the collected errors.
+                      case Failure(errors) =>
+                        if |errors| == 0 then
+                          Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
+                        else
+                          var concatString := (s, a) => a + "\n" + s;
+                          var error := Seq.FoldRight(
+                                         concatString,
+                                         errors,
+                                         "Unable to decrypt data key:\n"
+                                       );
+                          Failure(error)
+                    };
       var wrapped := Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(result);
       return wrapped;
     }
@@ -610,8 +610,8 @@ module
       res: Result<bool, string>
     ) {
       && (
-          && res.Success?
-          && res.value
+        && res.Success?
+        && res.value
         ==>
           edk.keyProviderId == PROVIDER_ID)
     }
@@ -648,9 +648,9 @@ module
 
   class DecryptSingleEncryptedDataKey
     extends ActionWithResult<
-      Crypto.EncryptedDataKey,
-      Materials.SealedDecryptionMaterials,
-      string>
+    Crypto.EncryptedDataKey,
+    Materials.SealedDecryptionMaterials,
+    string>
   {
     const materials: Materials.DecryptionMaterialsPendingPlaintextDataKey
     const client: KMS.IKeyManagementServiceClient
@@ -664,10 +664,10 @@ module
       grantTokens: KMS.GrantTokenList
     )
       ensures
-      && this.materials == materials
-      && this.client == client
-      && this.awsKmsKey == awsKmsKey
-      && this.grantTokens == grantTokens
+        && this.materials == materials
+        && this.client == client
+        && this.awsKmsKey == awsKmsKey
+        && this.grantTokens == grantTokens
     {
       this.materials := materials;
       this.client := client;
@@ -679,27 +679,27 @@ module
       edk: Crypto.EncryptedDataKey,
       res: Result<Materials.SealedDecryptionMaterials, string>
     ) {
-        res.Success?
+      res.Success?
       ==>
         && KMS.IsValid_CiphertextType(edk.ciphertext)
         && Materials.DecryptionMaterialsTransitionIsValid(materials, res.value)
         && var maybeStringifiedEncCtx := StringifyEncryptionContext(materials.encryptionContext);
         && maybeStringifiedEncCtx.Success?
         && var request := KMS.DecryptRequest(
-          KeyId := Some(awsKmsKey),
-          CiphertextBlob := edk.ciphertext,
-          EncryptionContext := Some(maybeStringifiedEncCtx.value),
-          GrantTokens := Some(grantTokens),
-          EncryptionAlgorithm := None
-        );
+                            KeyId := Some(awsKmsKey),
+                            CiphertextBlob := edk.ciphertext,
+                            EncryptionContext := Some(maybeStringifiedEncCtx.value),
+                            GrantTokens := Some(grantTokens),
+                            EncryptionAlgorithm := None
+                          );
         && client.DecryptCalledWith(request)
         && exists returnedEncryptionAlgorithm ::
-          && var response := KMS.DecryptResponse(
-            KeyId := Some(awsKmsKey),
-            Plaintext := Some(res.value.plaintextDataKey.value),
-            EncryptionAlgorithm := returnedEncryptionAlgorithm
-          );
-          && client.DecryptSucceededWith(request, response)
+             && var response := KMS.DecryptResponse(
+                                  KeyId := Some(awsKmsKey),
+                                  Plaintext := Some(res.value.plaintextDataKey.value),
+                                  EncryptionAlgorithm := returnedEncryptionAlgorithm
+                                );
+             && client.DecryptSucceededWith(request, response)
     }
 
     method Invoke(
@@ -711,12 +711,12 @@ module
 
       var stringifiedEncCtx :- StringifyEncryptionContext(materials.encryptionContext);
       var decryptRequest := KMS.DecryptRequest(
-        KeyId := Some(awsKmsKey),
-        CiphertextBlob := edk.ciphertext,
-        EncryptionContext := Some(stringifiedEncCtx),
-        GrantTokens := Some(grantTokens),
-        EncryptionAlgorithm := None
-      );
+                              KeyId := Some(awsKmsKey),
+                              CiphertextBlob := edk.ciphertext,
+                              EncryptionContext := Some(stringifiedEncCtx),
+                              GrantTokens := Some(grantTokens),
+                              EncryptionAlgorithm := None
+                            );
 
       var maybeDecryptResponse := client.Decrypt(decryptRequest);
       if maybeDecryptResponse.Failure? {
@@ -725,11 +725,11 @@ module
 
       var decryptResponse := maybeDecryptResponse.value;
       :- Need(
-        && decryptResponse.KeyId.Some?
-        && decryptResponse.KeyId.value == awsKmsKey
-        && decryptResponse.Plaintext.Some?
-        && AlgorithmSuites.GetSuite(materials.algorithmSuiteId).encrypt.keyLength as int == |decryptResponse.Plaintext.value|
-        , "Invalid response from KMS Decrypt");
+           && decryptResponse.KeyId.Some?
+           && decryptResponse.KeyId.value == awsKmsKey
+           && decryptResponse.Plaintext.Some?
+           && AlgorithmSuites.GetSuite(materials.algorithmSuiteId).encrypt.keyLength as int == |decryptResponse.Plaintext.value|
+         , "Invalid response from KMS Decrypt");
 
       //= compliance/framework/aws-kms/aws-kms-keyring.txt#2.8
       //# *  MUST set the plaintext data key on the decryption materials
@@ -750,12 +750,12 @@ module
       var stringifyResults: map<UTF8.ValidUTF8Bytes, Result<(string, string), string>> :=
         map utf8Key | utf8Key in utf8EncCtx.Keys :: utf8Key := StringifyEncryptionContextPair(utf8Key, utf8EncCtx[utf8Key]);
       if exists r | r in stringifyResults.Values :: r.Failure?
-        then Failure("Encryption context contains invalid UTF8")
+      then Failure("Encryption context contains invalid UTF8")
       else
         assert forall r | r in stringifyResults.Values :: r.Success?;
         // TODO state that UTF8.Decode is injective so we don't need this
         var stringKeysUnique := forall k, k' | k in stringifyResults && k' in stringifyResults
-          :: k != k' ==> stringifyResults[k].value.0 != stringifyResults[k'].value.0;
+                                :: k != k' ==> stringifyResults[k].value.0 != stringifyResults[k'].value.0;
         if !stringKeysUnique then Failure("Encryption context keys are not unique")  // this should never happen...
         else Success(map r | r in stringifyResults.Values :: r.value.0 := r.value.1)
   }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkAreUnique.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkAreUnique.dfy
@@ -15,7 +15,7 @@ module  AwsKmsMrkAreUnique {
   //= type=implication
   //# The caller MUST provide:
   function method AwsKmsMrkAreUnique(identifiers: seq<AwsKmsIdentifier>)
-  : (result: Outcome<string>)
+    : (result: Outcome<string>)
   {
     var mrks := Seq.Filter(IsMultiRegionAwsKmsIdentifier, identifiers);
 
@@ -61,8 +61,8 @@ module  AwsKmsMrkAreUnique {
     //# exit successfully.
     ensures
       |Seq.Filter(IsMultiRegionAwsKmsIdentifier, identifiers)| == 0
-    ==>
-      AwsKmsMrkAreUnique(identifiers).Pass?
+      ==>
+        AwsKmsMrkAreUnique(identifiers).Pass?
 
     //= compliance/framework/aws-kms/aws-kms-mrk-are-unique.txt#2.5
     //= type=implication
@@ -73,8 +73,8 @@ module  AwsKmsMrkAreUnique {
       var ids := Seq.Map(GetKeyId, mrks);
       && |mrks| > 0
       && Seq.HasNoDuplicates(ids)
-    ==>
-      AwsKmsMrkAreUnique(identifiers).Pass?
+      ==>
+        AwsKmsMrkAreUnique(identifiers).Pass?
 
     //= compliance/framework/aws-kms/aws-kms-mrk-are-unique.txt#2.5
     //= type=implication
@@ -86,9 +86,9 @@ module  AwsKmsMrkAreUnique {
       var ids := Seq.Map(GetKeyId, mrks);
       && |mrks| > 0
       && !Seq.HasNoDuplicates(ids)
-    ==>
-      // TODO this only checks for failure, but not the error message
-      AwsKmsMrkAreUnique(identifiers).Fail?
+      ==>
+        // TODO this only checks for failure, but not the error message
+        AwsKmsMrkAreUnique(identifiers).Fail?
   {
     var mrks := Seq.Filter(IsMultiRegionAwsKmsIdentifier, identifiers);
     var ids := Seq.Map(GetKeyId, mrks);

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkDiscoveryKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkDiscoveryKeyring.dfy
@@ -78,7 +78,7 @@ module
       ensures res.Failure?
     {
       var exception := new Crypto.AwsCryptographicMaterialProvidersException(
-        "Encryption is not supported with a Discovery Keyring.");
+            "Encryption is not supported with a Discovery Keyring.");
       return Failure(exception);
     }
 
@@ -92,11 +92,11 @@ module
     )
       returns (res: Result<Crypto.OnDecryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.DecryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+              ==>
+                && Materials.DecryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
 
       //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
       //= type=implication
@@ -106,77 +106,77 @@ module
       //# (../structures.md#decryption-materials).
       ensures
         input.materials.plaintextDataKey.Some?
-      ==>
-        && res.Failure?
+        ==>
+          && res.Failure?
 
       // If we could not convert the encryption context into a form understandable
       // by KMS, the result must be failure
       // TODO: add this to the spec
       ensures
         StringifyEncryptionContext(input.materials.encryptionContext).Failure?
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       ensures
         && res.Success?
-      ==>
-        && var stringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext).Extract();
-        && res.value.materials.plaintextDataKey.Some?
-        && exists edk: Crypto.EncryptedDataKey, awsKmsKey: string
-        |
-          && edk in input.encryptedDataKeys
-        ::
-          // && edk is EncryptedDataKey
-          //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
-          //= type=implication
-          //# *  Its provider ID MUST exactly match the value "aws-kms".
-          && edk.keyProviderId == PROVIDER_ID
-          && KMS.IsValid_CiphertextType(edk.ciphertext)
-          && KMS.IsValid_KeyIdType(awsKmsKey)
-          && var request := KMS.DecryptRequest(
-            KeyId := Option.Some(awsKmsKey),
-            CiphertextBlob :=  edk.ciphertext,
-            EncryptionContext := Option.Some(stringifiedEncCtx),
-            GrantTokens := Option.Some(grantTokens),
-            EncryptionAlgorithm := Option.None()
-          );
+        ==>
+          && var stringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext).Extract();
+          && res.value.materials.plaintextDataKey.Some?
+          && exists edk: Crypto.EncryptedDataKey, awsKmsKey: string
+               |
+               && edk in input.encryptedDataKeys
+             ::
+               // && edk is EncryptedDataKey
+               //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
+               //= type=implication
+               //# *  Its provider ID MUST exactly match the value "aws-kms".
+               && edk.keyProviderId == PROVIDER_ID
+               && KMS.IsValid_CiphertextType(edk.ciphertext)
+               && KMS.IsValid_KeyIdType(awsKmsKey)
+               && var request := KMS.DecryptRequest(
+                                   KeyId := Option.Some(awsKmsKey),
+                                   CiphertextBlob :=  edk.ciphertext,
+                                   EncryptionContext := Option.Some(stringifiedEncCtx),
+                                   GrantTokens := Option.Some(grantTokens),
+                                   EncryptionAlgorithm := Option.None()
+                                 );
 
-          //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
-          //= type=implication
-          //# To attempt to decrypt a particular encrypted data key
-          //# (../structures.md#encrypted-data-key), OnDecrypt MUST call AWS KMS
-          //# Decrypt (https://docs.aws.amazon.com/kms/latest/APIReference/
-          //# API_Decrypt.html) with the configured AWS KMS client.
-          && client.DecryptCalledWith(
-            //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
-            //= type=implication
-            //# When calling AWS KMS Decrypt
-            //# (https://docs.aws.amazon.com/kms/latest/APIReference/
-            //# API_Decrypt.html), the keyring MUST call with a request constructed
-            //# as follows:
-            request
-            )
-          //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
-          //= type=implication
-          //# Since the response does satisfies these requirements then OnDecrypt
-          //# MUST do the following with the response:
-          //#*  set the plaintext data key on the decryption materials
-          //#   (../structures.md#decryption-materials) as the response "Plaintext".
-          && exists returnedKeyId, returnedEncryptionAlgorithm ::
-            && var response := KMS.DecryptResponse(
-              KeyId := returnedKeyId,
-              Plaintext := res.value.materials.plaintextDataKey,
-              EncryptionAlgorithm := returnedEncryptionAlgorithm
-            );
-            && client.DecryptSucceededWith(request, response)
-          //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
-          //= type=implication
-          //# *  The length of the response's "Plaintext" MUST equal the key
-          //# derivation input length (../algorithm-suites.md#key-derivation-
-          //# input-length) specified by the algorithm suite (../algorithm-
-          //# suites.md) included in the input decryption materials
-          //# (../structures.md#decryption-materials).
-          && Materials.DecryptionMaterialsWithPlaintextDataKey(res.value.materials)
+               //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
+               //= type=implication
+               //# To attempt to decrypt a particular encrypted data key
+               //# (../structures.md#encrypted-data-key), OnDecrypt MUST call AWS KMS
+               //# Decrypt (https://docs.aws.amazon.com/kms/latest/APIReference/
+               //# API_Decrypt.html) with the configured AWS KMS client.
+               && client.DecryptCalledWith(
+                    //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
+                    //= type=implication
+                    //# When calling AWS KMS Decrypt
+                    //# (https://docs.aws.amazon.com/kms/latest/APIReference/
+                    //# API_Decrypt.html), the keyring MUST call with a request constructed
+                    //# as follows:
+                    request
+                  )
+                  //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
+                  //= type=implication
+                  //# Since the response does satisfies these requirements then OnDecrypt
+                  //# MUST do the following with the response:
+                  //#*  set the plaintext data key on the decryption materials
+                  //#   (../structures.md#decryption-materials) as the response "Plaintext".
+               && exists returnedKeyId, returnedEncryptionAlgorithm ::
+                    && var response := KMS.DecryptResponse(
+                                         KeyId := returnedKeyId,
+                                         Plaintext := res.value.materials.plaintextDataKey,
+                                         EncryptionAlgorithm := returnedEncryptionAlgorithm
+                                       );
+                    && client.DecryptSucceededWith(request, response)
+                       //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
+                       //= type=implication
+                       //# *  The length of the response's "Plaintext" MUST equal the key
+                       //# derivation input length (../algorithm-suites.md#key-derivation-
+                       //# input-length) specified by the algorithm suite (../algorithm-
+                       //# suites.md) included in the input decryption materials
+                       //# (../structures.md#decryption-materials).
+                    && Materials.DecryptionMaterialsWithPlaintextDataKey(res.value.materials)
     {
 
       var materials := input.materials;
@@ -184,8 +184,8 @@ module
       var suite := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
 
       :- Crypto.Need(
-        Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
-        "Keyring received decryption materials that already contain a plaintext data key.");
+           Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
+           "Keyring received decryption materials that already contain a plaintext data key.");
 
       //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
       //# The set of encrypted data keys MUST first be filtered to match this
@@ -195,21 +195,21 @@ module
       var edksToAttempt :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(filterResult);
 
       forall i
-      | 0 <= i < |parts|
-      ensures
-        && edkFilterTransform.Ensures(encryptedDataKeys[i], Success(parts[i]))
-        && 1 >= |parts[i]|
-        && |encryptedDataKeys| == |parts|
-        && edksToAttempt == Seq.Flatten(parts)
-        && |encryptedDataKeys| >= |edksToAttempt|
-        && multiset(parts[i]) <= multiset(edksToAttempt)
-        && multiset(edksToAttempt) <= multiset(Seq.Flatten(parts))
-        && forall helper: AwsKmsEdkHelper
-          | helper in parts[i]
-          ::
-            && helper in edksToAttempt
-            && helper.edk == encryptedDataKeys[i]
-            && helper.arn.resource.resourceType == "key"
+        | 0 <= i < |parts|
+        ensures
+          && edkFilterTransform.Ensures(encryptedDataKeys[i], Success(parts[i]))
+          && 1 >= |parts[i]|
+          && |encryptedDataKeys| == |parts|
+          && edksToAttempt == Seq.Flatten(parts)
+          && |encryptedDataKeys| >= |edksToAttempt|
+          && multiset(parts[i]) <= multiset(edksToAttempt)
+          && multiset(edksToAttempt) <= multiset(Seq.Flatten(parts))
+          && forall helper: AwsKmsEdkHelper
+               | helper in parts[i]
+             ::
+               && helper in edksToAttempt
+               && helper.edk == encryptedDataKeys[i]
+               && helper.arn.resource.resourceType == "key"
       {
         if |parts| < |edksToAttempt| {
           Seq.LemmaFlattenLengthLeMul(parts, 1);
@@ -218,21 +218,21 @@ module
         }
 
         forall helper: AwsKmsEdkHelper
-        | helper in parts[i]
-        ensures
-          && helper in edksToAttempt
-          && helper.edk == encryptedDataKeys[i]
-          && helper.arn.resource.resourceType == "key"
+          | helper in parts[i]
+          ensures
+            && helper in edksToAttempt
+            && helper.edk == encryptedDataKeys[i]
+            && helper.arn.resource.resourceType == "key"
         {
           LemmaMultisetSubMembership(parts[i], edksToAttempt);
         }
       }
 
       forall helper: AwsKmsEdkHelper
-      | helper in edksToAttempt
-      ensures
-        && helper.edk in encryptedDataKeys
-        && helper.arn.resource.resourceType == "key"
+        | helper in edksToAttempt
+        ensures
+          && helper.edk in encryptedDataKeys
+          && helper.arn.resource.resourceType == "key"
       {
         LemmaFlattenMembership(parts, edksToAttempt);
         assert helper in Seq.Flatten(parts);
@@ -242,46 +242,46 @@ module
       //# For each encrypted data key in the filtered set, one at a time, the
       //# OnDecrypt MUST attempt to decrypt the data key.
       var decryptAction: AwsKmsEncryptedDataKeyDecryptor := new AwsKmsEncryptedDataKeyDecryptor(
-        materials,
-        client,
-        region,
-        grantTokens
-      );
+            materials,
+            client,
+            region,
+            grantTokens
+          );
       //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
       //# If the response does not satisfies these requirements then an error
       //# is collected and the next encrypted data key in the filtered set MUST
       //# be attempted.
       var outcome := Actions.ReduceToSuccess(
-        decryptAction,
-        edksToAttempt
-      );
+                       decryptAction,
+                       edksToAttempt
+                     );
 
       var result := match outcome {
-        case Success(mat) =>
-          assert exists helper: AwsKmsEdkHelper
-          | helper in edksToAttempt
-          ::
-            && helper.edk in encryptedDataKeys
-            && helper.arn.resource.resourceType == "key"
-            && decryptAction.Ensures(helper, Success(mat));
+                      case Success(mat) =>
+                        assert exists helper: AwsKmsEdkHelper
+                            | helper in edksToAttempt
+                          ::
+                            && helper.edk in encryptedDataKeys
+                            && helper.arn.resource.resourceType == "key"
+                            && decryptAction.Ensures(helper, Success(mat));
 
-          Success(Crypto.OnDecryptOutput(materials := mat))
-        //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
-        //# If OnDecrypt fails to successfully decrypt any encrypted data key
-        //# (../structures.md#encrypted-data-key), then it MUST yield an error that
-        //# includes all collected errors.
-        case Failure(errors) =>
-          if |errors| == 0 then
-            Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
-          else
-            var concatString := (s, a) => a + "\n" + s;
-            var error := Seq.FoldRight(
-              concatString,
-              errors,
-              "Unable to decrypt data key:\n"
-            );
-            Failure(error)
-      };
+                        Success(Crypto.OnDecryptOutput(materials := mat))
+                      //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
+                      //# If OnDecrypt fails to successfully decrypt any encrypted data key
+                      //# (../structures.md#encrypted-data-key), then it MUST yield an error that
+                      //# includes all collected errors.
+                      case Failure(errors) =>
+                        if |errors| == 0 then
+                          Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
+                        else
+                          var concatString := (s, a) => a + "\n" + s;
+                          var error := Seq.FoldRight(
+                                         concatString,
+                                         errors,
+                                         "Unable to decrypt data key:\n"
+                                       );
+                          Failure(error)
+                    };
       var wrappedResult := Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(result);
       return wrappedResult;
     }
@@ -289,9 +289,9 @@ module
 
   class AwsKmsEncryptedDataKeyFilterTransform
     extends ActionWithResult<
-      Crypto.EncryptedDataKey,
-      seq<AwsKmsEdkHelper>,
-      string
+    Crypto.EncryptedDataKey,
+    seq<AwsKmsEdkHelper>,
+    string
     >
   {
     const region: string
@@ -353,8 +353,8 @@ module
       }
 
       return Success([
-        AwsKmsEdkHelper(edk, arn)
-      ]);
+                       AwsKmsEdkHelper(edk, arn)
+                     ]);
     }
   }
 
@@ -369,9 +369,9 @@ module
    */
   class AwsKmsEncryptedDataKeyDecryptor
     extends ActionWithResult<
-      AwsKmsEdkHelper,
-      Materials.SealedDecryptionMaterials,
-      string>
+    AwsKmsEdkHelper,
+    Materials.SealedDecryptionMaterials,
+    string>
   {
     const materials: Materials.DecryptionMaterialsPendingPlaintextDataKey
     const client: KMS.IKeyManagementServiceClient
@@ -385,10 +385,10 @@ module
       grantTokens: KMS.GrantTokenList
     )
       ensures
-      && this.materials == materials
-      && this.client == client
-      && this.region == region
-      && this.grantTokens == grantTokens
+        && this.materials == materials
+        && this.client == client
+        && this.region == region
+        && this.grantTokens == grantTokens
     {
       this.materials := materials;
       this.client := client;
@@ -416,20 +416,20 @@ module
         // Confirm that we called KMS in the right way and correctly returned the values
         // it gave us
         && var request := KMS.DecryptRequest(
-            KeyId := Option.Some(keyArn),
-            CiphertextBlob := helper.edk.ciphertext,
-            EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
-            GrantTokens := Option.Some(grantTokens),
-            EncryptionAlgorithm := Option.None()
-          );
+                            KeyId := Option.Some(keyArn),
+                            CiphertextBlob := helper.edk.ciphertext,
+                            EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
+                            GrantTokens := Option.Some(grantTokens),
+                            EncryptionAlgorithm := Option.None()
+                          );
         && client.DecryptCalledWith(request)
         && exists returnedKeyId, returnedEncryptionAlgorithm ::
-          && var response := KMS.DecryptResponse(
-            KeyId := returnedKeyId,
-            Plaintext := Option.Some(res.value.plaintextDataKey.value),
-            EncryptionAlgorithm := returnedEncryptionAlgorithm
-          );
-          && client.DecryptSucceededWith(request, response)
+             && var response := KMS.DecryptResponse(
+                                  KeyId := returnedKeyId,
+                                  Plaintext := Option.Some(res.value.plaintextDataKey.value),
+                                  EncryptionAlgorithm := returnedEncryptionAlgorithm
+                                );
+             && client.DecryptSucceededWith(request, response)
     }
 
     method Invoke(
@@ -445,12 +445,12 @@ module
       :- Need(KMS.IsValid_KeyIdType(awsKmsKey), "KMS key arn invalid");
 
       var decryptRequest := KMS.DecryptRequest(
-        KeyId := Option.Some(awsKmsKey),
-        CiphertextBlob := helper.edk.ciphertext,
-        EncryptionContext := Option.Some(stringifiedEncCtx),
-        GrantTokens := Option.Some(grantTokens),
-        EncryptionAlgorithm := Option.None()
-      );
+                              KeyId := Option.Some(awsKmsKey),
+                              CiphertextBlob := helper.edk.ciphertext,
+                              EncryptionContext := Option.Some(stringifiedEncCtx),
+                              GrantTokens := Option.Some(grantTokens),
+                              EncryptionAlgorithm := Option.None()
+                            );
 
       var maybeDecryptResponse := client.Decrypt(decryptRequest);
       if maybeDecryptResponse.Failure? {
@@ -462,11 +462,11 @@ module
       //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
       //# *  The "KeyId" field in the response MUST equal the requested "KeyId"
       :- Need(
-        && decryptResponse.KeyId.Some?
-        && decryptResponse.KeyId.value == awsKmsKey
-        && decryptResponse.Plaintext.Some?
-        && algId.encrypt.keyLength as int == |decryptResponse.Plaintext.value|
-        , "Invalid response from KMS Decrypt");
+           && decryptResponse.KeyId.Some?
+           && decryptResponse.KeyId.value == awsKmsKey
+           && decryptResponse.Plaintext.Some?
+           && algId.encrypt.keyLength as int == |decryptResponse.Plaintext.value|
+         , "Invalid response from KMS Decrypt");
 
       var result :-  Materials.DecryptionMaterialsAddDataKey(materials, decryptResponse.Plaintext.value);
       return Success(result);
@@ -509,17 +509,17 @@ module
     ensures
       && discoveryFilter.Some?
       && res
-    ==>
-      //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
-      //= type=implication
-      //# *  If a discovery filter is configured, its partition and the
-      //# provider info partition MUST match.
-      && discoveryFilter.value.partition == arn.partition
-      //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
-      //= type=implication
-      //# *  If a discovery filter is configured, its set of accounts MUST
-      //# contain the provider info account.
-      && arn.account in discoveryFilter.value.accountIds
+      ==>
+        //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
+        //= type=implication
+        //# *  If a discovery filter is configured, its partition and the
+        //# provider info partition MUST match.
+        && discoveryFilter.value.partition == arn.partition
+           //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
+           //= type=implication
+           //# *  If a discovery filter is configured, its set of accounts MUST
+           //# contain the provider info account.
+        && arn.account in discoveryFilter.value.accountIds
     //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
     //= type=implication
     //# *  If the provider info is not identified as a multi-Region key (aws-
@@ -528,19 +528,19 @@ module
     ensures
       && !IsMultiRegionAwsKmsArn(arn)
       && res
-    ==>
-      arn.region == region
+      ==>
+        arn.region == region
   {
     && match discoveryFilter {
-      case Some(filter) =>
-        && filter.partition == arn.partition
-        && arn.account in filter.accountIds
-      case None() => true
-    }
+         case Some(filter) =>
+           && filter.partition == arn.partition
+           && arn.account in filter.accountIds
+         case None() => true
+       }
     && if !IsMultiRegionAwsKmsArn(arn) then
-      region == arn.region
-    else
-      true
+         region == arn.region
+       else
+         true
   }
 
   lemma LemmaMultisetSubMembership<T>(a: seq<T>, b: seq<T>)
@@ -559,13 +559,13 @@ module
   lemma LemmaFlattenMembership<T>(parts: seq<seq<T>>, flat: seq<T>)
     requires Seq.Flatten(parts) == flat
     ensures forall index
-    | 0 <= index < |parts|
-    :: multiset(parts[index]) <= multiset(flat)
+              | 0 <= index < |parts|
+            :: multiset(parts[index]) <= multiset(flat)
     ensures multiset(Seq.Flatten(parts)) == multiset(flat)
     ensures forall part | part in parts
-    :: (forall i | i in part :: i in flat)
+            :: (forall i | i in part :: i in flat)
     ensures forall i | i in flat
-    :: (exists part | part in parts :: i in part)
+            :: (exists part | part in parts :: i in part)
   {
     if |parts| == 0 {
     } else {

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkDiscoveryKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkDiscoveryKeyring.dfy
@@ -257,31 +257,31 @@ module
       );
 
       var result := match outcome {
-                      case Success(mat) =>
-                        assert exists helper: AwsKmsEdkHelper
-                            | helper in edksToAttempt
-                          ::
-                            && helper.edk in encryptedDataKeys
-                            && helper.arn.resource.resourceType == "key"
-                            && decryptAction.Ensures(helper, Success(mat));
+        case Success(mat) =>
+          assert exists helper: AwsKmsEdkHelper
+              | helper in edksToAttempt
+            ::
+              && helper.edk in encryptedDataKeys
+              && helper.arn.resource.resourceType == "key"
+              && decryptAction.Ensures(helper, Success(mat));
 
-                        Success(Crypto.OnDecryptOutput(materials := mat))
-                      //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
-                      //# If OnDecrypt fails to successfully decrypt any encrypted data key
-                      //# (../structures.md#encrypted-data-key), then it MUST yield an error that
-                      //# includes all collected errors.
-                      case Failure(errors) =>
-                        if |errors| == 0 then
-                          Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
-                        else
-                          var concatString := (s, a) => a + "\n" + s;
-                          var error := Seq.FoldRight(
-                            concatString,
-                            errors,
-                            "Unable to decrypt data key:\n"
-                          );
-                          Failure(error)
-                    };
+          Success(Crypto.OnDecryptOutput(materials := mat))
+        //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
+        //# If OnDecrypt fails to successfully decrypt any encrypted data key
+        //# (../structures.md#encrypted-data-key), then it MUST yield an error that
+        //# includes all collected errors.
+        case Failure(errors) =>
+          if |errors| == 0 then
+            Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
+          else
+            var concatString := (s, a) => a + "\n" + s;
+            var error := Seq.FoldRight(
+              concatString,
+              errors,
+              "Unable to decrypt data key:\n"
+            );
+            Failure(error)
+      };
       var wrappedResult := Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(result);
       return wrappedResult;
     }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkDiscoveryKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkDiscoveryKeyring.dfy
@@ -289,9 +289,9 @@ module
 
   class AwsKmsEncryptedDataKeyFilterTransform
     extends ActionWithResult<
-    Crypto.EncryptedDataKey,
-    seq<AwsKmsEdkHelper>,
-    string
+      Crypto.EncryptedDataKey,
+      seq<AwsKmsEdkHelper>,
+      string
     >
   {
     const region: string
@@ -369,9 +369,9 @@ module
    */
   class AwsKmsEncryptedDataKeyDecryptor
     extends ActionWithResult<
-    AwsKmsEdkHelper,
-    Materials.SealedDecryptionMaterials,
-    string>
+      AwsKmsEdkHelper,
+      Materials.SealedDecryptionMaterials,
+      string>
   {
     const materials: Materials.DecryptionMaterialsPendingPlaintextDataKey
     const client: KMS.IKeyManagementServiceClient

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkDiscoveryKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkDiscoveryKeyring.dfy
@@ -78,7 +78,7 @@ module
       ensures res.Failure?
     {
       var exception := new Crypto.AwsCryptographicMaterialProvidersException(
-            "Encryption is not supported with a Discovery Keyring.");
+        "Encryption is not supported with a Discovery Keyring.");
       return Failure(exception);
     }
 
@@ -134,12 +134,12 @@ module
                && KMS.IsValid_CiphertextType(edk.ciphertext)
                && KMS.IsValid_KeyIdType(awsKmsKey)
                && var request := KMS.DecryptRequest(
-                                   KeyId := Option.Some(awsKmsKey),
-                                   CiphertextBlob :=  edk.ciphertext,
-                                   EncryptionContext := Option.Some(stringifiedEncCtx),
-                                   GrantTokens := Option.Some(grantTokens),
-                                   EncryptionAlgorithm := Option.None()
-                                 );
+                    KeyId := Option.Some(awsKmsKey),
+                    CiphertextBlob :=  edk.ciphertext,
+                    EncryptionContext := Option.Some(stringifiedEncCtx),
+                    GrantTokens := Option.Some(grantTokens),
+                    EncryptionAlgorithm := Option.None()
+                  );
 
                //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
                //= type=implication
@@ -164,10 +164,10 @@ module
                   //#   (../structures.md#decryption-materials) as the response "Plaintext".
                && exists returnedKeyId, returnedEncryptionAlgorithm ::
                     && var response := KMS.DecryptResponse(
-                                         KeyId := returnedKeyId,
-                                         Plaintext := res.value.materials.plaintextDataKey,
-                                         EncryptionAlgorithm := returnedEncryptionAlgorithm
-                                       );
+                      KeyId := returnedKeyId,
+                      Plaintext := res.value.materials.plaintextDataKey,
+                      EncryptionAlgorithm := returnedEncryptionAlgorithm
+                    );
                     && client.DecryptSucceededWith(request, response)
                        //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
                        //= type=implication
@@ -184,8 +184,8 @@ module
       var suite := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
 
       :- Crypto.Need(
-           Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
-           "Keyring received decryption materials that already contain a plaintext data key.");
+        Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
+        "Keyring received decryption materials that already contain a plaintext data key.");
 
       //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
       //# The set of encrypted data keys MUST first be filtered to match this
@@ -242,19 +242,19 @@ module
       //# For each encrypted data key in the filtered set, one at a time, the
       //# OnDecrypt MUST attempt to decrypt the data key.
       var decryptAction: AwsKmsEncryptedDataKeyDecryptor := new AwsKmsEncryptedDataKeyDecryptor(
-            materials,
-            client,
-            region,
-            grantTokens
-          );
+        materials,
+        client,
+        region,
+        grantTokens
+      );
       //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
       //# If the response does not satisfies these requirements then an error
       //# is collected and the next encrypted data key in the filtered set MUST
       //# be attempted.
       var outcome := Actions.ReduceToSuccess(
-                       decryptAction,
-                       edksToAttempt
-                     );
+        decryptAction,
+        edksToAttempt
+      );
 
       var result := match outcome {
                       case Success(mat) =>
@@ -276,10 +276,10 @@ module
                         else
                           var concatString := (s, a) => a + "\n" + s;
                           var error := Seq.FoldRight(
-                                         concatString,
-                                         errors,
-                                         "Unable to decrypt data key:\n"
-                                       );
+                            concatString,
+                            errors,
+                            "Unable to decrypt data key:\n"
+                          );
                           Failure(error)
                     };
       var wrappedResult := Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(result);
@@ -416,19 +416,19 @@ module
         // Confirm that we called KMS in the right way and correctly returned the values
         // it gave us
         && var request := KMS.DecryptRequest(
-                            KeyId := Option.Some(keyArn),
-                            CiphertextBlob := helper.edk.ciphertext,
-                            EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
-                            GrantTokens := Option.Some(grantTokens),
-                            EncryptionAlgorithm := Option.None()
-                          );
+             KeyId := Option.Some(keyArn),
+             CiphertextBlob := helper.edk.ciphertext,
+             EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
+             GrantTokens := Option.Some(grantTokens),
+             EncryptionAlgorithm := Option.None()
+           );
         && client.DecryptCalledWith(request)
         && exists returnedKeyId, returnedEncryptionAlgorithm ::
              && var response := KMS.DecryptResponse(
-                                  KeyId := returnedKeyId,
-                                  Plaintext := Option.Some(res.value.plaintextDataKey.value),
-                                  EncryptionAlgorithm := returnedEncryptionAlgorithm
-                                );
+               KeyId := returnedKeyId,
+               Plaintext := Option.Some(res.value.plaintextDataKey.value),
+               EncryptionAlgorithm := returnedEncryptionAlgorithm
+             );
              && client.DecryptSucceededWith(request, response)
     }
 
@@ -445,12 +445,12 @@ module
       :- Need(KMS.IsValid_KeyIdType(awsKmsKey), "KMS key arn invalid");
 
       var decryptRequest := KMS.DecryptRequest(
-                              KeyId := Option.Some(awsKmsKey),
-                              CiphertextBlob := helper.edk.ciphertext,
-                              EncryptionContext := Option.Some(stringifiedEncCtx),
-                              GrantTokens := Option.Some(grantTokens),
-                              EncryptionAlgorithm := Option.None()
-                            );
+        KeyId := Option.Some(awsKmsKey),
+        CiphertextBlob := helper.edk.ciphertext,
+        EncryptionContext := Option.Some(stringifiedEncCtx),
+        GrantTokens := Option.Some(grantTokens),
+        EncryptionAlgorithm := Option.None()
+      );
 
       var maybeDecryptResponse := client.Decrypt(decryptRequest);
       if maybeDecryptResponse.Failure? {
@@ -462,11 +462,11 @@ module
       //= compliance/framework/aws-kms/aws-kms-mrk-discovery-keyring.txt#2.8
       //# *  The "KeyId" field in the response MUST equal the requested "KeyId"
       :- Need(
-           && decryptResponse.KeyId.Some?
-           && decryptResponse.KeyId.value == awsKmsKey
-           && decryptResponse.Plaintext.Some?
-           && algId.encrypt.keyLength as int == |decryptResponse.Plaintext.value|
-         , "Invalid response from KMS Decrypt");
+        && decryptResponse.KeyId.Some?
+        && decryptResponse.KeyId.value == awsKmsKey
+        && decryptResponse.Plaintext.Some?
+        && algId.encrypt.keyLength as int == |decryptResponse.Plaintext.value|
+      , "Invalid response from KMS Decrypt");
 
       var result :-  Materials.DecryptionMaterialsAddDataKey(materials, decryptResponse.Plaintext.value);
       return Success(result);

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkKeyring.dfy
@@ -85,12 +85,12 @@ module
     method OnEncrypt(input: Crypto.OnEncryptInput)
       returns (res: Result<Crypto.OnEncryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.EncryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
-        && StringifyEncryptionContext(input.materials.encryptionContext).Success?
+              ==>
+                && Materials.EncryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
+                && StringifyEncryptionContext(input.materials.encryptionContext).Success?
       //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
       //= type=implication
       //# If the input encryption materials (../structures.md#encryption-
@@ -103,24 +103,24 @@ module
         && input.materials.plaintextDataKey.None?
         && KMS.IsValid_KeyIdType(awsKmsKey)
         && maybeStringifiedEncCtx.Success?
-      ==> (
-        //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
-        //= type=implication
-        //# If the keyring calls AWS KMS GenerateDataKeys, it MUST use the
-        //# configured AWS KMS client to make the call.
-        && client.GenerateDataKeyCalledWith(
-          //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
-          //= type=implication
-          //# The keyring MUST call
-          //# AWS KMS GenerateDataKeys with a request constructed as follows:
-          KMS.GenerateDataKeyRequest(
-            KeyId := awsKmsKey,
-            EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
-            GrantTokens := Option.Some(grantTokens),
-            NumberOfBytes := Option.Some(AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId).encrypt.keyLength as int32),
-            KeySpec := Option.None
-          ))
-      )
+        ==> (
+            //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
+            //= type=implication
+            //# If the keyring calls AWS KMS GenerateDataKeys, it MUST use the
+            //# configured AWS KMS client to make the call.
+            && client.GenerateDataKeyCalledWith(
+                 //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
+                 //= type=implication
+                 //# The keyring MUST call
+                 //# AWS KMS GenerateDataKeys with a request constructed as follows:
+                 KMS.GenerateDataKeyRequest(
+                   KeyId := awsKmsKey,
+                   EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
+                   GrantTokens := Option.Some(grantTokens),
+                   NumberOfBytes := Option.Some(AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId).encrypt.keyLength as int32),
+                   KeySpec := Option.None
+                 ))
+          )
 
       //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
       //= type=implication
@@ -129,40 +129,40 @@ module
       ensures
         && input.materials.plaintextDataKey.None?
         && res.Success?
-      ==>
-        && res.value.materials.plaintextDataKey.Some?
-        && |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
-        //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
-        //= type=implication
-        //# If the Generate Data Key call succeeds, OnEncrypt MUST verify that
-        //# the response "Plaintext" length matches the specification of the
-        //# algorithm suite (../algorithm-suites.md)'s Key Derivation Input Length
-        //# field.
-        && AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId).encrypt.keyLength as int == |res.value.materials.plaintextDataKey.value|
-        && KMS.IsValid_CiphertextType(Last(res.value.materials.encryptedDataKeys).ciphertext)
-        && KMS.IsValid_PlaintextType(res.value.materials.plaintextDataKey.value)
-        //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
-        //= type=implication
-        //# If verified, OnEncrypt MUST do the following with the response
-        //# from AWS KMS GenerateDataKey
-        //# (https://docs.aws.amazon.com/kms/latest/APIReference/
-        //# API_GenerateDataKey.html):
-        && var algId := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
-        && exists returnedKeyId ::
-          && client.GenerateDataKeySucceededWith(
-          input := KMS.GenerateDataKeyRequest(
-            KeyId := awsKmsKey,
-            EncryptionContext := Option.Some(StringifyEncryptionContext(input.materials.encryptionContext).Extract()),
-            GrantTokens := Option.Some(grantTokens),
-            NumberOfBytes := Option.Some(algId.encrypt.keyLength as int32),
-            KeySpec := Option.None
-          ),
-          output := KMS.GenerateDataKeyResponse(
-              KeyId := returnedKeyId,
-              CiphertextBlob := Option.Some(Last(res.value.materials.encryptedDataKeys).ciphertext),
-              Plaintext := Option.Some(res.value.materials.plaintextDataKey.value)
-          )
-        )
+        ==>
+          && res.value.materials.plaintextDataKey.Some?
+          && |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
+             //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
+             //= type=implication
+             //# If the Generate Data Key call succeeds, OnEncrypt MUST verify that
+             //# the response "Plaintext" length matches the specification of the
+             //# algorithm suite (../algorithm-suites.md)'s Key Derivation Input Length
+             //# field.
+          && AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId).encrypt.keyLength as int == |res.value.materials.plaintextDataKey.value|
+          && KMS.IsValid_CiphertextType(Last(res.value.materials.encryptedDataKeys).ciphertext)
+          && KMS.IsValid_PlaintextType(res.value.materials.plaintextDataKey.value)
+             //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
+             //= type=implication
+             //# If verified, OnEncrypt MUST do the following with the response
+             //# from AWS KMS GenerateDataKey
+             //# (https://docs.aws.amazon.com/kms/latest/APIReference/
+             //# API_GenerateDataKey.html):
+          && var algId := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
+          && exists returnedKeyId ::
+            && client.GenerateDataKeySucceededWith(
+                 input := KMS.GenerateDataKeyRequest(
+                            KeyId := awsKmsKey,
+                            EncryptionContext := Option.Some(StringifyEncryptionContext(input.materials.encryptionContext).Extract()),
+                            GrantTokens := Option.Some(grantTokens),
+                            NumberOfBytes := Option.Some(algId.encrypt.keyLength as int32),
+                            KeySpec := Option.None
+                          ),
+                 output := KMS.GenerateDataKeyResponse(
+                             KeyId := returnedKeyId,
+                             CiphertextBlob := Option.Some(Last(res.value.materials.encryptedDataKeys).ciphertext),
+                             Plaintext := Option.Some(res.value.materials.plaintextDataKey.value)
+                           )
+               )
 
       //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
       //= type=implication
@@ -174,25 +174,25 @@ module
         && input.materials.plaintextDataKey.Some?
         && KMS.IsValid_PlaintextType(input.materials.plaintextDataKey.value)
         && StringifyEncryptionContext(input.materials.encryptionContext).Success?
-      ==>
-        //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
-        //= type=implication
-        //# The keyring MUST call AWS KMS Encrypt
-        //# (https://docs.aws.amazon.com/kms/latest/APIReference/
-        //# API_Encrypt.html) using the configured AWS KMS client.
-        && var stringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext).Extract();
-        && client.EncryptCalledWith(
+        ==>
           //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
           //= type=implication
-          //# The keyring
-          //# MUST AWS KMS Encrypt call with a request constructed as follows:
-          KMS.EncryptRequest(
-            KeyId := awsKmsKey,
-            Plaintext := input.materials.plaintextDataKey.value,
-            EncryptionContext := Option.Some(stringifiedEncCtx),
-            GrantTokens := Option.Some(grantTokens),
-            EncryptionAlgorithm := Option.None
-          ))
+          //# The keyring MUST call AWS KMS Encrypt
+          //# (https://docs.aws.amazon.com/kms/latest/APIReference/
+          //# API_Encrypt.html) using the configured AWS KMS client.
+          && var stringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext).Extract();
+          && client.EncryptCalledWith(
+               //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
+               //= type=implication
+               //# The keyring
+               //# MUST AWS KMS Encrypt call with a request constructed as follows:
+               KMS.EncryptRequest(
+                 KeyId := awsKmsKey,
+                 Plaintext := input.materials.plaintextDataKey.value,
+                 EncryptionContext := Option.Some(stringifiedEncCtx),
+                 GrantTokens := Option.Some(grantTokens),
+                 EncryptionAlgorithm := Option.None
+               ))
 
       //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
       //= type=implication
@@ -202,31 +202,31 @@ module
         && input.materials.plaintextDataKey.Some?
         && KMS.IsValid_PlaintextType(input.materials.plaintextDataKey.value)
         && res.Success?
-      ==>
-        //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
-        //= type=implication
-        //# If verified, OnEncrypt MUST do the following with the
-        //# response from AWS KMS Encrypt
-        //# (https://docs.aws.amazon.com/kms/latest/APIReference/
-        //# API_Encrypt.html):
-        && |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
-        && KMS.IsValid_CiphertextType(Last(res.value.materials.encryptedDataKeys).ciphertext)
+        ==>
+          //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
+          //= type=implication
+          //# If verified, OnEncrypt MUST do the following with the
+          //# response from AWS KMS Encrypt
+          //# (https://docs.aws.amazon.com/kms/latest/APIReference/
+          //# API_Encrypt.html):
+          && |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
+          && KMS.IsValid_CiphertextType(Last(res.value.materials.encryptedDataKeys).ciphertext)
 
-        && exists returnedKeyId, returnedEncryptionAlgorithm ::
-          && client.EncryptSucceededWith(
-            input := KMS.EncryptRequest(
-              KeyId := awsKmsKey,
-              Plaintext := input.materials.plaintextDataKey.value,
-              EncryptionContext := Option.Some(StringifyEncryptionContext(input.materials.encryptionContext).Extract()),
-              GrantTokens := Option.Some(grantTokens),
-              EncryptionAlgorithm := Option.None
-            ),
-            output := KMS.EncryptResponse(
-              CiphertextBlob := Option.Some(Last(res.value.materials.encryptedDataKeys).ciphertext),
-              KeyId := returnedKeyId,
-              EncryptionAlgorithm := returnedEncryptionAlgorithm
-            )
-          )
+          && exists returnedKeyId, returnedEncryptionAlgorithm ::
+               && client.EncryptSucceededWith(
+                    input := KMS.EncryptRequest(
+                               KeyId := awsKmsKey,
+                               Plaintext := input.materials.plaintextDataKey.value,
+                               EncryptionContext := Option.Some(StringifyEncryptionContext(input.materials.encryptionContext).Extract()),
+                               GrantTokens := Option.Some(grantTokens),
+                               EncryptionAlgorithm := Option.None
+                             ),
+                    output := KMS.EncryptResponse(
+                                CiphertextBlob := Option.Some(Last(res.value.materials.encryptedDataKeys).ciphertext),
+                                KeyId := returnedKeyId,
+                                EncryptionAlgorithm := returnedEncryptionAlgorithm
+                              )
+                  )
     {
       var materials := input.materials;
       var suite := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
@@ -236,12 +236,12 @@ module
       if materials.plaintextDataKey.None? {
 
         var generatorRequest := KMS.GenerateDataKeyRequest(
-          KeyId := awsKmsKey,
-          EncryptionContext := Option.Some(stringifiedEncCtx),
-          GrantTokens := Option.Some(grantTokens),
-          NumberOfBytes := Option.Some(suite.encrypt.keyLength as int32),
-          KeySpec := Option.None
-        );
+                                  KeyId := awsKmsKey,
+                                  EncryptionContext := Option.Some(stringifiedEncCtx),
+                                  GrantTokens := Option.Some(grantTokens),
+                                  NumberOfBytes := Option.Some(suite.encrypt.keyLength as int32),
+                                  KeySpec := Option.None
+                                );
 
         var maybeGenerateResponse := client.GenerateDataKey(generatorRequest);
 
@@ -255,7 +255,7 @@ module
           var errMsg := maybeGenerateResponse.error.GetMessage();
           var exception := new Crypto.AwsCryptographicMaterialProvidersException(errMsg);
           return Failure(exception);
-       }
+        }
         var generateResponse := maybeGenerateResponse.value;
 
         //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
@@ -263,52 +263,52 @@ module
         //# KMS key ARN (aws-kms-key-arn.md#identifying-an-aws-kms-
         //# multi-region-key).
         :- Crypto.Need(
-          && generateResponse.KeyId.Some?
-          && ParseAwsKmsIdentifier(generateResponse.KeyId.value).Success?,
-          "Invalid response from KMS GenerateDataKey: Invalid Key Id"
-        );
+             && generateResponse.KeyId.Some?
+             && ParseAwsKmsIdentifier(generateResponse.KeyId.value).Success?,
+             "Invalid response from KMS GenerateDataKey: Invalid Key Id"
+           );
         var keyId := generateResponse.KeyId.value;
         var providerInfoResult := UTF8.Encode(keyId);
         var providerInfo :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-          providerInfoResult);
+                              providerInfoResult);
         :- Crypto.Need(|providerInfo| < UINT16_LIMIT,
-          "Invalid response from KMS GenerateDataKey: AWS KMS Key ID too long.");
+                       "Invalid response from KMS GenerateDataKey: AWS KMS Key ID too long.");
 
         :- Crypto.Need(
-          && generateResponse.Plaintext.Some?
-          && suite.encrypt.keyLength as int == |generateResponse.Plaintext.value|,
-          "Invalid response from KMS GenerateDataKey: Invalid data key"
-        );
+             && generateResponse.Plaintext.Some?
+             && suite.encrypt.keyLength as int == |generateResponse.Plaintext.value|,
+             "Invalid response from KMS GenerateDataKey: Invalid data key"
+           );
         var plaintextDataKey := generateResponse.Plaintext.value;
 
         :- Crypto.Need(
-          && generateResponse.CiphertextBlob.Some?
-          && KMS.IsValid_CiphertextType(generateResponse.CiphertextBlob.value),
-          "Returned ciphertext is invalid length");
+             && generateResponse.CiphertextBlob.Some?
+             && KMS.IsValid_CiphertextType(generateResponse.CiphertextBlob.value),
+             "Returned ciphertext is invalid length");
         var ciphertext := generateResponse.CiphertextBlob.value;
 
         var edk := Crypto.EncryptedDataKey(
-          keyProviderId := PROVIDER_ID,
-          keyProviderInfo := providerInfo,
-          ciphertext := ciphertext
-        );
+                     keyProviderId := PROVIDER_ID,
+                     keyProviderInfo := providerInfo,
+                     ciphertext := ciphertext
+                   );
 
         var addKeyResult := Materials.EncryptionMaterialAddDataKey(materials, plaintextDataKey, [edk]);
         var result :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(addKeyResult);
         return Success(Crypto.OnEncryptOutput(
-          materials := result
-        ));
+                         materials := result
+                       ));
       } else {
         :- Crypto.Need(KMS.IsValid_PlaintextType(materials.plaintextDataKey.value),
-          "PlaintextDataKey is invalid length"
-        );
+                       "PlaintextDataKey is invalid length"
+           );
         var encryptRequest := KMS.EncryptRequest(
-            KeyId := awsKmsKey,
-            Plaintext := materials.plaintextDataKey.value,
-            EncryptionContext := Option.Some(stringifiedEncCtx),
-            GrantTokens := Option.Some(grantTokens),
-            EncryptionAlgorithm := Option.None
-        );
+                                KeyId := awsKmsKey,
+                                Plaintext := materials.plaintextDataKey.value,
+                                EncryptionContext := Option.Some(stringifiedEncCtx),
+                                GrantTokens := Option.Some(grantTokens),
+                                EncryptionAlgorithm := Option.None
+                              );
         var maybeEncryptResponse := client.Encrypt(encryptRequest);
 
         //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.7
@@ -328,31 +328,31 @@ module
         //# If the Encrypt call succeeds the response's "KeyId" MUST be A valid
         //# AWS KMS key ARN (aws-kms-key-arn.md#a-valid-aws-kms-arn).
         :- Crypto.Need(
-          && encryptResponse.KeyId.Some?
-          && ParseAwsKmsIdentifier(encryptResponse.KeyId.value).Success?,
-          "Invalid response from AWS KMS Encrypt: Invalid Key Id"
-        );
+             && encryptResponse.KeyId.Some?
+             && ParseAwsKmsIdentifier(encryptResponse.KeyId.value).Success?,
+             "Invalid response from AWS KMS Encrypt: Invalid Key Id"
+           );
 
         :- Crypto.Need(encryptResponse.CiphertextBlob.Some?,
-          "Invalid response from AWS KMS Encrypt: Invalid Ciphertext Blob"
-        );
+                       "Invalid response from AWS KMS Encrypt: Invalid Ciphertext Blob"
+           );
 
         var providerInfoResult := UTF8.Encode(encryptResponse.KeyId.Extract());
         var providerInfo :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-          providerInfoResult);
+                              providerInfoResult);
         :- Crypto.Need(|providerInfo| < UINT16_LIMIT, "AWS KMS Key ID too long.");
 
         var edk := Crypto.EncryptedDataKey(
-          keyProviderId := PROVIDER_ID,
-          keyProviderInfo := providerInfo,
-          ciphertext := encryptResponse.CiphertextBlob.value
-        );
+                     keyProviderId := PROVIDER_ID,
+                     keyProviderInfo := providerInfo,
+                     ciphertext := encryptResponse.CiphertextBlob.value
+                   );
 
         var addKeyResult := Materials.EncryptionMaterialAddEncryptedDataKeys(materials, [edk]);
         var result :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(addKeyResult);
         return Success(Crypto.OnEncryptOutput(
-          materials := result
-        ));
+                         materials := result
+                       ));
       }
     }
 
@@ -366,75 +366,75 @@ module
     )
       returns (res: Result<Crypto.OnDecryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.DecryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+              ==>
+                && Materials.DecryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
 
       ensures
         && input.materials.plaintextDataKey.None?
         && res.Success?
-      ==>
-        && res.value.materials.plaintextDataKey.Some?
-        && var maybeStringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext);
-        && maybeStringifiedEncCtx.Success?
-        && exists edk | edk in input.encryptedDataKeys
-        ::
-          //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
-          //= type=implication
-          //# *  Its provider ID MUST exactly match the value "aws-kms".
-          && edk.keyProviderId == PROVIDER_ID
-          && KMS.IsValid_CiphertextType(edk.ciphertext)
-          && var request := KMS.DecryptRequest(
-            KeyId := Option.Some(awsKmsKey),
-            CiphertextBlob :=  edk.ciphertext,
-            EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
-            GrantTokens := Option.Some(grantTokens),
-            EncryptionAlgorithm := Option.None()
-          );
-          //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
-          //= type=implication
-          //# To attempt to decrypt a particular encrypted data key
-          //# (../structures.md#encrypted-data-key), OnDecrypt MUST call AWS KMS
-          //# Decrypt (https://docs.aws.amazon.com/kms/latest/APIReference/
-          //# API_Decrypt.html) with the configured AWS KMS client.
-          && client.DecryptCalledWith(
-            //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
-            //= type=implication
-            //# When calling AWS KMS Decrypt
-            //# (https://docs.aws.amazon.com/kms/latest/APIReference/
-            //# API_Decrypt.html), the keyring MUST call with a request constructed
-            //# as follows:
-            request)
-          //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
-          //= type=implication
-          //# * The length of the response's "Plaintext" MUST equal the key
-          //# derivation input length (../algorithm-suites.md#key-derivation-
-          //# input-length) specified by the algorithm suite (../algorithm-
-          //# suites.md) included in the input decryption materials
-          //# (../structures.md#decryption-materials).
-          && var algId := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
-          && algId.encrypt.keyLength as int == |res.value.materials.plaintextDataKey.value|
-          && exists returnedKeyId, returnedEncryptionAlgorithm ::
-            && var response := KMS.DecryptResponse(
-              KeyId := returnedKeyId,
-              Plaintext := res.value.materials.plaintextDataKey,
-              EncryptionAlgorithm := returnedEncryptionAlgorithm
-            );
-            //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
-            //= type=implication
-            //# If the response does satisfies these requirements then OnDecrypt MUST
-            //# do the following with the response:
-            && client.DecryptSucceededWith(request, response)
+        ==>
+          && res.value.materials.plaintextDataKey.Some?
+          && var maybeStringifiedEncCtx := StringifyEncryptionContext(input.materials.encryptionContext);
+          && maybeStringifiedEncCtx.Success?
+          && exists edk | edk in input.encryptedDataKeys
+             ::
+               //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
+               //= type=implication
+               //# *  Its provider ID MUST exactly match the value "aws-kms".
+               && edk.keyProviderId == PROVIDER_ID
+               && KMS.IsValid_CiphertextType(edk.ciphertext)
+               && var request := KMS.DecryptRequest(
+                                   KeyId := Option.Some(awsKmsKey),
+                                   CiphertextBlob :=  edk.ciphertext,
+                                   EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
+                                   GrantTokens := Option.Some(grantTokens),
+                                   EncryptionAlgorithm := Option.None()
+                                 );
+               //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
+               //= type=implication
+               //# To attempt to decrypt a particular encrypted data key
+               //# (../structures.md#encrypted-data-key), OnDecrypt MUST call AWS KMS
+               //# Decrypt (https://docs.aws.amazon.com/kms/latest/APIReference/
+               //# API_Decrypt.html) with the configured AWS KMS client.
+               && client.DecryptCalledWith(
+                    //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
+                    //= type=implication
+                    //# When calling AWS KMS Decrypt
+                    //# (https://docs.aws.amazon.com/kms/latest/APIReference/
+                    //# API_Decrypt.html), the keyring MUST call with a request constructed
+                    //# as follows:
+                    request)
+                  //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
+                  //= type=implication
+                  //# * The length of the response's "Plaintext" MUST equal the key
+                  //# derivation input length (../algorithm-suites.md#key-derivation-
+                  //# input-length) specified by the algorithm suite (../algorithm-
+                  //# suites.md) included in the input decryption materials
+                  //# (../structures.md#decryption-materials).
+               && var algId := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
+               && algId.encrypt.keyLength as int == |res.value.materials.plaintextDataKey.value|
+               && exists returnedKeyId, returnedEncryptionAlgorithm ::
+                    && var response := KMS.DecryptResponse(
+                                         KeyId := returnedKeyId,
+                                         Plaintext := res.value.materials.plaintextDataKey,
+                                         EncryptionAlgorithm := returnedEncryptionAlgorithm
+                                       );
+                    //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
+                    //= type=implication
+                    //# If the response does satisfies these requirements then OnDecrypt MUST
+                    //# do the following with the response:
+                    && client.DecryptSucceededWith(request, response)
     {
 
       var materials := input.materials;
       var suite := AlgorithmSuites.GetSuite(input.materials.algorithmSuiteId);
 
       :- Crypto.Need(
-        Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
-        "Keyring received decryption materials that already contain a plaintext data key.");
+           Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
+           "Keyring received decryption materials that already contain a plaintext data key.");
 
       //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
       //# The set of encrypted data keys MUST first be filtered to match this
@@ -449,65 +449,65 @@ module
       //# If this attempt
       //# results in an error, then these errors MUST be collected.
       var decryptClosure := new DecryptSingleEncryptedDataKey(
-        materials,
-        client,
-        awsKmsKey,
-        grantTokens
-      );
+            materials,
+            client,
+            awsKmsKey,
+            grantTokens
+          );
 
       //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
       //# If the response does not satisfies these requirements then an error
       //# MUST be collected and the next encrypted data key in the filtered set
       //# MUST be attempted.
       var outcome := ReduceToSuccess(
-        decryptClosure,
-        edksToAttempt
-      );
+                       decryptClosure,
+                       edksToAttempt
+                     );
 
       var stringifiedEncCtxResult := StringifyEncryptionContext(materials.encryptionContext);
       var stringifiedEncCtx :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
-        stringifiedEncCtxResult);
+                                 stringifiedEncCtxResult);
       var result := match outcome {
-        case Success(mat) =>
-          assert exists edk, returnedKeyId, returnedEncryptionAlgorithm | edk in edksToAttempt
-          ::
-            && edk in input.encryptedDataKeys
-            && filter.Ensures(edk, Success(true))
-            && decryptClosure.Ensures(edk, Success(mat))
-            && var request := KMS.DecryptRequest(
-              KeyId := Option.Some(awsKmsKey),
-              CiphertextBlob :=  edk.ciphertext,
-              EncryptionContext := Option.Some(stringifiedEncCtx),
-              GrantTokens := Option.Some(grantTokens),
-              EncryptionAlgorithm := Option.None()
-            );
+                      case Success(mat) =>
+                        assert exists edk, returnedKeyId, returnedEncryptionAlgorithm | edk in edksToAttempt
+                          ::
+                            && edk in input.encryptedDataKeys
+                            && filter.Ensures(edk, Success(true))
+                            && decryptClosure.Ensures(edk, Success(mat))
+                            && var request := KMS.DecryptRequest(
+                                                KeyId := Option.Some(awsKmsKey),
+                                                CiphertextBlob :=  edk.ciphertext,
+                                                EncryptionContext := Option.Some(stringifiedEncCtx),
+                                                GrantTokens := Option.Some(grantTokens),
+                                                EncryptionAlgorithm := Option.None()
+                                              );
 
-            && client.DecryptCalledWith(request)
-            && var response := KMS.DecryptResponse(
-              KeyId := returnedKeyId,
-              Plaintext := mat.plaintextDataKey,
-              EncryptionAlgorithm := returnedEncryptionAlgorithm
-            );
-            && client.DecryptSucceededWith(request, response);
-          Success(Crypto.OnDecryptOutput(
-            materials := mat
-          ))
-        //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
-        //# If OnDecrypt fails to successfully decrypt any encrypted data key
-        //# (../structures.md#encrypted-data-key), then it MUST yield an error that
-        //# includes all the collected errors.
-        case Failure(errors) =>
-          if |errors| == 0 then
-            Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
-          else
-            var concatString := (s, a) => a + "\n" + s;
-            var error := Seq.FoldRight(
-              concatString,
-              errors,
-              "Unable to decrypt data key:\n"
-            );
-            Failure(error)
-      };
+                            && client.DecryptCalledWith(request)
+                            && var response := KMS.DecryptResponse(
+                                                 KeyId := returnedKeyId,
+                                                 Plaintext := mat.plaintextDataKey,
+                                                 EncryptionAlgorithm := returnedEncryptionAlgorithm
+                                               );
+                            && client.DecryptSucceededWith(request, response);
+                        Success(Crypto.OnDecryptOutput(
+                                  materials := mat
+                                ))
+                      //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
+                      //# If OnDecrypt fails to successfully decrypt any encrypted data key
+                      //# (../structures.md#encrypted-data-key), then it MUST yield an error that
+                      //# includes all the collected errors.
+                      case Failure(errors) =>
+                        if |errors| == 0 then
+                          Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
+                        else
+                          var concatString := (s, a) => a + "\n" + s;
+                          var error := Seq.FoldRight(
+                                         concatString,
+                                         errors,
+                                         "Unable to decrypt data key:\n"
+                                       );
+                          Failure(error)
+                    };
       var wrappedResult := Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(result);
       return wrappedResult;
     }
@@ -527,8 +527,8 @@ module
       res: Result<bool, string>
     ) {
       && (
-          && res.Success?
-          && res.value
+        && res.Success?
+        && res.value
         ==>
           edk.keyProviderId == PROVIDER_ID)
     }
@@ -561,17 +561,17 @@ module
       //# for-decrypt.md#implementation) called with the configured AWS KMS
       //# key identifier and the provider info MUST return "true".
       return Success(AwsKmsMrkMatchForDecrypt(
-        awsKmsKey,
-        AwsKmsArnIdentifier(arn)
-      ));
+                       awsKmsKey,
+                       AwsKmsArnIdentifier(arn)
+                     ));
     }
   }
 
   class DecryptSingleEncryptedDataKey
     extends ActionWithResult<
-      Crypto.EncryptedDataKey,
-      Materials.SealedDecryptionMaterials,
-      string>
+    Crypto.EncryptedDataKey,
+    Materials.SealedDecryptionMaterials,
+    string>
   {
     const materials: Materials.DecryptionMaterialsPendingPlaintextDataKey
     const client: KMS.IKeyManagementServiceClient
@@ -585,10 +585,10 @@ module
       grantTokens: KMS.GrantTokenList
     )
       ensures
-      && this.materials == materials
-      && this.client == client
-      && this.awsKmsKey == awsKmsKey
-      && this.grantTokens == grantTokens
+        && this.materials == materials
+        && this.client == client
+        && this.awsKmsKey == awsKmsKey
+        && this.grantTokens == grantTokens
     {
       this.materials := materials;
       this.client := client;
@@ -600,27 +600,27 @@ module
       edk: Crypto.EncryptedDataKey,
       res: Result<Materials.SealedDecryptionMaterials, string>
     ) {
-        res.Success?
-       ==>
+      res.Success?
+      ==>
         && KMS.IsValid_CiphertextType(edk.ciphertext)
         && Materials.DecryptionMaterialsTransitionIsValid(materials, res.value)
         && var maybeStringifiedEncCtx := StringifyEncryptionContext(materials.encryptionContext);
         && maybeStringifiedEncCtx.Success?
         && var request := KMS.DecryptRequest(
-            KeyId := Option.Some(awsKmsKey),
-            CiphertextBlob := edk.ciphertext,
-            EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
-            GrantTokens := Option.Some(grantTokens),
-            EncryptionAlgorithm := Option.None()
-          );
+                            KeyId := Option.Some(awsKmsKey),
+                            CiphertextBlob := edk.ciphertext,
+                            EncryptionContext := Option.Some(maybeStringifiedEncCtx.Extract()),
+                            GrantTokens := Option.Some(grantTokens),
+                            EncryptionAlgorithm := Option.None()
+                          );
         && client.DecryptCalledWith(request )
         && exists returnedKeyId, returnedEncryptionAlgorithm ::
-          && var response := KMS.DecryptResponse(
-            KeyId := returnedKeyId,
-            Plaintext := Option.Some(res.value.plaintextDataKey.value),
-            EncryptionAlgorithm := returnedEncryptionAlgorithm
-          );
-          && client.DecryptSucceededWith(request, response)
+             && var response := KMS.DecryptResponse(
+                                  KeyId := returnedKeyId,
+                                  Plaintext := Option.Some(res.value.plaintextDataKey.value),
+                                  EncryptionAlgorithm := returnedEncryptionAlgorithm
+                                );
+             && client.DecryptSucceededWith(request, response)
     }
 
     method Invoke(
@@ -631,12 +631,12 @@ module
       :- Need(KMS.IsValid_CiphertextType(edk.ciphertext), "Ciphertext length invalid");
       var stringifiedEncCtx :- StringifyEncryptionContext(materials.encryptionContext);
       var decryptRequest := KMS.DecryptRequest(
-        KeyId := Option.Some(awsKmsKey),
-        CiphertextBlob := edk.ciphertext,
-        EncryptionContext := Option.Some(stringifiedEncCtx),
-        GrantTokens := Option.Some(grantTokens),
-        EncryptionAlgorithm := Option.None()
-      );
+                              KeyId := Option.Some(awsKmsKey),
+                              CiphertextBlob := edk.ciphertext,
+                              EncryptionContext := Option.Some(stringifiedEncCtx),
+                              GrantTokens := Option.Some(grantTokens),
+                              EncryptionAlgorithm := Option.None()
+                            );
 
       var maybeDecryptResponse := client.Decrypt(decryptRequest);
       if maybeDecryptResponse.Failure? {
@@ -646,11 +646,11 @@ module
       var decryptResponse := maybeDecryptResponse.value;
       var algId := AlgorithmSuites.GetSuite(materials.algorithmSuiteId);
       :- Need(
-        && decryptResponse.KeyId.Some?
-        && decryptResponse.KeyId.value == awsKmsKey
-        && decryptResponse.Plaintext.Some?
-        && algId.encrypt.keyLength as int == |decryptResponse.Plaintext.value|
-        , "Invalid response from KMS Decrypt");
+           && decryptResponse.KeyId.Some?
+           && decryptResponse.KeyId.value == awsKmsKey
+           && decryptResponse.Plaintext.Some?
+           && algId.encrypt.keyLength as int == |decryptResponse.Plaintext.value|
+         , "Invalid response from KMS Decrypt");
 
       var result :- Materials.DecryptionMaterialsAddDataKey(materials, decryptResponse.Plaintext.value);
       return Success(result);
@@ -666,12 +666,12 @@ module
       var stringifyResults: map<UTF8.ValidUTF8Bytes, Result<(string, string), string>> :=
         map utf8Key | utf8Key in utf8EncCtx.Keys :: utf8Key := StringifyEncryptionContextPair(utf8Key, utf8EncCtx[utf8Key]);
       if exists r | r in stringifyResults.Values :: r.Failure?
-        then Failure("Encryption context contains invalid UTF8")
+      then Failure("Encryption context contains invalid UTF8")
       else
         assert forall r | r in stringifyResults.Values :: r.Success?;
         // TODO state that UTF8.Decode is injective so we don't need this
         var stringKeysUnique := forall k, k' | k in stringifyResults && k' in stringifyResults
-          :: k != k' ==> stringifyResults[k].value.0 != stringifyResults[k'].value.0;
+                                :: k != k' ==> stringifyResults[k].value.0 != stringifyResults[k'].value.0;
         if !stringKeysUnique then Failure("Encryption context keys are not unique")  // this should never happen...
         else Success(map r | r in stringifyResults.Values :: r.value.0 := r.value.1)
   }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkKeyring.dfy
@@ -569,9 +569,9 @@ module
 
   class DecryptSingleEncryptedDataKey
     extends ActionWithResult<
-    Crypto.EncryptedDataKey,
-    Materials.SealedDecryptionMaterials,
-    string>
+      Crypto.EncryptedDataKey,
+      Materials.SealedDecryptionMaterials,
+      string>
   {
     const materials: Materials.DecryptionMaterialsPendingPlaintextDataKey
     const client: KMS.IKeyManagementServiceClient

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkKeyring.dfy
@@ -468,46 +468,46 @@ module
       var stringifiedEncCtx :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(
         stringifiedEncCtxResult);
       var result := match outcome {
-                      case Success(mat) =>
-                        assert exists edk, returnedKeyId, returnedEncryptionAlgorithm | edk in edksToAttempt
-                          ::
-                            && edk in input.encryptedDataKeys
-                            && filter.Ensures(edk, Success(true))
-                            && decryptClosure.Ensures(edk, Success(mat))
-                            && var request := KMS.DecryptRequest(
-                                 KeyId := Option.Some(awsKmsKey),
-                                 CiphertextBlob :=  edk.ciphertext,
-                                 EncryptionContext := Option.Some(stringifiedEncCtx),
-                                 GrantTokens := Option.Some(grantTokens),
-                                 EncryptionAlgorithm := Option.None()
-                               );
+        case Success(mat) =>
+          assert exists edk, returnedKeyId, returnedEncryptionAlgorithm | edk in edksToAttempt
+            ::
+              && edk in input.encryptedDataKeys
+              && filter.Ensures(edk, Success(true))
+              && decryptClosure.Ensures(edk, Success(mat))
+              && var request := KMS.DecryptRequest(
+                   KeyId := Option.Some(awsKmsKey),
+                   CiphertextBlob :=  edk.ciphertext,
+                   EncryptionContext := Option.Some(stringifiedEncCtx),
+                   GrantTokens := Option.Some(grantTokens),
+                   EncryptionAlgorithm := Option.None()
+                 );
 
-                            && client.DecryptCalledWith(request)
-                            && var response := KMS.DecryptResponse(
-                                 KeyId := returnedKeyId,
-                                 Plaintext := mat.plaintextDataKey,
-                                 EncryptionAlgorithm := returnedEncryptionAlgorithm
-                               );
-                            && client.DecryptSucceededWith(request, response);
-                        Success(Crypto.OnDecryptOutput(
-                                  materials := mat
-                                ))
-                      //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
-                      //# If OnDecrypt fails to successfully decrypt any encrypted data key
-                      //# (../structures.md#encrypted-data-key), then it MUST yield an error that
-                      //# includes all the collected errors.
-                      case Failure(errors) =>
-                        if |errors| == 0 then
-                          Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
-                        else
-                          var concatString := (s, a) => a + "\n" + s;
-                          var error := Seq.FoldRight(
-                            concatString,
-                            errors,
-                            "Unable to decrypt data key:\n"
-                          );
-                          Failure(error)
-                    };
+              && client.DecryptCalledWith(request)
+              && var response := KMS.DecryptResponse(
+                   KeyId := returnedKeyId,
+                   Plaintext := mat.plaintextDataKey,
+                   EncryptionAlgorithm := returnedEncryptionAlgorithm
+                 );
+              && client.DecryptSucceededWith(request, response);
+          Success(Crypto.OnDecryptOutput(
+                    materials := mat
+                  ))
+        //= compliance/framework/aws-kms/aws-kms-mrk-keyring.txt#2.8
+        //# If OnDecrypt fails to successfully decrypt any encrypted data key
+        //# (../structures.md#encrypted-data-key), then it MUST yield an error that
+        //# includes all the collected errors.
+        case Failure(errors) =>
+          if |errors| == 0 then
+            Failure("Unable to decrypt data key: No Encrypted Data Keys found to match.")
+          else
+            var concatString := (s, a) => a + "\n" + s;
+            var error := Seq.FoldRight(
+              concatString,
+              errors,
+              "Unable to decrypt data key:\n"
+            );
+            Failure(error)
+      };
       var wrappedResult := Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(result);
       return wrappedResult;
     }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkMatchForDecrypt.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsMrkMatchForDecrypt.dfy
@@ -14,7 +14,7 @@ module  AwsKmsMrkMatchForDecrypt {
   //= compliance/framework/aws-kms/aws-kms-mrk-match-for-decrypt.txt#2.5
   //= type=implication
   //# The caller MUST provide:
-  //# *  2 AWS KMS key identifiers 
+  //# *  2 AWS KMS key identifiers
   predicate method AwsKmsMrkMatchForDecrypt(
     configuredAwsKmsIdentifier: AwsKmsIdentifier,
     messageAwsKmsIdentifer: AwsKmsIdentifier
@@ -25,7 +25,7 @@ module  AwsKmsMrkMatchForDecrypt {
         case (
           AwsKmsArnIdentifier(configuredAwsKmsArn),
           AwsKmsArnIdentifier(messageAwsKmsArn)
-        ) =>
+          ) =>
           if !IsMultiRegionAwsKmsArn(configuredAwsKmsArn) || !IsMultiRegionAwsKmsArn(messageAwsKmsArn) then false
           else
             && messageAwsKmsArn.partition == configuredAwsKmsArn.partition
@@ -46,8 +46,8 @@ module  AwsKmsMrkMatchForDecrypt {
       && config == message
       && c.Success?
       && m.Success?
-    ==>
-      AwsKmsMrkMatchForDecrypt(c.value, m.value)
+      ==>
+        AwsKmsMrkMatchForDecrypt(c.value, m.value)
     //= compliance/framework/aws-kms/aws-kms-mrk-match-for-decrypt.txt#2.5
     //= type=implication
     //# Otherwise if either input is not identified as a multi-Region key
@@ -60,11 +60,11 @@ module  AwsKmsMrkMatchForDecrypt {
       && c.Success?
       && m.Success?
       && IsMultiRegionAwsKmsArn(c.value) != IsMultiRegionAwsKmsArn(m.value)
-    ==>
-      !AwsKmsMrkMatchForDecrypt(
-        AwsKmsArnIdentifier(c.value), 
-        AwsKmsArnIdentifier(m.value)
-      );
+      ==>
+        !AwsKmsMrkMatchForDecrypt(
+           AwsKmsArnIdentifier(c.value),
+           AwsKmsArnIdentifier(m.value)
+         );
     //= compliance/framework/aws-kms/aws-kms-mrk-match-for-decrypt.txt#2.5
     //= type=implication
     //# Otherwise if both inputs are
@@ -79,15 +79,15 @@ module  AwsKmsMrkMatchForDecrypt {
       && m.Success?
       && IsMultiRegionAwsKmsArn(c.value)
       && IsMultiRegionAwsKmsArn(m.value)
-    ==>
-      AwsKmsMrkMatchForDecrypt(
-        AwsKmsArnIdentifier(c.value),
-        AwsKmsArnIdentifier(m.value)
-      ) == (
-        && m.value.partition == c.value.partition
-        && m.value.service   == c.value.service
-        && m.value.account   == c.value.account
-        && m.value.resource  == c.value.resource
-      );
+      ==>
+        AwsKmsMrkMatchForDecrypt(
+          AwsKmsArnIdentifier(c.value),
+          AwsKmsArnIdentifier(m.value)
+        ) == (
+          && m.value.partition == c.value.partition
+          && m.value.service   == c.value.service
+          && m.value.account   == c.value.account
+          && m.value.resource  == c.value.resource
+        );
   {}
 }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsUtils.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsUtils.dfy
@@ -20,12 +20,12 @@ module {:extern "AwsKmsUtils"} AwsKmsUtils {
       var stringifyResults: map<UTF8.ValidUTF8Bytes, Result<(string, string), string>> :=
         map utf8Key | utf8Key in utf8EncCtx.Keys :: utf8Key := StringifyEncryptionContextPair(utf8Key, utf8EncCtx[utf8Key]);
       if exists r | r in stringifyResults.Values :: r.Failure?
-        then Failure("Encryption context contains invalid UTF8")
+      then Failure("Encryption context contains invalid UTF8")
       else
         assert forall r | r in stringifyResults.Values :: r.Success?;
         // TODO state that UTF8.Decode is injective so we don't need this
         var stringKeysUnique := forall k, k' | k in stringifyResults && k' in stringifyResults
-          :: k != k' ==> stringifyResults[k].value.0 != stringifyResults[k'].value.0;
+                                :: k != k' ==> stringifyResults[k].value.0 != stringifyResults[k'].value.0;
         if !stringKeysUnique then Failure("Encryption context keys are not unique")  // this should never happen...
         else Success(map r | r in stringifyResults.Values :: r.value.0 := r.value.1)
   }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/Constants.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/Constants.dfy
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 include "../../../Util/UTF8.dfy"
-include "../../../Generated/AwsCryptographicMaterialProviders.dfy" 
+include "../../../Generated/AwsCryptographicMaterialProviders.dfy"
 include "AwsKmsArnParsing.dfy"
 
 module Constants {
@@ -14,11 +14,11 @@ module Constants {
   const PROVIDER_ID: UTF8.ValidUTF8Bytes :=
     var s := [0x61, 0x77, 0x73, 0x2D, 0x6B, 0x6D, 0x73];
     assert UTF8.ValidUTF8Range(s, 0, 7);
-    s
+  s
 
   type AwsKmsEncryptedDataKey = edk: Crypto.EncryptedDataKey |
-    && edk.keyProviderId == PROVIDER_ID
-    && UTF8.ValidUTF8Seq(edk.keyProviderInfo)
+      && edk.keyProviderId == PROVIDER_ID
+      && UTF8.ValidUTF8Seq(edk.keyProviderInfo)
     witness *
 
   /*
@@ -29,7 +29,7 @@ module Constants {
    * format makes our lives easier.
    */
   datatype AwsKmsEdkHelper = AwsKmsEdkHelper(
-    edk: AwsKmsEncryptedDataKey,
-    arn: AwsKmsArnParsing.AwsKmsArn
-  )
+                               edk: AwsKmsEncryptedDataKey,
+                               arn: AwsKmsArnParsing.AwsKmsArn
+                             )
 }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/Constants.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/AwsKms/Constants.dfy
@@ -29,7 +29,7 @@ module Constants {
    * format makes our lives easier.
    */
   datatype AwsKmsEdkHelper = AwsKmsEdkHelper(
-                               edk: AwsKmsEncryptedDataKey,
-                               arn: AwsKmsArnParsing.AwsKmsArn
-                             )
+    edk: AwsKmsEncryptedDataKey,
+    arn: AwsKmsArnParsing.AwsKmsArn
+  )
 }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/MultiKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/MultiKeyring.dfy
@@ -67,19 +67,19 @@ module
       returns (res: Result<Crypto.OnEncryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
 
       ensures res.Success?
-      ==>
-        && Materials.EncryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+              ==>
+                && Materials.EncryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
 
       ensures res.Success? ==>
-        //= compliance/framework/multi-keyring.txt#2.6.1
-        //= type=implication
-        //# This means that this keyring MUST return
-        //# encryption materials (structures.md#encryption-materials) containing
-        //# a plaintext data key on OnEncrypt (keyring-interface.md#onencrypt).
-        && res.value.materials.plaintextDataKey.Some?
+                //= compliance/framework/multi-keyring.txt#2.6.1
+                //= type=implication
+                //# This means that this keyring MUST return
+                //# encryption materials (structures.md#encryption-materials) containing
+                //# a plaintext data key on OnEncrypt (keyring-interface.md#onencrypt).
+                && res.value.materials.plaintextDataKey.Some?
 
       //= compliance/framework/multi-keyring.txt#2.7.1
       //= type=implication
@@ -90,7 +90,7 @@ module
       ensures
         && this.generatorKeyring.None?
         && input.materials.plaintextDataKey.None?
-      ==> res.Failure?
+        ==> res.Failure?
 
       //= compliance/framework/multi-keyring.txt#2.7.1
       //= type=implication
@@ -99,7 +99,7 @@ module
       ensures
         && this.generatorKeyring.Some?
         && input.materials.plaintextDataKey.Some?
-      ==> res.Failure?
+        ==> res.Failure?
     {
 
       // We could also frame this as "Need", but I found an "if" statement more clearly matches the
@@ -107,7 +107,7 @@ module
       // and the input encryption materials does not include a plaintext data key")
       if this.generatorKeyring.None? && input.materials.plaintextDataKey.None? {
         var exception := new Crypto.AwsCryptographicMaterialProvidersException(
-          "Need either a generator keyring or input encryption materials which contain a plaintext data key");
+              "Need either a generator keyring or input encryption materials which contain a plaintext data key");
         return Failure(exception);
       }
 
@@ -118,7 +118,7 @@ module
       //# generate a plaintext data key using the generator keyring:
       if this.generatorKeyring.Some? {
         :- Crypto.Need(input.materials.plaintextDataKey.None?,
-          "This multi keyring has a generator but provided Encryption Materials already contain plaintext data key");
+                       "This multi keyring has a generator but provided Encryption Materials already contain plaintext data key");
 
         //= compliance/framework/multi-keyring.txt#2.7.1
         //# *  This keyring MUST first call the generator keyring's OnEncrypt
@@ -129,13 +129,13 @@ module
         //# *  If the generator keyring fails OnEncrypt, this OnEncrypt MUST also
         //# fail.
         :- Crypto.Need(onEncryptOutput.Success?,
-          "Generator keyring failed to generate plaintext data key");
+                       "Generator keyring failed to generate plaintext data key");
 
         //= compliance/framework/multi-keyring.txt#2.7.1
         //# *  If the generator keyring returns encryption materials missing a
         //# plaintext data key, OnEncrypt MUST fail.
         :- Crypto.Need(Materials.EncryptionMaterialsTransitionIsValid(input.materials, onEncryptOutput.value.materials),
-          "Generator keyring returned invalid encryption materials");
+                       "Generator keyring returned invalid encryption materials");
 
         returnMaterials := onEncryptOutput.value.materials;
       }
@@ -155,7 +155,7 @@ module
         //# If the child keyring's OnEncrypt (keyring-
         //# interface.md#onencrypt) fails, this OnEncrypt MUST also fail.
         :- Crypto.Need(onEncryptOutput.Success?,
-          "Child keyring failed to encrypt plaintext data key");
+                       "Child keyring failed to encrypt plaintext data key");
 
         // We have to explicitly check for this because our child and generator keyrings are of type
         // IKeyring, rather than VerifiableKeyring.
@@ -163,13 +163,13 @@ module
         // However, we want to support customer implementations of keyrings which may or may
         // not perform valid transitions.
         :- Crypto.Need(Materials.EncryptionMaterialsTransitionIsValid(returnMaterials, onEncryptOutput.value.materials),
-          "Child keyring performed invalid transition on encryption materials");
+                       "Child keyring performed invalid transition on encryption materials");
 
         returnMaterials := onEncryptOutput.value.materials;
       }
 
       :- Crypto.Need(Materials.EncryptionMaterialsTransitionIsValid(input.materials, returnMaterials),
-        "A child or generator keyring modified the encryption materials in illegal ways.");
+                     "A child or generator keyring modified the encryption materials in illegal ways.");
 
       //= compliance/framework/multi-keyring.txt#2.7.1
       //# If all previous OnEncrypt (keyring-interface.md#onencrypt) calls
@@ -185,11 +185,11 @@ module
     method OnDecrypt(input: Crypto.OnDecryptInput)
       returns (res: Result<Crypto.OnDecryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.DecryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+              ==>
+                && Materials.DecryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
 
       //= compliance/framework/multi-keyring.txt#2.7.2
       //= type=implication
@@ -205,7 +205,7 @@ module
       var materials := input.materials;
 
       :- Crypto.Need(Materials.DecryptionMaterialsWithoutPlaintextDataKey(input.materials),
-        "Keyring received decryption materials that already contain a plaintext data key.");
+                     "Keyring received decryption materials that already contain a plaintext data key.");
 
       // Failure messages will be collected here
       var failures : seq<string> := [];
@@ -278,10 +278,10 @@ module
       // omit the 'if' statement checking for it.
       var concatString := (s, a) => a + "\n" + s;
       var error := Seq.FoldRight(
-        concatString,
-        failures,
-        "Unable to decrypt data key:\n"
-      );
+                     concatString,
+                     failures,
+                     "Unable to decrypt data key:\n"
+                   );
       var combinedResult := new Crypto.AwsCryptographicMaterialProvidersException(error);
       return Failure(combinedResult);
     }
@@ -290,19 +290,19 @@ module
   method AttemptDecryptDataKey(keyring: Crypto.IKeyring, input: Crypto.OnDecryptInput)
     returns (res: Result<Crypto.OnDecryptOutput, string>)
     ensures res.Success?
-      ==> && res.value.materials.plaintextDataKey.Some?
-          && Materials.DecryptionMaterialsTransitionIsValid(input.materials, res.value.materials)
-    {
-      var decryptResult := keyring.OnDecrypt(input);
-      if decryptResult.Failure? {
-        return Failure(decryptResult.error.GetMessage());
-      }
-      var output := decryptResult.value;
+            ==> && res.value.materials.plaintextDataKey.Some?
+                && Materials.DecryptionMaterialsTransitionIsValid(input.materials, res.value.materials)
+  {
+    var decryptResult := keyring.OnDecrypt(input);
+    if decryptResult.Failure? {
+      return Failure(decryptResult.error.GetMessage());
+    }
+    var output := decryptResult.value;
 
-      :- Need(
-          Materials.DecryptionMaterialsTransitionIsValid(input.materials, output.materials),
-          "Keyring performed invalid material transition"
-        );
-      return Success(output);
+    :- Need(
+         Materials.DecryptionMaterialsTransitionIsValid(input.materials, output.materials),
+         "Keyring performed invalid material transition"
+       );
+    return Success(output);
   }
 }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/MultiKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/MultiKeyring.dfy
@@ -22,8 +22,8 @@ module
 
   class MultiKeyring
     extends
-    Keyring.VerifiableInterface,
-    Crypto.IKeyring
+      Keyring.VerifiableInterface,
+      Crypto.IKeyring
   {
     const generatorKeyring: Option<Crypto.IKeyring>
     const childKeyrings: seq<Crypto.IKeyring>

--- a/src/AwsCryptographicMaterialProviders/Keyrings/MultiKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/MultiKeyring.dfy
@@ -107,7 +107,7 @@ module
       // and the input encryption materials does not include a plaintext data key")
       if this.generatorKeyring.None? && input.materials.plaintextDataKey.None? {
         var exception := new Crypto.AwsCryptographicMaterialProvidersException(
-              "Need either a generator keyring or input encryption materials which contain a plaintext data key");
+          "Need either a generator keyring or input encryption materials which contain a plaintext data key");
         return Failure(exception);
       }
 
@@ -278,10 +278,10 @@ module
       // omit the 'if' statement checking for it.
       var concatString := (s, a) => a + "\n" + s;
       var error := Seq.FoldRight(
-                     concatString,
-                     failures,
-                     "Unable to decrypt data key:\n"
-                   );
+        concatString,
+        failures,
+        "Unable to decrypt data key:\n"
+      );
       var combinedResult := new Crypto.AwsCryptographicMaterialProvidersException(error);
       return Failure(combinedResult);
     }
@@ -300,9 +300,9 @@ module
     var output := decryptResult.value;
 
     :- Need(
-         Materials.DecryptionMaterialsTransitionIsValid(input.materials, output.materials),
-         "Keyring performed invalid material transition"
-       );
+      Materials.DecryptionMaterialsTransitionIsValid(input.materials, output.materials),
+      "Keyring performed invalid material transition"
+    );
     return Success(output);
   }
 }

--- a/src/AwsCryptographicMaterialProviders/Keyrings/RawAESKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/RawAESKeyring.dfy
@@ -37,8 +37,8 @@ module
 
   class RawAESKeyring
     extends
-    Keyring.VerifiableInterface,
-    Crypto.IKeyring
+      Keyring.VerifiableInterface,
+      Crypto.IKeyring
   {
     const keyNamespace: UTF8.ValidUTF8Bytes
     const keyName: UTF8.ValidUTF8Bytes

--- a/src/AwsCryptographicMaterialProviders/Keyrings/RawAESKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/RawAESKeyring.dfy
@@ -111,8 +111,8 @@ module
                 && |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
                 && wrappingAlgorithm.tagLength as nat <= |res.value.materials.encryptedDataKeys[|input.materials.encryptedDataKeys|].ciphertext|
                 && var encOutput := DeserializeEDKCiphertext(
-                                      res.value.materials.encryptedDataKeys[|input.materials.encryptedDataKeys|].ciphertext,
-                                      wrappingAlgorithm.tagLength as nat);
+                     res.value.materials.encryptedDataKeys[|input.materials.encryptedDataKeys|].ciphertext,
+                     wrappingAlgorithm.tagLength as nat);
                 && AESEncryption.EncryptionOutputEncryptedWithAAD(
                      encOutput,
                      EncryptionContextToAAD(input.materials.encryptionContext).value)
@@ -168,12 +168,12 @@ module
       //# The keyring MUST encrypt the plaintext data key in the encryption
       //# materials (structures.md#encryption-materials) using AES-GCM.
       var aesEncryptResult := AESEncryption.AESEncrypt(
-                                wrappingAlgorithm,
-                                iv,
-                                wrappingKey,
-                                plaintextDataKey,
-                                aad
-                              );
+        wrappingAlgorithm,
+        iv,
+        wrappingKey,
+        plaintextDataKey,
+        aad
+      );
       var encryptResult :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(aesEncryptResult);
       var encryptedKey := SerializeEDKCiphertext(encryptResult);
 
@@ -234,8 +234,8 @@ module
     {
       var materials := input.materials;
       :- Crypto.Need(
-           Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
-           "Keyring received decryption materials that already contain a plaintext data key.");
+        Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
+        "Keyring received decryption materials that already contain a plaintext data key.");
 
       var aadResult := EncryptionContextToAAD(input.materials.encryptionContext);
       var aad :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(aadResult);
@@ -254,17 +254,17 @@ module
 
           var iv := GetIvFromProvInfo(input.encryptedDataKeys[i].keyProviderInfo);
           var encryptionOutput := DeserializeEDKCiphertext(
-                                    input.encryptedDataKeys[i].ciphertext,
-                                    wrappingAlgorithm.tagLength as nat
-                                  );
+            input.encryptedDataKeys[i].ciphertext,
+            wrappingAlgorithm.tagLength as nat
+          );
 
           var ptKeyRes := this.Decrypt(iv, encryptionOutput, input.materials.encryptionContext);
           if ptKeyRes.Success?
           {
             :- Crypto.Need(
-                 GetSuite(materials.algorithmSuiteId).encrypt.keyLength as int == |ptKeyRes.Extract()|,
-                 // this should never happen
-                 "Plaintext Data Key is not the expected length");
+              GetSuite(materials.algorithmSuiteId).encrypt.keyLength as int == |ptKeyRes.Extract()|,
+              // this should never happen
+              "Plaintext Data Key is not the expected length");
             //= compliance/framework/raw-aes-keyring.txt#2.7.2
             //# If a decryption succeeds, this keyring MUST add the resulting
             //# plaintext data key to the decryption materials and return the
@@ -292,7 +292,7 @@ module
       //# If no decryption succeeds, the keyring MUST fail and MUST NOT modify
       //# the decryption materials (structures.md#decryption-materials).
       var combinedErrorsException := new Crypto.AwsCryptographicMaterialProvidersException(
-            "Unable to decrypt any data keys. Encountered the following errors: " + Seq.Flatten(errors));
+        "Unable to decrypt any data keys. Encountered the following errors: " + Seq.Flatten(errors));
       return Failure(combinedErrorsException);
     }
 
@@ -316,13 +316,13 @@ module
       :- Need(|iv| == wrappingAlgorithm.ivLength as int, "");
       var aad :- EncryptionContextToAAD(encryptionContext);
       var ptKey: seq<uint8> :- AESEncryption.AESDecrypt(
-                                 wrappingAlgorithm,
-                                 wrappingKey,
-                                 encryptionOutput.cipherText,
-                                 encryptionOutput.authTag,
-                                 iv,
-                                 aad
-                               );
+        wrappingAlgorithm,
+        wrappingKey,
+        encryptionOutput.cipherText,
+        encryptionOutput.authTag,
+        iv,
+        aad
+      );
       return Success(ptKey);
     }
 

--- a/src/AwsCryptographicMaterialProviders/Keyrings/RawRSAKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/RawRSAKeyring.dfy
@@ -114,59 +114,59 @@ module
       returns (res: Result<Crypto.OnEncryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures
         res.Success?
-      ==>
-        && Materials.EncryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+        ==>
+          && Materials.EncryptionMaterialsTransitionIsValid(
+               input.materials,
+               res.value.materials
+             )
 
-     //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-     //= type=implication
-     //# OnEncrypt MUST fail if this keyring does not have a specified public
-     //# key (Section 2.5.2).
-     ensures
-       this.publicKey.None? || |this.publicKey.Extract()| == 0
-     ==>
-       res.Failure?
+      //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+      //= type=implication
+      //# OnEncrypt MUST fail if this keyring does not have a specified public
+      //# key (Section 2.5.2).
+      ensures
+        this.publicKey.None? || |this.publicKey.Extract()| == 0
+        ==>
+          res.Failure?
 
-     //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-     //= type=implication
-     //# If the encryption materials (structures.md#encryption-materials) do
-     //# not contain a plaintext data key, OnEncrypt MUST generate a random
-     //# plaintext data key and set it on the encryption materials
-     //# (structures.md#encryption-materials).
-     ensures
-       && input.materials.plaintextDataKey.None?
-       && res.Success?
-     ==>
-       res.value.materials.plaintextDataKey.Some?
+      //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+      //= type=implication
+      //# If the encryption materials (structures.md#encryption-materials) do
+      //# not contain a plaintext data key, OnEncrypt MUST generate a random
+      //# plaintext data key and set it on the encryption materials
+      //# (structures.md#encryption-materials).
+      ensures
+        && input.materials.plaintextDataKey.None?
+        && res.Success?
+        ==>
+          res.value.materials.plaintextDataKey.Some?
 
-     //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-     //= type=implication
-     //# If RSA encryption was successful, OnEncrypt MUST return the input
-     //# encryption materials (structures.md#encryption-materials), modified
-     //# in the following ways:
-     //#*  The encrypted data key list has a new encrypted data key added,
-     //#   constructed as follows:
-     ensures
-       && res.Success?
-     ==>
-       |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
+      //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+      //= type=implication
+      //# If RSA encryption was successful, OnEncrypt MUST return the input
+      //# encryption materials (structures.md#encryption-materials), modified
+      //# in the following ways:
+      //#*  The encrypted data key list has a new encrypted data key added,
+      //#   constructed as follows:
+      ensures
+        && res.Success?
+        ==>
+          |res.value.materials.encryptedDataKeys| == |input.materials.encryptedDataKeys| + 1
 
-     //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-     //= type=implication
-     //# The keyring MUST NOT derive a public key from a
-     //# specified private key (Section 2.5.3).
-     // NOTE: Attempting to proove this by stating that a Keyring
-     // without a public key but with a private key will not encrypt
-     ensures
-       this.privateKey.Some? && this.publicKey.None?
-     ==>
-       res.Failure?
+      //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+      //= type=implication
+      //# The keyring MUST NOT derive a public key from a
+      //# specified private key (Section 2.5.3).
+      // NOTE: Attempting to proove this by stating that a Keyring
+      // without a public key but with a private key will not encrypt
+      ensures
+        this.privateKey.Some? && this.publicKey.None?
+        ==>
+          res.Failure?
     {
       :- Crypto.Need(
-        this.publicKey.Some? && |this.publicKey.Extract()| > 0,
-        "A RawRSAKeyring without a public key cannot provide OnEncrypt");
+           this.publicKey.Some? && |this.publicKey.Extract()| > 0,
+           "A RawRSAKeyring without a public key cannot provide OnEncrypt");
 
       var materials := input.materials;
       var suite := GetSuite(materials.algorithmSuiteId);
@@ -192,19 +192,19 @@ module
       //# The keyring performs RSA encryption (Section 2.4.2) with the
       //# following specifics:
       var externEncryptResult := RSAEncryption.EncryptExtern(
-        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-        //#*  This keyring's padding scheme (Section 2.5.1.1) is the RSA padding
-        //#   scheme.
-        this.paddingScheme,
+                                   //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+                                   //#*  This keyring's padding scheme (Section 2.5.1.1) is the RSA padding
+                                   //#   scheme.
+                                   this.paddingScheme,
 
-        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-        //#*  This keyring's public key (Section 2.5.2) is the RSA public key.
-        this.publicKey.Extract(),
+                                   //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+                                   //#*  This keyring's public key (Section 2.5.2) is the RSA public key.
+                                   this.publicKey.Extract(),
 
-        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-        //#*  The plaintext data key is the plaintext input to RSA encryption.
-        plaintextDataKey
-      );
+                                   //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+                                   //#*  The plaintext data key is the plaintext input to RSA encryption.
+                                   plaintextDataKey
+                                 );
       var ciphertext :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(externEncryptResult);
 
       //= compliance/framework/raw-rsa-keyring.txt#2.6.1
@@ -215,29 +215,29 @@ module
       //#   constructed as follows:
       var edk: Crypto.EncryptedDataKey := Crypto.EncryptedDataKey(
 
-        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-        //#  -  The key provider ID (structures.md#key-provider-id) field is
-        //#     this keyring's key namespace (keyring-interface.md#key-
-        //#     namespace).
-        keyProviderId := this.keyNamespace,
+                                            //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+                                            //#  -  The key provider ID (structures.md#key-provider-id) field is
+                                            //#     this keyring's key namespace (keyring-interface.md#key-
+                                            //#     namespace).
+                                            keyProviderId := this.keyNamespace,
 
-        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-        //#  -  The key provider information (structures.md#key-provider-
-        //#     information) field is this keyring's key name (keyring-
-        //#     interface.md#key-name).
-        keyProviderInfo := this.keyName,
+                                            //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+                                            //#  -  The key provider information (structures.md#key-provider-
+                                            //#     information) field is this keyring's key name (keyring-
+                                            //#     interface.md#key-name).
+                                            keyProviderInfo := this.keyName,
 
-        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-        //#  -  The ciphertext (structures.md#ciphertext) field is the
-        //#     ciphertext output by the RSA encryption of the plaintext data
-        //#     key.
-        ciphertext := ciphertext
-      );
+                                            //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+                                            //#  -  The ciphertext (structures.md#ciphertext) field is the
+                                            //#     ciphertext output by the RSA encryption of the plaintext data
+                                            //#     key.
+                                            ciphertext := ciphertext
+                                          );
 
       var addKeyResult := if materials.plaintextDataKey.None? then
-        Materials.EncryptionMaterialAddDataKey(materials, plaintextDataKey, [edk])
-      else
-        Materials.EncryptionMaterialAddEncryptedDataKeys(materials, [edk]);
+                            Materials.EncryptionMaterialAddDataKey(materials, plaintextDataKey, [edk])
+                          else
+                            Materials.EncryptionMaterialAddEncryptedDataKeys(materials, [edk]);
       var r :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(addKeyResult);
       return Success(Crypto.OnEncryptOutput(materials := r));
     }
@@ -250,11 +250,11 @@ module
     method OnDecrypt(input: Crypto.OnDecryptInput)
       returns (res: Result<Crypto.OnDecryptOutput, Crypto.IAwsCryptographicMaterialProvidersException>)
       ensures res.Success?
-      ==>
-        && Materials.DecryptionMaterialsTransitionIsValid(
-          input.materials,
-          res.value.materials
-        )
+              ==>
+                && Materials.DecryptionMaterialsTransitionIsValid(
+                     input.materials,
+                     res.value.materials
+                   )
 
       //= compliance/framework/raw-rsa-keyring.txt#2.6.2
       //= type=implication
@@ -262,8 +262,8 @@ module
       //# key (Section 2.5.3).
       ensures
         this.privateKey.None? || |this.privateKey.Extract()| == 0
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       //= compliance/framework/raw-rsa-keyring.txt#2.6.2
       //= type=implication
@@ -272,17 +272,17 @@ module
       //# (structures.md#decryption-materials).
       ensures
         input.materials.plaintextDataKey.Some?
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
     {
       :- Crypto.Need(
-        this.privateKey.Some? && |this.privateKey.Extract()| > 0,
-        "A RawRSAKeyring without a private key cannot provide OnEncrypt");
+           this.privateKey.Some? && |this.privateKey.Extract()| > 0,
+           "A RawRSAKeyring without a private key cannot provide OnEncrypt");
 
       var materials := input.materials;
       :- Crypto.Need(
-        Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
-        "Keyring received decryption materials that already contain a plaintext data key.");
+           Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
+           "Keyring received decryption materials that already contain a plaintext data key.");
 
       var errors: seq<string> := [];
       //= compliance/framework/raw-rsa-keyring.txt#2.6.2
@@ -294,10 +294,10 @@ module
         if ShouldDecryptEDK(input.encryptedDataKeys[i]) {
           var edk := input.encryptedDataKeys[i];
           var decryptResult := RSAEncryption.DecryptExtern(
-            this.paddingScheme,
-            this.privateKey.Extract(),
-            edk.ciphertext
-          );
+                                 this.paddingScheme,
+                                 this.privateKey.Extract(),
+                                 edk.ciphertext
+                               );
 
           //= compliance/framework/raw-rsa-keyring.txt#2.6.2
           //# If any decryption succeeds, this keyring MUST immediately return the
@@ -308,32 +308,32 @@ module
             //#*  The output of RSA decryption is set as the decryption material's
             //#   plaintext data key.
             var addKeyResult := Materials.DecryptionMaterialsAddDataKey(
-              materials,
-              decryptResult.Extract()
-            );
+                                  materials,
+                                  decryptResult.Extract()
+                                );
             var r :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(addKeyResult);
             return Success(Crypto.OnDecryptOutput(materials := r));
           } else {
             errors := errors + [
-              "RSAKeyring could not decrypt EncryptedDataKey "
-              + Base10Int2String(i)
-              + ": "
-              + decryptResult.error
-            ];
+                        "RSAKeyring could not decrypt EncryptedDataKey "
+                        + Base10Int2String(i)
+                        + ": "
+                        + decryptResult.error
+                      ];
           }
         } else {
           errors := errors + [
-            "EncryptedDataKey "
-            + Base10Int2String(i)
-            + " did not match RSAKeyring. "
-          ];
+                      "EncryptedDataKey "
+                      + Base10Int2String(i)
+                      + " did not match RSAKeyring. "
+                    ];
         }
       }
       //= compliance/framework/raw-rsa-keyring.txt#2.6.2
       //# If no decryption succeeds, the keyring MUST fail and MUST NOT modify
       //# the decryption materials (structures.md#decryption-materials).
       var combinedErrorsException := new Crypto.AwsCryptographicMaterialProvidersException(
-        "Unable to decrypt any data keys. Encountered the following errors: " + Seq.Flatten(errors));
+            "Unable to decrypt any data keys. Encountered the following errors: " + Seq.Flatten(errors));
       return Failure(combinedErrorsException);
     }
 
@@ -359,8 +359,8 @@ module
         && edk.keyProviderId == this.keyNamespace
 
         && |edk.ciphertext| > 0
-      ==>
-        true
+        ==>
+          true
     {
       && UTF8.ValidUTF8Seq(edk.keyProviderInfo)
       && edk.keyProviderInfo == this.keyName

--- a/src/AwsCryptographicMaterialProviders/Keyrings/RawRSAKeyring.dfy
+++ b/src/AwsCryptographicMaterialProviders/Keyrings/RawRSAKeyring.dfy
@@ -165,8 +165,8 @@ module
           res.Failure?
     {
       :- Crypto.Need(
-           this.publicKey.Some? && |this.publicKey.Extract()| > 0,
-           "A RawRSAKeyring without a public key cannot provide OnEncrypt");
+        this.publicKey.Some? && |this.publicKey.Extract()| > 0,
+        "A RawRSAKeyring without a public key cannot provide OnEncrypt");
 
       var materials := input.materials;
       var suite := GetSuite(materials.algorithmSuiteId);
@@ -192,19 +192,19 @@ module
       //# The keyring performs RSA encryption (Section 2.4.2) with the
       //# following specifics:
       var externEncryptResult := RSAEncryption.EncryptExtern(
-                                   //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-                                   //#*  This keyring's padding scheme (Section 2.5.1.1) is the RSA padding
-                                   //#   scheme.
-                                   this.paddingScheme,
+        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+        //#*  This keyring's padding scheme (Section 2.5.1.1) is the RSA padding
+        //#   scheme.
+        this.paddingScheme,
 
-                                   //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-                                   //#*  This keyring's public key (Section 2.5.2) is the RSA public key.
-                                   this.publicKey.Extract(),
+        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+        //#*  This keyring's public key (Section 2.5.2) is the RSA public key.
+        this.publicKey.Extract(),
 
-                                   //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-                                   //#*  The plaintext data key is the plaintext input to RSA encryption.
-                                   plaintextDataKey
-                                 );
+        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+        //#*  The plaintext data key is the plaintext input to RSA encryption.
+        plaintextDataKey
+      );
       var ciphertext :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(externEncryptResult);
 
       //= compliance/framework/raw-rsa-keyring.txt#2.6.1
@@ -215,24 +215,24 @@ module
       //#   constructed as follows:
       var edk: Crypto.EncryptedDataKey := Crypto.EncryptedDataKey(
 
-                                            //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-                                            //#  -  The key provider ID (structures.md#key-provider-id) field is
-                                            //#     this keyring's key namespace (keyring-interface.md#key-
-                                            //#     namespace).
-                                            keyProviderId := this.keyNamespace,
+        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+        //#  -  The key provider ID (structures.md#key-provider-id) field is
+        //#     this keyring's key namespace (keyring-interface.md#key-
+        //#     namespace).
+        keyProviderId := this.keyNamespace,
 
-                                            //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-                                            //#  -  The key provider information (structures.md#key-provider-
-                                            //#     information) field is this keyring's key name (keyring-
-                                            //#     interface.md#key-name).
-                                            keyProviderInfo := this.keyName,
+        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+        //#  -  The key provider information (structures.md#key-provider-
+        //#     information) field is this keyring's key name (keyring-
+        //#     interface.md#key-name).
+        keyProviderInfo := this.keyName,
 
-                                            //= compliance/framework/raw-rsa-keyring.txt#2.6.1
-                                            //#  -  The ciphertext (structures.md#ciphertext) field is the
-                                            //#     ciphertext output by the RSA encryption of the plaintext data
-                                            //#     key.
-                                            ciphertext := ciphertext
-                                          );
+        //= compliance/framework/raw-rsa-keyring.txt#2.6.1
+        //#  -  The ciphertext (structures.md#ciphertext) field is the
+        //#     ciphertext output by the RSA encryption of the plaintext data
+        //#     key.
+        ciphertext := ciphertext
+      );
 
       var addKeyResult := if materials.plaintextDataKey.None? then
                             Materials.EncryptionMaterialAddDataKey(materials, plaintextDataKey, [edk])
@@ -276,13 +276,13 @@ module
           res.Failure?
     {
       :- Crypto.Need(
-           this.privateKey.Some? && |this.privateKey.Extract()| > 0,
-           "A RawRSAKeyring without a private key cannot provide OnEncrypt");
+        this.privateKey.Some? && |this.privateKey.Extract()| > 0,
+        "A RawRSAKeyring without a private key cannot provide OnEncrypt");
 
       var materials := input.materials;
       :- Crypto.Need(
-           Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
-           "Keyring received decryption materials that already contain a plaintext data key.");
+        Materials.DecryptionMaterialsWithoutPlaintextDataKey(materials),
+        "Keyring received decryption materials that already contain a plaintext data key.");
 
       var errors: seq<string> := [];
       //= compliance/framework/raw-rsa-keyring.txt#2.6.2
@@ -294,10 +294,10 @@ module
         if ShouldDecryptEDK(input.encryptedDataKeys[i]) {
           var edk := input.encryptedDataKeys[i];
           var decryptResult := RSAEncryption.DecryptExtern(
-                                 this.paddingScheme,
-                                 this.privateKey.Extract(),
-                                 edk.ciphertext
-                               );
+            this.paddingScheme,
+            this.privateKey.Extract(),
+            edk.ciphertext
+          );
 
           //= compliance/framework/raw-rsa-keyring.txt#2.6.2
           //# If any decryption succeeds, this keyring MUST immediately return the
@@ -308,9 +308,9 @@ module
             //#*  The output of RSA decryption is set as the decryption material's
             //#   plaintext data key.
             var addKeyResult := Materials.DecryptionMaterialsAddDataKey(
-                                  materials,
-                                  decryptResult.Extract()
-                                );
+              materials,
+              decryptResult.Extract()
+            );
             var r :- Crypto.AwsCryptographicMaterialProvidersException.WrapResultString(addKeyResult);
             return Success(Crypto.OnDecryptOutput(materials := r));
           } else {
@@ -333,7 +333,7 @@ module
       //# If no decryption succeeds, the keyring MUST fail and MUST NOT modify
       //# the decryption materials (structures.md#decryption-materials).
       var combinedErrorsException := new Crypto.AwsCryptographicMaterialProvidersException(
-            "Unable to decrypt any data keys. Encountered the following errors: " + Seq.Flatten(errors));
+        "Unable to decrypt any data keys. Encountered the following errors: " + Seq.Flatten(errors));
       return Failure(combinedErrorsException);
     }
 

--- a/src/AwsCryptographicMaterialProviders/Materials.dfy
+++ b/src/AwsCryptographicMaterialProviders/Materials.dfy
@@ -9,7 +9,7 @@ module
   {:extern "Dafny.Aws.EncryptionSdk.Core.Materials"}
   MaterialProviders.Materials
 {
-import opened StandardLibrary
+  import opened StandardLibrary
   import opened Wrappers
   import opened UInt = StandardLibrary.UInt
   import UTF8
@@ -20,9 +20,9 @@ import opened StandardLibrary
   const EC_PUBLIC_KEY_FIELD: UTF8.ValidUTF8Bytes :=
     var s :=
       [0x61, 0x77, 0x73, 0x2D, 0x63, 0x72, 0x79, 0x70, 0x74, 0x6F, 0x2D, 0x70,
-      0x75, 0x62, 0x6C, 0x69, 0x63, 0x2D, 0x6B, 0x65, 0x79];
+       0x75, 0x62, 0x6C, 0x69, 0x63, 0x2D, 0x6B, 0x65, 0x79];
     assert UTF8.ValidUTF8Range(s, 0, 21);
-    s
+  s
   const RESERVED_KEY_VALUES := { EC_PUBLIC_KEY_FIELD }
 
 
@@ -47,10 +47,10 @@ import opened StandardLibrary
     && newMat.encryptionContext == oldMat.encryptionContext
     && newMat.signingKey == oldMat.signingKey
     && (
-      || (oldMat.plaintextDataKey.None? && newMat.plaintextDataKey.Some?)
-      || oldMat.plaintextDataKey == newMat.plaintextDataKey
-    )
-    
+         || (oldMat.plaintextDataKey.None? && newMat.plaintextDataKey.Some?)
+         || oldMat.plaintextDataKey == newMat.plaintextDataKey
+       )
+
     && newMat.plaintextDataKey.Some?
     && |newMat.encryptedDataKeys| >= |oldMat.encryptedDataKeys|
     && multiset(oldMat.encryptedDataKeys) <= multiset(newMat.encryptedDataKeys)
@@ -67,47 +67,47 @@ import opened StandardLibrary
   )
     // You can not transition from invalid materials
     ensures !ValidEncryptionMaterials(oldMat)
-    ==> !EncryptionMaterialsTransitionIsValid(oldMat, newMat)
+            ==> !EncryptionMaterialsTransitionIsValid(oldMat, newMat)
 
     // You can not transition to invalid materials
     ensures !ValidEncryptionMaterials(newMat)
-    ==> !EncryptionMaterialsTransitionIsValid(oldMat, newMat)
+            ==> !EncryptionMaterialsTransitionIsValid(oldMat, newMat)
 
     // During transitions, we MUST always end up with a plaintext data key.
     // It is not valid to start with a plaintext datakey and remove it.
     // It is not valid to start with no plaintext datakey and not add one.
     ensures
       && newMat.plaintextDataKey.None?
-    ==> !EncryptionMaterialsTransitionIsValid(oldMat, newMat)
+      ==> !EncryptionMaterialsTransitionIsValid(oldMat, newMat)
   {}
 
   predicate method ValidEncryptionMaterials(encryptionMaterials: Crypto.EncryptionMaterials) {
     && var suite := AlgorithmSuites.GetSuite(encryptionMaterials.algorithmSuiteId);
     && (suite.signature.None? <==> encryptionMaterials.signingKey.None?)
-    //= compliance/framework/structures.txt#2.3.3.2.4
-    //= type=implication
-    //# The plaintext data key MUST:
-    //   * Fit the specification for the key derivation algorithm (algorithm-
-    //     suites.md#key-derivation-algorithm) included in this decryption
-    //     material's algorithm suite (Section 2.3.3.2.1).
+       //= compliance/framework/structures.txt#2.3.3.2.4
+       //= type=implication
+       //# The plaintext data key MUST:
+       //   * Fit the specification for the key derivation algorithm (algorithm-
+       //     suites.md#key-derivation-algorithm) included in this decryption
+       //     material's algorithm suite (Section 2.3.3.2.1).
     && (encryptionMaterials.plaintextDataKey.Some? ==> suite.encrypt.keyLength as int == |encryptionMaterials.plaintextDataKey.value|)
-    //= compliance/framework/structures.txt#2.3.3.2.2
-    //= type=implication
-    //# If the plaintext data key is not included in this set of encryption
-    //# materials, this list MUST be empty.
+       //= compliance/framework/structures.txt#2.3.3.2.2
+       //= type=implication
+       //# If the plaintext data key is not included in this set of encryption
+       //# materials, this list MUST be empty.
     && (encryptionMaterials.plaintextDataKey.None? ==> |encryptionMaterials.encryptedDataKeys| == 0)
-    //= compliance/framework/structures.txt#2.3.3.2.3
-    //= type=implication
-    //# If an encryption material (Section 2.3.3) contains a signing key
-    //# (Section 2.3.3.2.5), the encryption context (Section 2.3.2) SHOULD
-    //# include the reserved key "aws-crypto-public-key".
-    //
-    //= compliance/framework/structures.txt#2.3.3.2.3
-    //= type=implication
-    //# If an encryption
-    //# material (Section 2.3.3) does not contains a signing key
-    //# (Section 2.3.3.2.5), the encryption context (Section 2.3.2) SHOULD
-    //# NOT include the reserved key "aws-crypto-public-key".
+       //= compliance/framework/structures.txt#2.3.3.2.3
+       //= type=implication
+       //# If an encryption material (Section 2.3.3) contains a signing key
+       //# (Section 2.3.3.2.5), the encryption context (Section 2.3.2) SHOULD
+       //# include the reserved key "aws-crypto-public-key".
+       //
+       //= compliance/framework/structures.txt#2.3.3.2.3
+       //= type=implication
+       //# If an encryption
+       //# material (Section 2.3.3) does not contains a signing key
+       //# (Section 2.3.3.2.5), the encryption context (Section 2.3.2) SHOULD
+       //# NOT include the reserved key "aws-crypto-public-key".
     && (!suite.signature.None? <==> EC_PUBLIC_KEY_FIELD in encryptionMaterials.encryptionContext)
   }
 
@@ -124,19 +124,19 @@ import opened StandardLibrary
     :(res: Result<Crypto.EncryptionMaterials, string>)
     requires |encryptedDataKeysToAdd| > 0
     ensures res.Success?
-    ==>
-      && EncryptionMaterialsWithPlaintextDataKey(res.value)
-      && EncryptionMaterialsTransitionIsValid(encryptionMaterials, res.value)
+            ==>
+              && EncryptionMaterialsWithPlaintextDataKey(res.value)
+              && EncryptionMaterialsTransitionIsValid(encryptionMaterials, res.value)
   {
     :- Need(ValidEncryptionMaterials(encryptionMaterials), "Attempt to modify invalid encryption material.");
     :- Need(encryptionMaterials.plaintextDataKey.Some?, "Adding encrypted data keys without a plaintext data key is not allowed.");
     Success(Crypto.EncryptionMaterials(
-      plaintextDataKey := encryptionMaterials.plaintextDataKey,
-      encryptedDataKeys := encryptionMaterials.encryptedDataKeys + encryptedDataKeysToAdd,
-      algorithmSuiteId := encryptionMaterials.algorithmSuiteId,
-      encryptionContext := encryptionMaterials.encryptionContext,
-      signingKey := encryptionMaterials.signingKey
-    ))
+              plaintextDataKey := encryptionMaterials.plaintextDataKey,
+              encryptedDataKeys := encryptionMaterials.encryptedDataKeys + encryptedDataKeysToAdd,
+              algorithmSuiteId := encryptionMaterials.algorithmSuiteId,
+              encryptionContext := encryptionMaterials.encryptionContext,
+              signingKey := encryptionMaterials.signingKey
+            ))
   }
 
   function method EncryptionMaterialAddDataKey(
@@ -147,9 +147,9 @@ import opened StandardLibrary
     :(res: Result<Crypto.EncryptionMaterials, string>)
     requires |encryptedDataKeysToAdd| > 0
     ensures res.Success?
-    ==>
-      && EncryptionMaterialsWithPlaintextDataKey(res.value)
-      && EncryptionMaterialsTransitionIsValid(encryptionMaterials, res.value)
+            ==>
+              && EncryptionMaterialsWithPlaintextDataKey(res.value)
+              && EncryptionMaterialsTransitionIsValid(encryptionMaterials, res.value)
   {
     var suite := AlgorithmSuites.GetSuite(encryptionMaterials.algorithmSuiteId);
     :- Need(ValidEncryptionMaterials(encryptionMaterials), "Attempt to modify invalid encryption material.");
@@ -157,12 +157,12 @@ import opened StandardLibrary
     :- Need(suite.encrypt.keyLength as int == |plaintextDataKey|, "plaintextDataKey does not match Algorithm Suite specification.");
 
     Success(Crypto.EncryptionMaterials(
-      plaintextDataKey := Some(plaintextDataKey),
-      encryptedDataKeys := encryptionMaterials.encryptedDataKeys + encryptedDataKeysToAdd,
-      algorithmSuiteId := encryptionMaterials.algorithmSuiteId,
-      encryptionContext := encryptionMaterials.encryptionContext,
-      signingKey := encryptionMaterials.signingKey
-    ))
+              plaintextDataKey := Some(plaintextDataKey),
+              encryptedDataKeys := encryptionMaterials.encryptedDataKeys + encryptedDataKeysToAdd,
+              algorithmSuiteId := encryptionMaterials.algorithmSuiteId,
+              encryptionContext := encryptionMaterials.encryptionContext,
+              signingKey := encryptionMaterials.signingKey
+            ))
   }
 
   // Decryption Materials
@@ -197,11 +197,11 @@ import opened StandardLibrary
   )
     // You can not transition from invalid materials
     ensures !ValidDecryptionMaterials(oldMat)
-    ==> !DecryptionMaterialsTransitionIsValid(oldMat, newMat)
+            ==> !DecryptionMaterialsTransitionIsValid(oldMat, newMat)
 
     // You can not transition to invalid materials
     ensures !ValidDecryptionMaterials(newMat)
-    ==> !DecryptionMaterialsTransitionIsValid(oldMat, newMat)
+            ==> !DecryptionMaterialsTransitionIsValid(oldMat, newMat)
   {}
 
   predicate method ValidDecryptionMaterials(decryptionMaterials: Crypto.DecryptionMaterials) {
@@ -213,18 +213,18 @@ import opened StandardLibrary
     //     suites.md#encryption-algorithm) included in this decryption
     //     material's algorithm suite (Section 2.3.4.2.1).
     && (decryptionMaterials.plaintextDataKey.Some? ==> suite.encrypt.keyLength as int == |decryptionMaterials.plaintextDataKey.value|)
-    //= compliance/framework/structures.txt#2.3.4.2.2
-    //= type=implication
-    //# If a decryption materials (Section 2.3.4) contains a verification key
-    //# (Section 2.3.4.2.4), the encryption context (Section 2.3.2) SHOULD
-    //# include the reserved key "aws-crypto-public-key".
-    //
-    //= compliance/framework/structures.txt#2.3.4.2.2
-    //= type=implication
-    //# If a decryption materials (Section 2.3.4) does not contain a
-    //# verification key (Section 2.3.4.2.4), the encryption context
-    //# (Section 2.3.2) SHOULD NOT include the reserved key "aws-crypto-
-    //# public-key".
+       //= compliance/framework/structures.txt#2.3.4.2.2
+       //= type=implication
+       //# If a decryption materials (Section 2.3.4) contains a verification key
+       //# (Section 2.3.4.2.4), the encryption context (Section 2.3.2) SHOULD
+       //# include the reserved key "aws-crypto-public-key".
+       //
+       //= compliance/framework/structures.txt#2.3.4.2.2
+       //= type=implication
+       //# If a decryption materials (Section 2.3.4) does not contain a
+       //# verification key (Section 2.3.4.2.4), the encryption context
+       //# (Section 2.3.2) SHOULD NOT include the reserved key "aws-crypto-
+       //# public-key".
     && (suite.signature.ECDSA? <==> decryptionMaterials.verificationKey.Some?)
     && (!suite.signature.None? <==> EC_PUBLIC_KEY_FIELD in decryptionMaterials.encryptionContext)
   }
@@ -235,9 +235,9 @@ import opened StandardLibrary
   )
     :(res: Result<Crypto.DecryptionMaterials, string>)
     ensures res.Success?
-    ==>
-      && DecryptionMaterialsWithPlaintextDataKey(res.value)
-      && DecryptionMaterialsTransitionIsValid(decryptionMaterials, res.value)
+            ==>
+              && DecryptionMaterialsWithPlaintextDataKey(res.value)
+              && DecryptionMaterialsTransitionIsValid(decryptionMaterials, res.value)
   {
     var suite := AlgorithmSuites.GetSuite(decryptionMaterials.algorithmSuiteId);
     :- Need(ValidDecryptionMaterials(decryptionMaterials), "Attempt to modify invalid decryption material.");
@@ -245,11 +245,11 @@ import opened StandardLibrary
     :- Need(suite.encrypt.keyLength as int == |plaintextDataKey|, "plaintextDataKey does not match Algorithm Suite specification.");
 
     Success(Crypto.DecryptionMaterials(
-      plaintextDataKey := Some(plaintextDataKey),
-      algorithmSuiteId := decryptionMaterials.algorithmSuiteId,
-      encryptionContext := decryptionMaterials.encryptionContext,
-      verificationKey := decryptionMaterials.verificationKey
-    ))
+              plaintextDataKey := Some(plaintextDataKey),
+              algorithmSuiteId := decryptionMaterials.algorithmSuiteId,
+              encryptionContext := decryptionMaterials.encryptionContext,
+              verificationKey := decryptionMaterials.verificationKey
+            ))
   }
 
   predicate method DecryptionMaterialsWithoutPlaintextDataKey(decryptionMaterials: Crypto.DecryptionMaterials) {

--- a/src/Crypto/AESEncryption.dfy
+++ b/src/Crypto/AESEncryption.dfy
@@ -24,10 +24,10 @@ module {:extern "AESEncryption"} AESEncryption {
   type IVLength = l: uint8 | l == 12 witness 12
 
   datatype AES_GCM = AES_GCM(
-                       nameonly keyLength: KeyLength,
-                       nameonly tagLength: TagLength,
-                       nameonly ivLength: IVLength
-                     )
+    nameonly keyLength: KeyLength,
+    nameonly tagLength: TagLength,
+    nameonly ivLength: IVLength
+  )
 
   datatype EncryptionOutput = EncryptionOutput(cipherText: seq<uint8>, authTag: seq<uint8>)
 

--- a/src/Crypto/AESEncryption.dfy
+++ b/src/Crypto/AESEncryption.dfy
@@ -10,10 +10,10 @@ module {:extern "AESEncryption"} AESEncryption {
 
   export
     provides AESDecrypt, AESEncrypt, AESDecryptExtern, AESEncryptExtern, Wrappers,
-      UInt, PlaintextDecryptedWithAAD, EncryptionOutputEncryptedWithAAD, CiphertextGeneratedWithPlaintext,
-      EncryptedWithKey, DecryptedWithKey
-    reveals 
-      EncryptionOutput, 
+             UInt, PlaintextDecryptedWithAAD, EncryptionOutputEncryptedWithAAD, CiphertextGeneratedWithPlaintext,
+             EncryptedWithKey, DecryptedWithKey
+    reveals
+      EncryptionOutput,
       AES_GCM,
       KeyLength,
       TagLength,
@@ -24,10 +24,10 @@ module {:extern "AESEncryption"} AESEncryption {
   type IVLength = l: uint8 | l == 12 witness 12
 
   datatype AES_GCM = AES_GCM(
-    nameonly keyLength: KeyLength,
-    nameonly tagLength: TagLength,
-    nameonly ivLength: IVLength
-  )
+                       nameonly keyLength: KeyLength,
+                       nameonly tagLength: TagLength,
+                       nameonly ivLength: IVLength
+                     )
 
   datatype EncryptionOutput = EncryptionOutput(cipherText: seq<uint8>, authTag: seq<uint8>)
 
@@ -49,7 +49,7 @@ module {:extern "AESEncryption"} AESEncryption {
   }
 
   method {:extern "AESEncryption.AES_GCM", "AESEncryptExtern"} AESEncryptExtern(encAlg: AES_GCM, iv: seq<uint8>, key: seq<uint8>, msg: seq<uint8>, aad: seq<uint8>)
-      returns (res : Result<EncryptionOutput, string>)
+    returns (res : Result<EncryptionOutput, string>)
     requires |iv| == encAlg.ivLength as int
     requires |key| == encAlg.keyLength as int
     ensures res.Success? ==> EncryptionOutputEncryptedWithAAD(res.value, aad)
@@ -57,28 +57,28 @@ module {:extern "AESEncryption"} AESEncryption {
     ensures res.Success? ==> EncryptedWithKey(res.value.cipherText, key)
 
   method AESEncrypt(encAlg: AES_GCM, iv: seq<uint8>, key: seq<uint8>, msg: seq<uint8>, aad: seq<uint8>)
-      returns (res : Result<EncryptionOutput, string>)
+    returns (res : Result<EncryptionOutput, string>)
     requires |iv| == encAlg.ivLength as int
     requires |key| == encAlg.keyLength as int
     ensures res.Success? ==>
-      |res.value.cipherText| == |msg| && |res.value.authTag| == encAlg.tagLength as int
+              |res.value.cipherText| == |msg| && |res.value.authTag| == encAlg.tagLength as int
     ensures res.Success? ==> EncryptionOutputEncryptedWithAAD(res.value, aad)
     ensures res.Success? ==> CiphertextGeneratedWithPlaintext(res.value.cipherText, msg)
     ensures res.Success? ==> EncryptedWithKey(res.value.cipherText, key)
     // This is useful information to have to prove correctness
     ensures res.Success? ==> |res.value.authTag| == encAlg.tagLength as nat
-    {
-      res := AESEncryptExtern(encAlg, iv, key, msg, aad);
-      if (res.Success? && |res.value.cipherText| != |msg|){
-        res := Failure("AESEncrypt did not return cipherText of expected length");
-      }
-      if (res.Success? && |res.value.authTag| != encAlg.tagLength as int){
-        res := Failure("AESEncryption did not return valid tag");
-      }
+  {
+    res := AESEncryptExtern(encAlg, iv, key, msg, aad);
+    if (res.Success? && |res.value.cipherText| != |msg|){
+      res := Failure("AESEncrypt did not return cipherText of expected length");
     }
+    if (res.Success? && |res.value.authTag| != encAlg.tagLength as int){
+      res := Failure("AESEncryption did not return valid tag");
+    }
+  }
 
   method {:extern "AESEncryption.AES_GCM", "AESDecryptExtern"} AESDecryptExtern(encAlg: AES_GCM, key: seq<uint8>, cipherTxt: seq<uint8>, authTag: seq<uint8>, iv: seq<uint8>, aad: seq<uint8>)
-      returns (res: Result<seq<uint8>, string>)
+    returns (res: Result<seq<uint8>, string>)
     requires |key| == encAlg.keyLength as int
     requires |iv| == encAlg.ivLength as int
     requires |authTag| == encAlg.tagLength as int
@@ -87,7 +87,7 @@ module {:extern "AESEncryption"} AESEncryption {
     ensures res.Success? ==> DecryptedWithKey(key, res.value)
 
   method AESDecrypt(encAlg: AES_GCM, key: seq<uint8>, cipherTxt: seq<uint8>, authTag: seq<uint8>, iv: seq<uint8>, aad: seq<uint8>)
-      returns (res: Result<seq<uint8>, string>)
+    returns (res: Result<seq<uint8>, string>)
     requires |key| == encAlg.keyLength as int
     requires |iv| == encAlg.ivLength as int
     requires |authTag| == encAlg.tagLength as int
@@ -95,11 +95,11 @@ module {:extern "AESEncryption"} AESEncryption {
     ensures res.Success? ==> PlaintextDecryptedWithAAD(res.value, aad)
     ensures res.Success? ==> CiphertextGeneratedWithPlaintext(cipherTxt, res.value)
     ensures res.Success? ==> DecryptedWithKey(key, res.value)
-    {
-      res := AESDecryptExtern(encAlg, key, cipherTxt, authTag, iv, aad);
-      if (res.Success? && |cipherTxt| != |res.value|){
-        res := Failure("AESDecrypt did not return plaintext of expected length");
-      }
+  {
+    res := AESDecryptExtern(encAlg, key, cipherTxt, authTag, iv, aad);
+    if (res.Success? && |cipherTxt| != |res.value|){
+      res := Failure("AESDecrypt did not return plaintext of expected length");
     }
+  }
 
 }

--- a/src/Crypto/Digest.dfy
+++ b/src/Crypto/Digest.dfy
@@ -21,7 +21,7 @@ module Digest {
   {
     var result := ExternDigest.Digest(alg, msg);
     if result.Success? && |result.value| != Length(alg) {
-        return Failure("Incorrect length digest from ExternDigest.");
+      return Failure("Incorrect length digest from ExternDigest.");
     }
     return result;
   }

--- a/src/Crypto/HKDF/HKDF.dfy
+++ b/src/Crypto/HKDF/HKDF.dfy
@@ -53,7 +53,7 @@ module HKDF {
       exists prev :: PreTi(hmac, info, n, prev) &&  hmac.HashSignature(prev, res)
   }
 
-    // return T (i)
+  // return T (i)
   predicate PreTi(hmac: HMac, info: seq<uint8>, n: nat, res: seq<uint8>)
     requires 1 <= n < 256
     decreases n, 0
@@ -74,9 +74,9 @@ module HKDF {
     ensures hmac.GetKey() == prk
     ensures hmac.GetDigest() == digest
     ensures var n := (GetHashLength(digest) + expectedLength - 1) / GetHashLength(digest);
-      && T(hmac, info, n, okmUnabridged)
-      && (|okmUnabridged| <= expectedLength ==> okm == okmUnabridged)
-      && (expectedLength < |okmUnabridged| ==> okm == okmUnabridged[..expectedLength])
+            && T(hmac, info, n, okmUnabridged)
+            && (|okmUnabridged| <= expectedLength ==> okm == okmUnabridged)
+            && (expectedLength < |okmUnabridged| ==> okm == okmUnabridged[..expectedLength])
   {
     // N = ceil(L / Hash Length)
     var hashLength := GetHashLength(digest);

--- a/src/Crypto/HKDF/HMAC.dfy
+++ b/src/Crypto/HKDF/HMAC.dfy
@@ -7,7 +7,7 @@ module {:extern "HMAC"} HMAC {
   import opened StandardLibrary
   import opened UInt = StandardLibrary.UInt
 
-  datatype {:extern "Digests"} Digests = 
+  datatype {:extern "Digests"} Digests =
     | SHA_256
     | SHA_384
     | SHA_512

--- a/src/Crypto/RSAEncryption.dfy
+++ b/src/Crypto/RSAEncryption.dfy
@@ -40,10 +40,10 @@ module {:extern "RSAEncryption"} RSAEncryption {
   // PrivateKey represents an extension of Key for RSA private keys to aid with type safety
   class PrivateKey extends Key {
     constructor(pem: seq<uint8>, strength: StrengthBits)
-    requires |pem| > 0
-    ensures this.pem == pem
-    ensures this.strength == strength
-    ensures Valid()
+      requires |pem| > 0
+      ensures this.pem == pem
+      ensures this.strength == strength
+      ensures Valid()
     {
       this.pem := pem;
       this.strength := strength;
@@ -53,10 +53,10 @@ module {:extern "RSAEncryption"} RSAEncryption {
   // PublicKey represents an extension of Key for RSA public keys to aid with type safety
   class PublicKey extends Key {
     constructor(pem: seq<uint8>, strength: StrengthBits)
-    requires |pem| > 0
-    ensures this.pem == pem
-    ensures this.strength == strength
-    ensures Valid()
+      requires |pem| > 0
+      ensures this.pem == pem
+      ensures this.strength == strength
+      ensures Valid()
     {
       this.pem := pem;
       this.strength := strength;
@@ -64,7 +64,7 @@ module {:extern "RSAEncryption"} RSAEncryption {
   }
 
   method GenerateKeyPair(strength: StrengthBits)
-      returns (publicKey: PublicKey, privateKey: PrivateKey)
+    returns (publicKey: PublicKey, privateKey: PrivateKey)
     ensures privateKey.Valid()
     ensures publicKey.Valid()
   {
@@ -77,20 +77,20 @@ module {:extern "RSAEncryption"} RSAEncryption {
   // Note: Customers should call GenerateKeyPair instead of GenerateKeyPairExtern to ensure type safety and additional
   // verification
   method {:extern "RSAEncryption.RSA", "GenerateKeyPairExtern"} GenerateKeyPairExtern(strength: StrengthBits)
-      returns (publicKey: seq<uint8>, privateKey: seq<uint8>)
+    returns (publicKey: seq<uint8>, privateKey: seq<uint8>)
     ensures |publicKey| > 0
     ensures |privateKey| > 0
-    // Tie the public and private keys to a strength and padding to ensure validation fails if they are later changed
+  // Tie the public and private keys to a strength and padding to ensure validation fails if they are later changed
 
   method {:extern "RSAEncryption.RSA", "DecryptExtern"} DecryptExtern(padding: PaddingMode, privateKey: seq<uint8>,
                                                                       cipherText: seq<uint8>)
-      returns (res: Result<seq<uint8>, string>)
+    returns (res: Result<seq<uint8>, string>)
     requires |privateKey| > 0
     requires |cipherText| > 0
 
   method {:extern "RSAEncryption.RSA", "EncryptExtern"} EncryptExtern(padding: PaddingMode, publicKey: seq<uint8>,
                                                                       plaintextData: seq<uint8>)
-      returns (res: Result<seq<uint8>, string>)
+    returns (res: Result<seq<uint8>, string>)
     requires |publicKey| > 0
     requires |plaintextData| > 0
 }

--- a/src/Crypto/Random.dfy
+++ b/src/Crypto/Random.dfy
@@ -18,7 +18,7 @@ module Random {
   {
     var result := ExternRandom.GenerateBytes(i);
     if result.Success? && |result.value| != i as int {
-        return Failure("Incorrect length from ExternRandom.");
+      return Failure("Incorrect length from ExternRandom.");
     }
     return result;
   }

--- a/src/Crypto/Signature.dfy
+++ b/src/Crypto/Signature.dfy
@@ -36,15 +36,15 @@ module {:extern "Signature"} Signature {
 
   method KeyGen(s: ECDSAParams) returns (res: Result<SignatureKeyPair, string>)
     ensures match res
-      case Success(sigKeyPair) =>
-        //= compliance/framework/structures.txt#2.3.3.2.5
-        //= type=implication
-        //# The signing key MUST fit the specification described by the signature
-        //# algorithm (algorithm-suites.md#signature-algorithm) included in this
-        //# encryption material's algorithm suite (Section 2.3.3.2.1).
-        && |sigKeyPair.verificationKey| == s.FieldSize()
-        && IsValidSignatureKeyPair(sigKeyPair)
-      case Failure(_) => true
+            case Success(sigKeyPair) =>
+              //= compliance/framework/structures.txt#2.3.3.2.5
+              //= type=implication
+              //# The signing key MUST fit the specification described by the signature
+              //# algorithm (algorithm-suites.md#signature-algorithm) included in this
+              //# encryption material's algorithm suite (Section 2.3.3.2.1).
+              && |sigKeyPair.verificationKey| == s.FieldSize()
+              && IsValidSignatureKeyPair(sigKeyPair)
+            case Failure(_) => true
   {
     var sigKeyPair :- ExternKeyGen(s);
     if |sigKeyPair.verificationKey| == s.FieldSize() {

--- a/src/Generated/Aws.dfy
+++ b/src/Generated/Aws.dfy
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module {:extern "Dafny.Aws"} Aws {
-    // No content, this just creates the parent module so that
-    // we can add sub-modules.
+  // No content, this just creates the parent module so that
+  // we can add sub-modules.
 
-    // "Dafny" prefix on the extern because we are also generating
-    // code in the "Aws.*" namespace from our Smithy-to-X code
-    // generation and we need these to be separate
-    // TODO: better name than "Dafny"?
+  // "Dafny" prefix on the extern because we are also generating
+  // code in the "Aws.*" namespace from our Smithy-to-X code
+  // generation and we need these to be separate
+  // TODO: better name than "Dafny"?
 }

--- a/src/Generated/AwsCryptographicMaterialProviders.dfy
+++ b/src/Generated/AwsCryptographicMaterialProviders.dfy
@@ -7,462 +7,462 @@ include "../Generated/KeyManagementService.dfy"
 include "./KeyManagementService.dfy"
 
 module {:extern "Dafny.Aws.EncryptionSdk.Core"} Aws.Crypto {
-    import opened Wrappers
-    import KMS = Com.Amazonaws.Kms
-    import opened UInt = StandardLibrary.UInt
-    import opened UTF8
+  import opened Wrappers
+  import KMS = Com.Amazonaws.Kms
+  import opened UInt = StandardLibrary.UInt
+  import opened UTF8
 
-    // TODO this is currently needed for proof stability reasons, otherwise any file that has a transitive dependency on this one tries to
-    // load too much at once, making the verification unstable
-    export
-      provides UTF8, UInt, KMS, Wrappers,
-        IClientSupplier,
-        IClientSupplier.GetClient,
-        IKeyring.OnDecrypt,
-        IKeyring.OnEncrypt,
-        ICryptographicMaterialsManager.GetEncryptionMaterials,
-        ICryptographicMaterialsManager.DecryptMaterials,
-        IAwsCryptographicMaterialProviders.CreateRawAesKeyring,
-        IAwsCryptographicMaterialProviders.CreateDefaultCryptographicMaterialsManager,
-        IAwsCryptographicMaterialProviders.CreateAwsKmsKeyring,
-        IAwsCryptographicMaterialProviders.CreateAwsKmsDiscoveryKeyring,
-        IAwsCryptographicMaterialProviders.CreateAwsKmsMrkKeyring,
-        IAwsCryptographicMaterialProviders.CreateAwsKmsMrkDiscoveryKeyring,
-        IAwsCryptographicMaterialProviders.CreateMultiKeyring,
-        IAwsCryptographicMaterialProviders.CreateRawRsaKeyring,
-        IAwsCryptographicMaterialProviders.CreateDefaultClientSupplier,
-        IAwsCryptographicMaterialProviders.CreateAwsKmsMrkMultiKeyring,
-        IAwsCryptographicMaterialProviders.CreateAwsKmsMrkDiscoveryMultiKeyring,
-        IAwsCryptographicMaterialProviders.CreateAwsKmsMultiKeyring,
-        IAwsCryptographicMaterialProviders.CreateAwsKmsDiscoveryMultiKeyring,
-        AwsCryptographicMaterialProvidersException.message,
-        AwsCryptographicMaterialProvidersException.WrapResultString,
-        AwsCryptographicMaterialProvidersException.WrapOutcomeString,
-        Need
+  // TODO this is currently needed for proof stability reasons, otherwise any file that has a transitive dependency on this one tries to
+  // load too much at once, making the verification unstable
+  export
+    provides UTF8, UInt, KMS, Wrappers,
+             IClientSupplier,
+             IClientSupplier.GetClient,
+             IKeyring.OnDecrypt,
+             IKeyring.OnEncrypt,
+             ICryptographicMaterialsManager.GetEncryptionMaterials,
+             ICryptographicMaterialsManager.DecryptMaterials,
+             IAwsCryptographicMaterialProviders.CreateRawAesKeyring,
+             IAwsCryptographicMaterialProviders.CreateDefaultCryptographicMaterialsManager,
+             IAwsCryptographicMaterialProviders.CreateAwsKmsKeyring,
+             IAwsCryptographicMaterialProviders.CreateAwsKmsDiscoveryKeyring,
+             IAwsCryptographicMaterialProviders.CreateAwsKmsMrkKeyring,
+             IAwsCryptographicMaterialProviders.CreateAwsKmsMrkDiscoveryKeyring,
+             IAwsCryptographicMaterialProviders.CreateMultiKeyring,
+             IAwsCryptographicMaterialProviders.CreateRawRsaKeyring,
+             IAwsCryptographicMaterialProviders.CreateDefaultClientSupplier,
+             IAwsCryptographicMaterialProviders.CreateAwsKmsMrkMultiKeyring,
+             IAwsCryptographicMaterialProviders.CreateAwsKmsMrkDiscoveryMultiKeyring,
+             IAwsCryptographicMaterialProviders.CreateAwsKmsMultiKeyring,
+             IAwsCryptographicMaterialProviders.CreateAwsKmsDiscoveryMultiKeyring,
+             AwsCryptographicMaterialProvidersException.message,
+             AwsCryptographicMaterialProvidersException.WrapResultString,
+             AwsCryptographicMaterialProvidersException.WrapOutcomeString,
+             Need
 
-      reveals
-        AlgorithmSuiteId,
-        EncryptedDataKey,
-        EncryptedDataKeyList,
-        IKeyring,
-        GetEncryptionMaterialsInput,
-        GetEncryptionMaterialsOutput,
-        DecryptMaterialsInput,
-        DecryptMaterialsOutput,
-        ICryptographicMaterialsManager,
-        EncryptionContext,
-        EncryptionMaterials,
-        DecryptionMaterials,
-        OnEncryptInput,
-        OnEncryptOutput,
-        OnDecryptInput,
-        OnDecryptOutput,
-        EncryptionMaterials.Valid,
-        CreateAwsKmsKeyringInput,
-        CreateAwsKmsDiscoveryKeyringInput,
-        CreateDefaultClientSupplierInput,
-        CreateDefaultCryptographicMaterialsManagerInput,
-        CreateAwsKmsMrkDiscoveryKeyringInput,
-        CreateAwsKmsMrkKeyringInput,
-        CreateMultiKeyringInput,
-        CreateRawAesKeyringInput,
-        CreateAwsKmsMrkMultiKeyringInput,
-        CreateAwsKmsMrkDiscoveryMultiKeyringInput,
-        CreateAwsKmsMultiKeyringInput,
-        CreateAwsKmsDiscoveryMultiKeyringInput,
-        DiscoveryFilter,
-        AccountId,
-        AccountIdList,
-        KmsKeyId,
-        GrantToken,
-        GrantTokenList,
-        IAwsCryptographicMaterialProviders,
-        IAwsCryptographicMaterialProvidersFactory,
-        IClientSupplier,
-        GetClientInput,
-        IAwsCryptographicMaterialProvidersException,
-        IAwsCryptographicMaterialProvidersException.GetMessage,
-        AwsCryptographicMaterialProvidersException,
-        AwsCryptographicMaterialProvidersException.GetMessage,
-        AesWrappingAlg,
-        CommitmentPolicy,
-        CreateRawRsaKeyringInput,
-        PaddingScheme,
-        KmsKeyIdList,
-        RegionList,
-        Region
+    reveals
+      AlgorithmSuiteId,
+      EncryptedDataKey,
+      EncryptedDataKeyList,
+      IKeyring,
+      GetEncryptionMaterialsInput,
+      GetEncryptionMaterialsOutput,
+      DecryptMaterialsInput,
+      DecryptMaterialsOutput,
+      ICryptographicMaterialsManager,
+      EncryptionContext,
+      EncryptionMaterials,
+      DecryptionMaterials,
+      OnEncryptInput,
+      OnEncryptOutput,
+      OnDecryptInput,
+      OnDecryptOutput,
+      EncryptionMaterials.Valid,
+      CreateAwsKmsKeyringInput,
+      CreateAwsKmsDiscoveryKeyringInput,
+      CreateDefaultClientSupplierInput,
+      CreateDefaultCryptographicMaterialsManagerInput,
+      CreateAwsKmsMrkDiscoveryKeyringInput,
+      CreateAwsKmsMrkKeyringInput,
+      CreateMultiKeyringInput,
+      CreateRawAesKeyringInput,
+      CreateAwsKmsMrkMultiKeyringInput,
+      CreateAwsKmsMrkDiscoveryMultiKeyringInput,
+      CreateAwsKmsMultiKeyringInput,
+      CreateAwsKmsDiscoveryMultiKeyringInput,
+      DiscoveryFilter,
+      AccountId,
+      AccountIdList,
+      KmsKeyId,
+      GrantToken,
+      GrantTokenList,
+      IAwsCryptographicMaterialProviders,
+      IAwsCryptographicMaterialProvidersFactory,
+      IClientSupplier,
+      GetClientInput,
+      IAwsCryptographicMaterialProvidersException,
+      IAwsCryptographicMaterialProvidersException.GetMessage,
+      AwsCryptographicMaterialProvidersException,
+      AwsCryptographicMaterialProvidersException.GetMessage,
+      AesWrappingAlg,
+      CommitmentPolicy,
+      CreateRawRsaKeyringInput,
+      PaddingScheme,
+      KmsKeyIdList,
+      RegionList,
+      Region
 
-    /////////////
-    // kms.smithy
-    type KmsKeyId = string
-    type KmsKeyIdList = seq<KmsKeyId>
+  /////////////
+  // kms.smithy
+  type KmsKeyId = string
+  type KmsKeyIdList = seq<KmsKeyId>
 
-    type GrantToken = string
-    type GrantTokenList = seq<GrantToken>
+  type GrantToken = string
+  type GrantTokenList = seq<GrantToken>
 
-    type Region = string
-    type RegionList = seq<Region>
+  type Region = string
+  type RegionList = seq<Region>
 
-    type AccountId = string
-    type AccountIdList = seq<AccountId>
+  type AccountId = string
+  type AccountIdList = seq<AccountId>
 
-    datatype DiscoveryFilter = DiscoveryFilter(accountIds: AccountIdList, partition: string)
+  datatype DiscoveryFilter = DiscoveryFilter(accountIds: AccountIdList, partition: string)
 
-    datatype GetClientInput = GetClientInput(region: string)
+  datatype GetClientInput = GetClientInput(region: string)
 
-    trait {:termination false} IClientSupplier {
-        method GetClient(input: GetClientInput)
-            returns (res: Result<KMS.IKeyManagementServiceClient, IAwsCryptographicMaterialProvidersException>)
+  trait {:termination false} IClientSupplier {
+    method GetClient(input: GetClientInput)
+      returns (res: Result<KMS.IKeyManagementServiceClient, IAwsCryptographicMaterialProvidersException>)
+  }
+
+  datatype CreateDefaultClientSupplierInput = CreateDefaultClientSupplierInput()
+
+  /////////////
+  // structures.smithy
+  // TODO: May eventually change this to strings, for now leaving as utf8 bytes for
+  // compatibility with existing code.
+  type EncryptionContext = map<ValidUTF8Bytes, ValidUTF8Bytes>
+
+  datatype EncryptedDataKey = EncryptedDataKey(nameonly keyProviderId: ValidUTF8Bytes,
+                                               nameonly keyProviderInfo: seq<uint8>,
+                                               nameonly ciphertext: seq<uint8>)
+
+  type EncryptedDataKeyList = seq<EncryptedDataKey>
+
+  //= compliance/framework/structures.txt#2.3.3.2
+  //= type=implication
+  //# This structure MAY include
+  //# any of the following fields:
+  //
+  //= compliance/framework/structures.txt#2.3.3.2.4
+  //= type=implication
+  //# The plaintext data key SHOULD be stored as immutable data.
+  datatype EncryptionMaterials = EncryptionMaterials(nameonly algorithmSuiteId: AlgorithmSuiteId, // TODO update to algorithmSuite or update Smithy model (and elsewhere)
+                                                     nameonly encryptionContext: EncryptionContext, // TODO should EC be an Option? (and elsewhere)
+                                                     nameonly encryptedDataKeys: EncryptedDataKeyList, // TODO should this be an Option? (and elsewhere)
+                                                     nameonly plaintextDataKey: Option<seq<uint8>>,
+                                                     nameonly signingKey: Option<seq<uint8>>)
+  {
+    predicate Valid() {
+      true
+    }
+  }
+
+  //= compliance/framework/structures.txt#2.3.4.2
+  //= type=implication
+  //# This structure MAY include
+  //# any of the following fields:
+  //
+  //= compliance/framework/structures.txt#2.3.4.2.3
+  //= type=implication
+  //# The plaintext data key SHOULD be stored as immutable data.
+  datatype DecryptionMaterials = DecryptionMaterials(nameonly algorithmSuiteId: AlgorithmSuiteId,
+                                                     nameonly encryptionContext: EncryptionContext,
+                                                     nameonly plaintextDataKey: Option<seq<uint8>>,
+                                                     nameonly verificationKey: Option<seq<uint8>>)
+  {
+    predicate Valid() {
+      true
+    }
+  }
+
+  ///////////////////////
+  // crypto-config.smithy
+  //= compliance/client-apis/client.txt#2.4.1
+  //= type=implication
+  //# The AWS Encryption SDK MUST provide the following commitment
+  //# policies:
+  //#*  FORBID_ENCRYPT_ALLOW_DECRYPT
+  //#*  REQUIRE_ENCRYPT_ALLOW_DECRYPT
+  //#*  REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+  datatype CommitmentPolicy =
+    FORBID_ENCRYPT_ALLOW_DECRYPT |
+    REQUIRE_ENCRYPT_ALLOW_DECRYPT |
+    REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+
+  datatype AesWrappingAlg =
+    ALG_AES128_GCM_IV12_TAG16 |
+    ALG_AES192_GCM_IV12_TAG16 |
+    ALG_AES256_GCM_IV12_TAG16
+
+  datatype AlgorithmSuiteId =
+    ALG_AES_128_GCM_IV12_TAG16_NO_KDF |
+    ALG_AES_192_GCM_IV12_TAG16_NO_KDF |
+    ALG_AES_256_GCM_IV12_TAG16_NO_KDF |
+    ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256 |
+    ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256 |
+    ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256 |
+    ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256 |
+    ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 |
+    ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 |
+    ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY |
+    ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
+
+  datatype PaddingScheme =
+    PKCS1 |
+    OAEP_SHA1_MGF1 |
+    OAEP_SHA256_MGF1 |
+    OAEP_SHA384_MGF1 |
+    OAEP_SHA512_MGF1
+
+  //////////////////
+  // keyrings.smithy
+
+  datatype OnEncryptInput = OnEncryptInput(nameonly materials: EncryptionMaterials)
+
+  datatype OnEncryptOutput = OnEncryptOutput(nameonly materials: EncryptionMaterials)
+  datatype OnDecryptInput = OnDecryptInput(nameonly materials: DecryptionMaterials,
+                                           nameonly encryptedDataKeys: EncryptedDataKeyList)
+
+  datatype OnDecryptOutput = OnDecryptOutput(nameonly materials: DecryptionMaterials)
+
+  trait {:termination false} IKeyring {
+    method OnEncrypt(input: OnEncryptInput)
+      returns (res: Result<OnEncryptOutput, IAwsCryptographicMaterialProvidersException>)
+    method OnDecrypt(input: OnDecryptInput)
+      returns (res: Result<OnDecryptOutput, IAwsCryptographicMaterialProvidersException>)
+  }
+
+  //////////////
+  // cmms.smithy
+  datatype GetEncryptionMaterialsInput = GetEncryptionMaterialsInput(
+                                           nameonly encryptionContext: EncryptionContext,
+                                           nameonly commitmentPolicy: CommitmentPolicy,
+                                           nameonly algorithmSuiteId: Option<AlgorithmSuiteId>,
+                                           nameonly maxPlaintextLength: Option<int64>
+                                         )
+
+  datatype GetEncryptionMaterialsOutput = GetEncryptionMaterialsOutput(
+                                            nameonly encryptionMaterials: EncryptionMaterials
+                                          )
+
+  datatype DecryptMaterialsInput = DecryptMaterialsInput(
+                                     nameonly algorithmSuiteId: AlgorithmSuiteId,
+                                     nameonly commitmentPolicy: CommitmentPolicy,
+                                     nameonly encryptedDataKeys: EncryptedDataKeyList,
+                                     nameonly encryptionContext: EncryptionContext
+                                   )
+
+  datatype DecryptMaterialsOutput = DecryptMaterialsOutput(
+                                      nameonly decryptionMaterials: DecryptionMaterials
+                                    )
+
+  trait {:termination false} ICryptographicMaterialsManager {
+    method GetEncryptionMaterials(input: GetEncryptionMaterialsInput)
+      returns (res: Result<GetEncryptionMaterialsOutput, IAwsCryptographicMaterialProvidersException>)
+    method DecryptMaterials(input: DecryptMaterialsInput)
+      returns (res: Result<DecryptMaterialsOutput, IAwsCryptographicMaterialProvidersException>)
+  }
+
+  // Keyring creation input structures
+
+  // KMS
+  datatype CreateAwsKmsKeyringInput = CreateAwsKmsKeyringInput(
+                                        nameonly kmsKeyId: KmsKeyId,
+                                        nameonly kmsClient: KMS.IKeyManagementServiceClient,
+                                        nameonly grantTokens: Option<GrantTokenList>
+                                      )
+
+  datatype CreateAwsKmsMultiKeyringInput = CreateAwsKmsMultiKeyringInput(
+                                             nameonly generator: Option<KmsKeyId>,
+                                             nameonly kmsKeyIds: Option<KmsKeyIdList>,
+                                             nameonly clientSupplier: Option<IClientSupplier>,
+                                             nameonly grantTokens: Option<GrantTokenList>
+                                           )
+
+  // KMS - Discovery
+  datatype CreateAwsKmsDiscoveryKeyringInput = CreateAwsKmsDiscoveryKeyringInput(
+                                                 nameonly kmsClient: KMS.IKeyManagementServiceClient,
+                                                 nameonly discoveryFilter: Option<DiscoveryFilter>,
+                                                 grantTokens: Option<GrantTokenList>
+                                               )
+
+  datatype CreateAwsKmsDiscoveryMultiKeyringInput = CreateAwsKmsDiscoveryMultiKeyringInput(
+                                                      nameonly regions: RegionList,
+                                                      nameonly discoveryFilter: Option<DiscoveryFilter>,
+                                                      nameonly clientSupplier: Option<IClientSupplier>,
+                                                      nameonly grantTokens: Option<GrantTokenList>
+                                                    )
+
+
+  // KMS - MRK Aware, Strict
+  datatype CreateAwsKmsMrkKeyringInput = CreateAwsKmsMrkKeyringInput(
+                                           nameonly kmsKeyId: KmsKeyId,
+                                           nameonly kmsClient: KMS.IKeyManagementServiceClient,
+                                           nameonly grantTokens: Option<GrantTokenList>
+                                         )
+
+  datatype CreateAwsKmsMrkMultiKeyringInput = CreateAwsKmsMrkMultiKeyringInput(
+                                                nameonly generator: Option<KmsKeyId>,
+                                                nameonly kmsKeyIds: Option<KmsKeyIdList>,
+                                                nameonly clientSupplier: Option<IClientSupplier>,
+                                                nameonly grantTokens: Option<GrantTokenList>
+                                              )
+
+  // KMS - MRK Aware, Discovery
+  datatype CreateAwsKmsMrkDiscoveryKeyringInput = CreateAwsKmsMrkDiscoveryKeyringInput(
+                                                    nameonly kmsClient: KMS.IKeyManagementServiceClient,
+                                                    nameonly discoveryFilter: Option<DiscoveryFilter>,
+                                                    nameonly grantTokens: Option<GrantTokenList>,
+                                                    nameonly region: string
+                                                  )
+
+  datatype CreateAwsKmsMrkDiscoveryMultiKeyringInput = CreateAwsKmsMrkDiscoveryMultiKeyringInput(
+                                                         nameonly regions: RegionList,
+                                                         nameonly discoveryFilter: Option<DiscoveryFilter>,
+                                                         nameonly clientSupplier: Option<IClientSupplier>,
+                                                         nameonly grantTokens: Option<GrantTokenList>
+                                                       )
+
+  // Multi
+  datatype CreateMultiKeyringInput = CreateMultiKeyringInput(
+                                       nameonly generator: Option<IKeyring>,
+                                       nameonly childKeyrings: seq<IKeyring>
+                                     )
+
+  // Raw Keyrings
+  datatype CreateRawAesKeyringInput = CreateRawAesKeyringInput(
+                                        nameonly keyNamespace: string,
+                                        nameonly keyName: string,
+                                        nameonly wrappingKey: seq<uint8>,
+                                        // TODO update spec with wrappingAlg input to Raw AES Keyring init
+                                        nameonly wrappingAlg: AesWrappingAlg
+                                      )
+
+  datatype CreateRawRsaKeyringInput = CreateRawRsaKeyringInput(
+                                        nameonly keyNamespace: string,
+                                        nameonly keyName: string,
+                                        nameonly paddingScheme: PaddingScheme,
+                                        nameonly publicKey: Option<seq<uint8>>,
+                                        nameonly privateKey: Option<seq<uint8>>
+                                      )
+
+  // CMM Creation input structures
+
+  datatype CreateDefaultCryptographicMaterialsManagerInput = CreateDefaultCryptographicMaterialsManagerInput(
+                                                               nameonly keyring: IKeyring
+                                                             )
+
+  trait {:termination false} IAwsCryptographicMaterialProvidersFactory {
+    method CreateDefaultAwsCryptographicMaterialProviders()
+      returns (res: Result<IAwsCryptographicMaterialProviders, IAwsCryptographicMaterialProvidersException>)
+  }
+
+  trait {:termination false} IAwsCryptographicMaterialProviders {
+
+    // Keyrings
+    method CreateAwsKmsKeyring(input: CreateAwsKmsKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+    method CreateAwsKmsMultiKeyring(input: CreateAwsKmsMultiKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+    method CreateAwsKmsDiscoveryKeyring(input: CreateAwsKmsDiscoveryKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+    method CreateAwsKmsDiscoveryMultiKeyring(input: CreateAwsKmsDiscoveryMultiKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+    method CreateAwsKmsMrkKeyring(input: CreateAwsKmsMrkKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+    method CreateAwsKmsMrkMultiKeyring(input: CreateAwsKmsMrkMultiKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+    method CreateAwsKmsMrkDiscoveryKeyring(input: CreateAwsKmsMrkDiscoveryKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+    method CreateAwsKmsMrkDiscoveryMultiKeyring(input: CreateAwsKmsMrkDiscoveryMultiKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+    method CreateMultiKeyring(input: CreateMultiKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+    method CreateRawAesKeyring(input: CreateRawAesKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+    method CreateRawRsaKeyring(input: CreateRawRsaKeyringInput)
+      returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
+
+    // CMMs
+    method CreateDefaultCryptographicMaterialsManager(input: CreateDefaultCryptographicMaterialsManagerInput)
+      returns (res: Result<ICryptographicMaterialsManager, IAwsCryptographicMaterialProvidersException>)
+
+    // Client Supplier
+    method CreateDefaultClientSupplier(input: CreateDefaultClientSupplierInput)
+      returns (res: Result<IClientSupplier, IAwsCryptographicMaterialProvidersException>)
+  }
+
+  trait IAwsCryptographicMaterialProvidersException {
+    function method GetMessage(): (message: string)
+      reads this
+  }
+
+  class AwsCryptographicMaterialProvidersBaseException extends IAwsCryptographicMaterialProvidersException {
+    var message: string
+
+    constructor (message: string) {
+      this.message := message;
     }
 
-    datatype CreateDefaultClientSupplierInput = CreateDefaultClientSupplierInput()
-
-    /////////////
-    // structures.smithy
-    // TODO: May eventually change this to strings, for now leaving as utf8 bytes for
-    // compatibility with existing code.
-    type EncryptionContext = map<ValidUTF8Bytes, ValidUTF8Bytes>
-
-    datatype EncryptedDataKey = EncryptedDataKey(nameonly keyProviderId: ValidUTF8Bytes,
-                                                 nameonly keyProviderInfo: seq<uint8>,
-                                                 nameonly ciphertext: seq<uint8>)
-
-    type EncryptedDataKeyList = seq<EncryptedDataKey>
-
-    //= compliance/framework/structures.txt#2.3.3.2
-    //= type=implication
-    //# This structure MAY include
-    //# any of the following fields:
-    //
-    //= compliance/framework/structures.txt#2.3.3.2.4
-    //= type=implication
-    //# The plaintext data key SHOULD be stored as immutable data.
-    datatype EncryptionMaterials = EncryptionMaterials(nameonly algorithmSuiteId: AlgorithmSuiteId, // TODO update to algorithmSuite or update Smithy model (and elsewhere)
-                                                       nameonly encryptionContext: EncryptionContext, // TODO should EC be an Option? (and elsewhere)
-                                                       nameonly encryptedDataKeys: EncryptedDataKeyList, // TODO should this be an Option? (and elsewhere)
-                                                       nameonly plaintextDataKey: Option<seq<uint8>>,
-                                                       nameonly signingKey: Option<seq<uint8>>)
+    function method GetMessage(): (message: string)
+      reads this
     {
-        predicate Valid() {
-            true
-        }
+      this.message
+    }
+  }
+
+  class AwsCryptographicMaterialProvidersException extends IAwsCryptographicMaterialProvidersException {
+    var message: string
+
+    constructor (message: string) {
+      this.message := message;
     }
 
-    //= compliance/framework/structures.txt#2.3.4.2
-    //= type=implication
-    //# This structure MAY include
-    //# any of the following fields:
-    //
-    //= compliance/framework/structures.txt#2.3.4.2.3
-    //= type=implication
-    //# The plaintext data key SHOULD be stored as immutable data.
-    datatype DecryptionMaterials = DecryptionMaterials(nameonly algorithmSuiteId: AlgorithmSuiteId,
-                                                       nameonly encryptionContext: EncryptionContext,
-                                                       nameonly plaintextDataKey: Option<seq<uint8>>,
-                                                       nameonly verificationKey: Option<seq<uint8>>)
+    function method GetMessage(): (message: string)
+      reads this
     {
-        predicate Valid() {
-            true
-        }
+      this.message
     }
 
-    ///////////////////////
-    // crypto-config.smithy
-    //= compliance/client-apis/client.txt#2.4.1
-    //= type=implication
-    //# The AWS Encryption SDK MUST provide the following commitment
-    //# policies:
-    //#*  FORBID_ENCRYPT_ALLOW_DECRYPT
-    //#*  REQUIRE_ENCRYPT_ALLOW_DECRYPT
-    //#*  REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-    datatype CommitmentPolicy =
-        FORBID_ENCRYPT_ALLOW_DECRYPT |
-        REQUIRE_ENCRYPT_ALLOW_DECRYPT |
-        REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-
-    datatype AesWrappingAlg =
-      ALG_AES128_GCM_IV12_TAG16 |
-      ALG_AES192_GCM_IV12_TAG16 |
-      ALG_AES256_GCM_IV12_TAG16
-
-    datatype AlgorithmSuiteId =
-        ALG_AES_128_GCM_IV12_TAG16_NO_KDF |
-        ALG_AES_192_GCM_IV12_TAG16_NO_KDF |
-        ALG_AES_256_GCM_IV12_TAG16_NO_KDF |
-        ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256 |
-        ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256 |
-        ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256 |
-        ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256 |
-        ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 |
-        ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 |
-        ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY |
-        ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384
-
-    datatype PaddingScheme =
-        PKCS1 |
-        OAEP_SHA1_MGF1 |
-        OAEP_SHA256_MGF1 |
-        OAEP_SHA384_MGF1 |
-        OAEP_SHA512_MGF1
-
-    //////////////////
-    // keyrings.smithy
-
-    datatype OnEncryptInput = OnEncryptInput(nameonly materials: EncryptionMaterials)
-
-    datatype OnEncryptOutput = OnEncryptOutput(nameonly materials: EncryptionMaterials)
-    datatype OnDecryptInput = OnDecryptInput(nameonly materials: DecryptionMaterials,
-                                             nameonly encryptedDataKeys: EncryptedDataKeyList)
-
-    datatype OnDecryptOutput = OnDecryptOutput(nameonly materials: DecryptionMaterials)
-
-    trait {:termination false} IKeyring {
-        method OnEncrypt(input: OnEncryptInput)
-            returns (res: Result<OnEncryptOutput, IAwsCryptographicMaterialProvidersException>)
-        method OnDecrypt(input: OnDecryptInput)
-            returns (res: Result<OnDecryptOutput, IAwsCryptographicMaterialProvidersException>)
-    }
-
-    //////////////
-    // cmms.smithy
-    datatype GetEncryptionMaterialsInput = GetEncryptionMaterialsInput(
-        nameonly encryptionContext: EncryptionContext,
-        nameonly commitmentPolicy: CommitmentPolicy,
-        nameonly algorithmSuiteId: Option<AlgorithmSuiteId>,
-        nameonly maxPlaintextLength: Option<int64>
-    )
-
-    datatype GetEncryptionMaterialsOutput = GetEncryptionMaterialsOutput(
-        nameonly encryptionMaterials: EncryptionMaterials
-    )
-
-    datatype DecryptMaterialsInput = DecryptMaterialsInput(
-        nameonly algorithmSuiteId: AlgorithmSuiteId,
-        nameonly commitmentPolicy: CommitmentPolicy,
-        nameonly encryptedDataKeys: EncryptedDataKeyList,
-        nameonly encryptionContext: EncryptionContext
-    )
-
-    datatype DecryptMaterialsOutput = DecryptMaterialsOutput(
-        nameonly decryptionMaterials: DecryptionMaterials
-    )
-
-    trait {:termination false} ICryptographicMaterialsManager {
-        method GetEncryptionMaterials(input: GetEncryptionMaterialsInput)
-            returns (res: Result<GetEncryptionMaterialsOutput, IAwsCryptographicMaterialProvidersException>)
-        method DecryptMaterials(input: DecryptMaterialsInput)
-            returns (res: Result<DecryptMaterialsOutput, IAwsCryptographicMaterialProvidersException>)
-    }
-
-    // Keyring creation input structures
-
-    // KMS
-    datatype CreateAwsKmsKeyringInput = CreateAwsKmsKeyringInput(
-        nameonly kmsKeyId: KmsKeyId,
-        nameonly kmsClient: KMS.IKeyManagementServiceClient,
-        nameonly grantTokens: Option<GrantTokenList>
-	)
-
-    datatype CreateAwsKmsMultiKeyringInput = CreateAwsKmsMultiKeyringInput(
-        nameonly generator: Option<KmsKeyId>,
-        nameonly kmsKeyIds: Option<KmsKeyIdList>,
-        nameonly clientSupplier: Option<IClientSupplier>,
-        nameonly grantTokens: Option<GrantTokenList>
-    )
-
-    // KMS - Discovery
-    datatype CreateAwsKmsDiscoveryKeyringInput = CreateAwsKmsDiscoveryKeyringInput(
-        nameonly kmsClient: KMS.IKeyManagementServiceClient,
-        nameonly discoveryFilter: Option<DiscoveryFilter>,
-        grantTokens: Option<GrantTokenList>
-    )
-
-    datatype CreateAwsKmsDiscoveryMultiKeyringInput = CreateAwsKmsDiscoveryMultiKeyringInput(
-        nameonly regions: RegionList,
-        nameonly discoveryFilter: Option<DiscoveryFilter>,
-        nameonly clientSupplier: Option<IClientSupplier>,
-        nameonly grantTokens: Option<GrantTokenList>
-    )
-
-
-    // KMS - MRK Aware, Strict
-    datatype CreateAwsKmsMrkKeyringInput = CreateAwsKmsMrkKeyringInput(
-        nameonly kmsKeyId: KmsKeyId,
-        nameonly kmsClient: KMS.IKeyManagementServiceClient,
-        nameonly grantTokens: Option<GrantTokenList>
-    )
-
-    datatype CreateAwsKmsMrkMultiKeyringInput = CreateAwsKmsMrkMultiKeyringInput(
-        nameonly generator: Option<KmsKeyId>,
-        nameonly kmsKeyIds: Option<KmsKeyIdList>,
-        nameonly clientSupplier: Option<IClientSupplier>,
-        nameonly grantTokens: Option<GrantTokenList>
-    )
-
-    // KMS - MRK Aware, Discovery
-    datatype CreateAwsKmsMrkDiscoveryKeyringInput = CreateAwsKmsMrkDiscoveryKeyringInput(
-        nameonly kmsClient: KMS.IKeyManagementServiceClient,
-        nameonly discoveryFilter: Option<DiscoveryFilter>,
-        nameonly grantTokens: Option<GrantTokenList>,
-        nameonly region: string
-    )
-
-    datatype CreateAwsKmsMrkDiscoveryMultiKeyringInput = CreateAwsKmsMrkDiscoveryMultiKeyringInput(
-        nameonly regions: RegionList,
-        nameonly discoveryFilter: Option<DiscoveryFilter>,
-        nameonly clientSupplier: Option<IClientSupplier>,
-        nameonly grantTokens: Option<GrantTokenList>
-    )
-
-    // Multi
-    datatype CreateMultiKeyringInput = CreateMultiKeyringInput(
-        nameonly generator: Option<IKeyring>,
-        nameonly childKeyrings: seq<IKeyring>
-    )
-
-    // Raw Keyrings
-    datatype CreateRawAesKeyringInput = CreateRawAesKeyringInput(
-        nameonly keyNamespace: string,
-        nameonly keyName: string,
-        nameonly wrappingKey: seq<uint8>,
-        // TODO update spec with wrappingAlg input to Raw AES Keyring init
-        nameonly wrappingAlg: AesWrappingAlg
-    )
-
-    datatype CreateRawRsaKeyringInput = CreateRawRsaKeyringInput(
-        nameonly keyNamespace: string,
-        nameonly keyName: string,
-        nameonly paddingScheme: PaddingScheme,
-        nameonly publicKey: Option<seq<uint8>>,
-        nameonly privateKey: Option<seq<uint8>>
-    )
-
-    // CMM Creation input structures
-
-    datatype CreateDefaultCryptographicMaterialsManagerInput = CreateDefaultCryptographicMaterialsManagerInput(
-        nameonly keyring: IKeyring
-    )
-
-    trait {:termination false} IAwsCryptographicMaterialProvidersFactory {
-        method CreateDefaultAwsCryptographicMaterialProviders()
-            returns (res: Result<IAwsCryptographicMaterialProviders, IAwsCryptographicMaterialProvidersException>)
-    }
-
-    trait {:termination false} IAwsCryptographicMaterialProviders {
-
-        // Keyrings
-        method CreateAwsKmsKeyring(input: CreateAwsKmsKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-        method CreateAwsKmsMultiKeyring(input: CreateAwsKmsMultiKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-        method CreateAwsKmsDiscoveryKeyring(input: CreateAwsKmsDiscoveryKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-        method CreateAwsKmsDiscoveryMultiKeyring(input: CreateAwsKmsDiscoveryMultiKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-        method CreateAwsKmsMrkKeyring(input: CreateAwsKmsMrkKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-        method CreateAwsKmsMrkMultiKeyring(input: CreateAwsKmsMrkMultiKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-        method CreateAwsKmsMrkDiscoveryKeyring(input: CreateAwsKmsMrkDiscoveryKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-        method CreateAwsKmsMrkDiscoveryMultiKeyring(input: CreateAwsKmsMrkDiscoveryMultiKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-        method CreateMultiKeyring(input: CreateMultiKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-        method CreateRawAesKeyring(input: CreateRawAesKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-        method CreateRawRsaKeyring(input: CreateRawRsaKeyringInput)
-            returns (res: Result<IKeyring, IAwsCryptographicMaterialProvidersException>)
-
-        // CMMs
-        method CreateDefaultCryptographicMaterialsManager(input: CreateDefaultCryptographicMaterialsManagerInput)
-            returns (res: Result<ICryptographicMaterialsManager, IAwsCryptographicMaterialProvidersException>)
-
-        // Client Supplier
-        method CreateDefaultClientSupplier(input: CreateDefaultClientSupplierInput)
-          returns (res: Result<IClientSupplier, IAwsCryptographicMaterialProvidersException>)
-    }
-
-    trait IAwsCryptographicMaterialProvidersException {
-        function method GetMessage(): (message: string)
-            reads this
-    }
-
-    class AwsCryptographicMaterialProvidersBaseException extends IAwsCryptographicMaterialProvidersException {
-        var message: string
-
-        constructor (message: string) {
-            this.message := message;
-        }
-
-        function method GetMessage(): (message: string)
-            reads this
-        {
-            this.message
-        }
-    }
-
-    class AwsCryptographicMaterialProvidersException extends IAwsCryptographicMaterialProvidersException {
-        var message: string
-
-        constructor (message: string) {
-            this.message := message;
-        }
-
-        function method GetMessage(): (message: string)
-            reads this
-        {
-            this.message
-        }
-
-        static method WrapResultString<T>(result: Result<T, string>)
-            returns (wrapped: Result<T, IAwsCryptographicMaterialProvidersException>)
-            ensures result.Success? ==>
+    static method WrapResultString<T>(result: Result<T, string>)
+      returns (wrapped: Result<T, IAwsCryptographicMaterialProvidersException>)
+      ensures result.Success? ==>
                 && wrapped.Success?
                 && wrapped.value == result.value
-            ensures result.Failure? ==>
+      ensures result.Failure? ==>
                 && wrapped.Failure?
-        {
-            match result {
-                case Success(value) => return Result.Success(value);
-                case Failure(error) =>
-                    var wrappedError := new AwsCryptographicMaterialProvidersException(error);
-                    return Result.Failure(wrappedError);
-            }
-        }
-
-        static method WrapOutcomeString(outcome: Outcome<string>)
-          returns (wrapped: Outcome<IAwsCryptographicMaterialProvidersException>)
-          ensures outcome.Fail? ==> && wrapped.Fail?
-        {
-          match outcome {
-            case Pass => return Pass;
-            case Fail(error) =>
-              var wrappedError := new AwsCryptographicMaterialProvidersException(error);
-              return Outcome.Fail(wrappedError);
-          }
-        }
-    }
-
-    // A helper method to ensure a requirement is true at runtime.
-    // If the requirement is false, the returned result contains a generic exception that wraps the provided message.
-    // :- Need(5 == |mySet|, "The set MUST have 5 elements.")
-    //
-    // This is like `Wrappers.Need<E>`, except:
-    //
-    //   - `E` is specialized to be IAwsCryptographicMaterialProvidersException,
-    //     and the error string is wrapped in a class implementing that trait
-    //   - it's a `method` and not a `function method`, because we must instantiate a `new`
-    //     error object and that is not permitted in ghost contexts
-    method Need(condition: bool, error: string)
-        returns (result: Outcome<IAwsCryptographicMaterialProvidersException>)
-        ensures condition <==> result.Pass?
     {
-        if condition {
-            return Pass;
-        } else {
-            var exception := new AwsCryptographicMaterialProvidersException(error);
-            return Fail(exception);
-        }
+      match result {
+        case Success(value) => return Result.Success(value);
+        case Failure(error) =>
+          var wrappedError := new AwsCryptographicMaterialProvidersException(error);
+          return Result.Failure(wrappedError);
+      }
     }
+
+    static method WrapOutcomeString(outcome: Outcome<string>)
+      returns (wrapped: Outcome<IAwsCryptographicMaterialProvidersException>)
+      ensures outcome.Fail? ==> && wrapped.Fail?
+    {
+      match outcome {
+        case Pass => return Pass;
+        case Fail(error) =>
+          var wrappedError := new AwsCryptographicMaterialProvidersException(error);
+          return Outcome.Fail(wrappedError);
+      }
+    }
+  }
+
+  // A helper method to ensure a requirement is true at runtime.
+  // If the requirement is false, the returned result contains a generic exception that wraps the provided message.
+  // :- Need(5 == |mySet|, "The set MUST have 5 elements.")
+  //
+  // This is like `Wrappers.Need<E>`, except:
+  //
+  //   - `E` is specialized to be IAwsCryptographicMaterialProvidersException,
+  //     and the error string is wrapped in a class implementing that trait
+  //   - it's a `method` and not a `function method`, because we must instantiate a `new`
+  //     error object and that is not permitted in ghost contexts
+  method Need(condition: bool, error: string)
+    returns (result: Outcome<IAwsCryptographicMaterialProvidersException>)
+    ensures condition <==> result.Pass?
+  {
+    if condition {
+      return Pass;
+    } else {
+      var exception := new AwsCryptographicMaterialProvidersException(error);
+      return Fail(exception);
+    }
+  }
 }

--- a/src/Generated/AwsCryptographicMaterialProviders.dfy
+++ b/src/Generated/AwsCryptographicMaterialProviders.dfy
@@ -226,26 +226,26 @@ module {:extern "Dafny.Aws.EncryptionSdk.Core"} Aws.Crypto {
   //////////////
   // cmms.smithy
   datatype GetEncryptionMaterialsInput = GetEncryptionMaterialsInput(
-                                           nameonly encryptionContext: EncryptionContext,
-                                           nameonly commitmentPolicy: CommitmentPolicy,
-                                           nameonly algorithmSuiteId: Option<AlgorithmSuiteId>,
-                                           nameonly maxPlaintextLength: Option<int64>
-                                         )
+    nameonly encryptionContext: EncryptionContext,
+    nameonly commitmentPolicy: CommitmentPolicy,
+    nameonly algorithmSuiteId: Option<AlgorithmSuiteId>,
+    nameonly maxPlaintextLength: Option<int64>
+  )
 
   datatype GetEncryptionMaterialsOutput = GetEncryptionMaterialsOutput(
-                                            nameonly encryptionMaterials: EncryptionMaterials
-                                          )
+    nameonly encryptionMaterials: EncryptionMaterials
+  )
 
   datatype DecryptMaterialsInput = DecryptMaterialsInput(
-                                     nameonly algorithmSuiteId: AlgorithmSuiteId,
-                                     nameonly commitmentPolicy: CommitmentPolicy,
-                                     nameonly encryptedDataKeys: EncryptedDataKeyList,
-                                     nameonly encryptionContext: EncryptionContext
-                                   )
+    nameonly algorithmSuiteId: AlgorithmSuiteId,
+    nameonly commitmentPolicy: CommitmentPolicy,
+    nameonly encryptedDataKeys: EncryptedDataKeyList,
+    nameonly encryptionContext: EncryptionContext
+  )
 
   datatype DecryptMaterialsOutput = DecryptMaterialsOutput(
-                                      nameonly decryptionMaterials: DecryptionMaterials
-                                    )
+    nameonly decryptionMaterials: DecryptionMaterials
+  )
 
   trait {:termination false} ICryptographicMaterialsManager {
     method GetEncryptionMaterials(input: GetEncryptionMaterialsInput)
@@ -258,90 +258,90 @@ module {:extern "Dafny.Aws.EncryptionSdk.Core"} Aws.Crypto {
 
   // KMS
   datatype CreateAwsKmsKeyringInput = CreateAwsKmsKeyringInput(
-                                        nameonly kmsKeyId: KmsKeyId,
-                                        nameonly kmsClient: KMS.IKeyManagementServiceClient,
-                                        nameonly grantTokens: Option<GrantTokenList>
-                                      )
+    nameonly kmsKeyId: KmsKeyId,
+    nameonly kmsClient: KMS.IKeyManagementServiceClient,
+    nameonly grantTokens: Option<GrantTokenList>
+  )
 
   datatype CreateAwsKmsMultiKeyringInput = CreateAwsKmsMultiKeyringInput(
-                                             nameonly generator: Option<KmsKeyId>,
-                                             nameonly kmsKeyIds: Option<KmsKeyIdList>,
-                                             nameonly clientSupplier: Option<IClientSupplier>,
-                                             nameonly grantTokens: Option<GrantTokenList>
-                                           )
+    nameonly generator: Option<KmsKeyId>,
+    nameonly kmsKeyIds: Option<KmsKeyIdList>,
+    nameonly clientSupplier: Option<IClientSupplier>,
+    nameonly grantTokens: Option<GrantTokenList>
+  )
 
   // KMS - Discovery
   datatype CreateAwsKmsDiscoveryKeyringInput = CreateAwsKmsDiscoveryKeyringInput(
-                                                 nameonly kmsClient: KMS.IKeyManagementServiceClient,
-                                                 nameonly discoveryFilter: Option<DiscoveryFilter>,
-                                                 grantTokens: Option<GrantTokenList>
-                                               )
+    nameonly kmsClient: KMS.IKeyManagementServiceClient,
+    nameonly discoveryFilter: Option<DiscoveryFilter>,
+    grantTokens: Option<GrantTokenList>
+  )
 
   datatype CreateAwsKmsDiscoveryMultiKeyringInput = CreateAwsKmsDiscoveryMultiKeyringInput(
-                                                      nameonly regions: RegionList,
-                                                      nameonly discoveryFilter: Option<DiscoveryFilter>,
-                                                      nameonly clientSupplier: Option<IClientSupplier>,
-                                                      nameonly grantTokens: Option<GrantTokenList>
-                                                    )
+    nameonly regions: RegionList,
+    nameonly discoveryFilter: Option<DiscoveryFilter>,
+    nameonly clientSupplier: Option<IClientSupplier>,
+    nameonly grantTokens: Option<GrantTokenList>
+  )
 
 
   // KMS - MRK Aware, Strict
   datatype CreateAwsKmsMrkKeyringInput = CreateAwsKmsMrkKeyringInput(
-                                           nameonly kmsKeyId: KmsKeyId,
-                                           nameonly kmsClient: KMS.IKeyManagementServiceClient,
-                                           nameonly grantTokens: Option<GrantTokenList>
-                                         )
+    nameonly kmsKeyId: KmsKeyId,
+    nameonly kmsClient: KMS.IKeyManagementServiceClient,
+    nameonly grantTokens: Option<GrantTokenList>
+  )
 
   datatype CreateAwsKmsMrkMultiKeyringInput = CreateAwsKmsMrkMultiKeyringInput(
-                                                nameonly generator: Option<KmsKeyId>,
-                                                nameonly kmsKeyIds: Option<KmsKeyIdList>,
-                                                nameonly clientSupplier: Option<IClientSupplier>,
-                                                nameonly grantTokens: Option<GrantTokenList>
-                                              )
+    nameonly generator: Option<KmsKeyId>,
+    nameonly kmsKeyIds: Option<KmsKeyIdList>,
+    nameonly clientSupplier: Option<IClientSupplier>,
+    nameonly grantTokens: Option<GrantTokenList>
+  )
 
   // KMS - MRK Aware, Discovery
   datatype CreateAwsKmsMrkDiscoveryKeyringInput = CreateAwsKmsMrkDiscoveryKeyringInput(
-                                                    nameonly kmsClient: KMS.IKeyManagementServiceClient,
-                                                    nameonly discoveryFilter: Option<DiscoveryFilter>,
-                                                    nameonly grantTokens: Option<GrantTokenList>,
-                                                    nameonly region: string
-                                                  )
+    nameonly kmsClient: KMS.IKeyManagementServiceClient,
+    nameonly discoveryFilter: Option<DiscoveryFilter>,
+    nameonly grantTokens: Option<GrantTokenList>,
+    nameonly region: string
+  )
 
   datatype CreateAwsKmsMrkDiscoveryMultiKeyringInput = CreateAwsKmsMrkDiscoveryMultiKeyringInput(
-                                                         nameonly regions: RegionList,
-                                                         nameonly discoveryFilter: Option<DiscoveryFilter>,
-                                                         nameonly clientSupplier: Option<IClientSupplier>,
-                                                         nameonly grantTokens: Option<GrantTokenList>
-                                                       )
+    nameonly regions: RegionList,
+    nameonly discoveryFilter: Option<DiscoveryFilter>,
+    nameonly clientSupplier: Option<IClientSupplier>,
+    nameonly grantTokens: Option<GrantTokenList>
+  )
 
   // Multi
   datatype CreateMultiKeyringInput = CreateMultiKeyringInput(
-                                       nameonly generator: Option<IKeyring>,
-                                       nameonly childKeyrings: seq<IKeyring>
-                                     )
+    nameonly generator: Option<IKeyring>,
+    nameonly childKeyrings: seq<IKeyring>
+  )
 
   // Raw Keyrings
   datatype CreateRawAesKeyringInput = CreateRawAesKeyringInput(
-                                        nameonly keyNamespace: string,
-                                        nameonly keyName: string,
-                                        nameonly wrappingKey: seq<uint8>,
-                                        // TODO update spec with wrappingAlg input to Raw AES Keyring init
-                                        nameonly wrappingAlg: AesWrappingAlg
-                                      )
+    nameonly keyNamespace: string,
+    nameonly keyName: string,
+    nameonly wrappingKey: seq<uint8>,
+    // TODO update spec with wrappingAlg input to Raw AES Keyring init
+    nameonly wrappingAlg: AesWrappingAlg
+  )
 
   datatype CreateRawRsaKeyringInput = CreateRawRsaKeyringInput(
-                                        nameonly keyNamespace: string,
-                                        nameonly keyName: string,
-                                        nameonly paddingScheme: PaddingScheme,
-                                        nameonly publicKey: Option<seq<uint8>>,
-                                        nameonly privateKey: Option<seq<uint8>>
-                                      )
+    nameonly keyNamespace: string,
+    nameonly keyName: string,
+    nameonly paddingScheme: PaddingScheme,
+    nameonly publicKey: Option<seq<uint8>>,
+    nameonly privateKey: Option<seq<uint8>>
+  )
 
   // CMM Creation input structures
 
   datatype CreateDefaultCryptographicMaterialsManagerInput = CreateDefaultCryptographicMaterialsManagerInput(
-                                                               nameonly keyring: IKeyring
-                                                             )
+    nameonly keyring: IKeyring
+  )
 
   trait {:termination false} IAwsCryptographicMaterialProvidersFactory {
     method CreateDefaultAwsCryptographicMaterialProviders()

--- a/src/Generated/AwsEncryptionSdk.dfy
+++ b/src/Generated/AwsEncryptionSdk.dfy
@@ -6,158 +6,158 @@ include "../StandardLibrary/StandardLibrary.dfy"
 include "AwsCryptographicMaterialProviders.dfy"
 
 module {:extern "Dafny.Aws.EncryptionSdk"} Aws.Esdk {
-    import Crypto
-    import opened UInt = StandardLibrary.UInt
-    import opened Wrappers
+  import Crypto
+  import opened UInt = StandardLibrary.UInt
+  import opened Wrappers
 
-    // TODO: All annotations in this file should probably eventually go on
-    // the smithy model, since that's the authority and this code will be
-    // auto-generated
+  // TODO: All annotations in this file should probably eventually go on
+  // the smithy model, since that's the authority and this code will be
+  // auto-generated
 
-    datatype EncryptInput = EncryptInput(
-        //= compliance/client-apis/encrypt.txt#2.4
-        //= type=implication
-        //# The following inputs to this behavior are REQUIRED:
-        //# *  Plaintext (Section 2.4.1)
+  datatype EncryptInput = EncryptInput(
+                            //= compliance/client-apis/encrypt.txt#2.4
+                            //= type=implication
+                            //# The following inputs to this behavior are REQUIRED:
+                            //# *  Plaintext (Section 2.4.1)
 
-        //= compliance/client-apis/encrypt.txt#2.4.1
-        //= type=implication
-        //# This MUST be a sequence of bytes.
-        nameonly plaintext: seq<uint8>,
-        nameonly encryptionContext: Option<Crypto.EncryptionContext>,
-        nameonly materialsManager: Option<Crypto.ICryptographicMaterialsManager>,
-        nameonly keyring: Option<Crypto.IKeyring>,
+                            //= compliance/client-apis/encrypt.txt#2.4.1
+                            //= type=implication
+                            //# This MUST be a sequence of bytes.
+                            nameonly plaintext: seq<uint8>,
+                            nameonly encryptionContext: Option<Crypto.EncryptionContext>,
+                            nameonly materialsManager: Option<Crypto.ICryptographicMaterialsManager>,
+                            nameonly keyring: Option<Crypto.IKeyring>,
 
-        //= compliance/client-apis/encrypt.txt#2.4
-        //# The following inputs to this behavior MUST be OPTIONAL:
-        //# *  Algorithm Suite (Section 2.4.5)
-        //# *  Encryption Context (Section 2.4.2)
-        //# *  Frame Length (Section 2.4.6)
-        nameonly algorithmSuiteId: Option<Crypto.AlgorithmSuiteId>,
-        nameonly frameLength: Option<int64>
-    )
+                            //= compliance/client-apis/encrypt.txt#2.4
+                            //# The following inputs to this behavior MUST be OPTIONAL:
+                            //# *  Algorithm Suite (Section 2.4.5)
+                            //# *  Encryption Context (Section 2.4.2)
+                            //# *  Frame Length (Section 2.4.6)
+                            nameonly algorithmSuiteId: Option<Crypto.AlgorithmSuiteId>,
+                            nameonly frameLength: Option<int64>
+                          )
 
-    datatype EncryptOutput = EncryptOutput(
-        //= compliance/client-apis/encrypt.txt#2.5.1
-        //# This MUST
-        //# be a sequence of bytes and conform to the message format
-        //# specification (../data-format/message.md).
-        nameonly ciphertext: seq<uint8>,
-        nameonly encryptionContext: Crypto.EncryptionContext,
-        nameonly algorithmSuiteId: Crypto.AlgorithmSuiteId
-    )
+  datatype EncryptOutput = EncryptOutput(
+                             //= compliance/client-apis/encrypt.txt#2.5.1
+                             //# This MUST
+                             //# be a sequence of bytes and conform to the message format
+                             //# specification (../data-format/message.md).
+                             nameonly ciphertext: seq<uint8>,
+                             nameonly encryptionContext: Crypto.EncryptionContext,
+                             nameonly algorithmSuiteId: Crypto.AlgorithmSuiteId
+                           )
 
-    //= compliance/client-apis/decrypt.txt#2.5
-    //= type=implication
-    //# The client MUST require the following as inputs to this operation:
-    //#*  Encrypted Message (Section 2.5.1)
+  //= compliance/client-apis/decrypt.txt#2.5
+  //= type=implication
+  //# The client MUST require the following as inputs to this operation:
+  //#*  Encrypted Message (Section 2.5.1)
 
-    //= compliance/client-apis/decrypt.txt#2.5.1
-    //= type=implication
-    //# The input encrypted message MUST
-    //# be a sequence of bytes in the message format (../data-format/
-    //# message.md) specified by the AWS Encryption SDK.
-    // The above is a little silly. We do not validate that input is
-    // an ESDK message, but fail to Decrypt if it is not.
-    // TODO: Update Spec accordingly
-    datatype DecryptInput = DecryptInput(
-        nameonly ciphertext: seq<uint8>,
-        nameonly materialsManager: Option<Crypto.ICryptographicMaterialsManager>,
-        nameonly keyring: Option<Crypto.IKeyring>
-    )
+  //= compliance/client-apis/decrypt.txt#2.5.1
+  //= type=implication
+  //# The input encrypted message MUST
+  //# be a sequence of bytes in the message format (../data-format/
+  //# message.md) specified by the AWS Encryption SDK.
+  // The above is a little silly. We do not validate that input is
+  // an ESDK message, but fail to Decrypt if it is not.
+  // TODO: Update Spec accordingly
+  datatype DecryptInput = DecryptInput(
+                            nameonly ciphertext: seq<uint8>,
+                            nameonly materialsManager: Option<Crypto.ICryptographicMaterialsManager>,
+                            nameonly keyring: Option<Crypto.IKeyring>
+                          )
 
-    //= compliance/client-apis/decrypt.txt#2.6
-    //= type=implication
-    //# The client MUST return as output to this operation:
-    //#*  Section 2.6.1
-    //#*  Encryption Context (Section 2.6.2)
-    //#*  Algorithm Suite (Section 2.6.3)
+  //= compliance/client-apis/decrypt.txt#2.6
+  //= type=implication
+  //# The client MUST return as output to this operation:
+  //#*  Section 2.6.1
+  //#*  Encryption Context (Section 2.6.2)
+  //#*  Algorithm Suite (Section 2.6.3)
 
-    //= compliance/client-apis/decrypt.txt#2.6.2
-    //= type=exception
-    //# This output MAY be satisfied by outputting a parsed header
-    //# (Section 2.6.4) containing this value.
-    // Where This is the Encryption Context. We do not return
-    // a Parsed Header, but we do return the Encryption Context
+  //= compliance/client-apis/decrypt.txt#2.6.2
+  //= type=exception
+  //# This output MAY be satisfied by outputting a parsed header
+  //# (Section 2.6.4) containing this value.
+  // Where This is the Encryption Context. We do not return
+  // a Parsed Header, but we do return the Encryption Context
 
-    //= compliance/client-apis/decrypt.txt#2.6.3
-    //= type=exception
-    //# This output MAY be satisfied by outputting a parsed header
-    //# (Section 2.6.4) containing this value.
-    // Where This is the Algorithm Suite. We do not return
-    // a Parsed Header, but we do return the Algorithm Suite
-    
-    //= compliance/client-apis/decrypt.txt#2.6
-    //= type=exception
-    //# The client SHOULD return as an output:
-    //#*  Parsed Header (Section 2.6.4)
-    datatype DecryptOutput = DecryptOutput(
-        nameonly plaintext: seq<uint8>,
-        nameonly encryptionContext: Crypto.EncryptionContext,
-        nameonly algorithmSuiteId: Crypto.AlgorithmSuiteId
-    )
+  //= compliance/client-apis/decrypt.txt#2.6.3
+  //= type=exception
+  //# This output MAY be satisfied by outputting a parsed header
+  //# (Section 2.6.4) containing this value.
+  // Where This is the Algorithm Suite. We do not return
+  // a Parsed Header, but we do return the Algorithm Suite
 
-    datatype AwsEncryptionSdkConfig = AwsEncryptionSdkConfig(
-        nameonly commitmentPolicy: Option<Crypto.CommitmentPolicy>,
-        nameonly maxEncryptedDataKeys: Option<int64>
-    )
+  //= compliance/client-apis/decrypt.txt#2.6
+  //= type=exception
+  //# The client SHOULD return as an output:
+  //#*  Parsed Header (Section 2.6.4)
+  datatype DecryptOutput = DecryptOutput(
+                             nameonly plaintext: seq<uint8>,
+                             nameonly encryptionContext: Crypto.EncryptionContext,
+                             nameonly algorithmSuiteId: Crypto.AlgorithmSuiteId
+                           )
 
-    trait {:termination false} IAwsEncryptionSdkFactory {
-        method CreateAwsEncryptionSdk(input: AwsEncryptionSdkConfig) returns (res: Result<IAwsEncryptionSdk, IAwsEncryptionSdkException>)
-        method CreateDefaultAwsEncryptionSdk() returns (res: Result<IAwsEncryptionSdk, IAwsEncryptionSdkException>)
+  datatype AwsEncryptionSdkConfig = AwsEncryptionSdkConfig(
+                                      nameonly commitmentPolicy: Option<Crypto.CommitmentPolicy>,
+                                      nameonly maxEncryptedDataKeys: Option<int64>
+                                    )
+
+  trait {:termination false} IAwsEncryptionSdkFactory {
+    method CreateAwsEncryptionSdk(input: AwsEncryptionSdkConfig) returns (res: Result<IAwsEncryptionSdk, IAwsEncryptionSdkException>)
+    method CreateDefaultAwsEncryptionSdk() returns (res: Result<IAwsEncryptionSdk, IAwsEncryptionSdkException>)
+  }
+
+  trait {:termination false} IAwsEncryptionSdk {
+    method Encrypt(input: EncryptInput) returns (res: Result<EncryptOutput, IAwsEncryptionSdkException>)
+    method Decrypt(input: DecryptInput) returns (res: Result<DecryptOutput, IAwsEncryptionSdkException>)
+  }
+
+  trait IAwsEncryptionSdkException {
+    function method GetMessage(): (message: string)
+      reads this
+  }
+
+  class AwsEncryptionSdkBaseException extends IAwsEncryptionSdkException {
+    var message: string
+
+    constructor (message: string) {
+      this.message := message;
     }
 
-    trait {:termination false} IAwsEncryptionSdk {
-        method Encrypt(input: EncryptInput) returns (res: Result<EncryptOutput, IAwsEncryptionSdkException>)
-        method Decrypt(input: DecryptInput) returns (res: Result<DecryptOutput, IAwsEncryptionSdkException>)
+    function method GetMessage(): (message: string)
+      reads this
+    {
+      this.message
+    }
+  }
+
+  class AwsEncryptionSdkException extends IAwsEncryptionSdkException {
+    var message: string
+
+    constructor (message: string) {
+      this.message := message;
     }
 
-    trait IAwsEncryptionSdkException {
-        function method GetMessage(): (message: string)
-            reads this
+    function method GetMessage(): (message: string)
+      reads this
+    {
+      this.message
     }
 
-    class AwsEncryptionSdkBaseException extends IAwsEncryptionSdkException {
-        var message: string
-
-        constructor (message: string) {
-            this.message := message;
-        }
-
-        function method GetMessage(): (message: string)
-            reads this
-        {
-            this.message
-        }
-    }
-
-    class AwsEncryptionSdkException extends IAwsEncryptionSdkException {
-        var message: string
-
-        constructor (message: string) {
-            this.message := message;
-        }
-
-        function method GetMessage(): (message: string)
-            reads this
-        {
-            this.message
-        }
-
-        static method WrapResultString<T>(result: Result<T, string>)
-            returns (wrapped: Result<T, IAwsEncryptionSdkException>)
-            ensures result.Success? ==>
+    static method WrapResultString<T>(result: Result<T, string>)
+      returns (wrapped: Result<T, IAwsEncryptionSdkException>)
+      ensures result.Success? ==>
                 && wrapped.Success?
                 && wrapped.value == result.value
-            ensures result.Failure? ==>
+      ensures result.Failure? ==>
                 && wrapped.Failure?
-        {
-            match result {
-                case Success(value) => return Result.Success(value);
-                case Failure(error) =>
-                    var wrappedError := new AwsEncryptionSdkException(error);
-                    return Result.Failure(wrappedError);
-            }
-        }
+    {
+      match result {
+        case Success(value) => return Result.Success(value);
+        case Failure(error) =>
+          var wrappedError := new AwsEncryptionSdkException(error);
+          return Result.Failure(wrappedError);
+      }
     }
+  }
 }

--- a/src/Generated/AwsEncryptionSdk.dfy
+++ b/src/Generated/AwsEncryptionSdk.dfy
@@ -15,37 +15,37 @@ module {:extern "Dafny.Aws.EncryptionSdk"} Aws.Esdk {
   // auto-generated
 
   datatype EncryptInput = EncryptInput(
-                            //= compliance/client-apis/encrypt.txt#2.4
-                            //= type=implication
-                            //# The following inputs to this behavior are REQUIRED:
-                            //# *  Plaintext (Section 2.4.1)
+    //= compliance/client-apis/encrypt.txt#2.4
+    //= type=implication
+    //# The following inputs to this behavior are REQUIRED:
+    //# *  Plaintext (Section 2.4.1)
 
-                            //= compliance/client-apis/encrypt.txt#2.4.1
-                            //= type=implication
-                            //# This MUST be a sequence of bytes.
-                            nameonly plaintext: seq<uint8>,
-                            nameonly encryptionContext: Option<Crypto.EncryptionContext>,
-                            nameonly materialsManager: Option<Crypto.ICryptographicMaterialsManager>,
-                            nameonly keyring: Option<Crypto.IKeyring>,
+    //= compliance/client-apis/encrypt.txt#2.4.1
+    //= type=implication
+    //# This MUST be a sequence of bytes.
+    nameonly plaintext: seq<uint8>,
+    nameonly encryptionContext: Option<Crypto.EncryptionContext>,
+    nameonly materialsManager: Option<Crypto.ICryptographicMaterialsManager>,
+    nameonly keyring: Option<Crypto.IKeyring>,
 
-                            //= compliance/client-apis/encrypt.txt#2.4
-                            //# The following inputs to this behavior MUST be OPTIONAL:
-                            //# *  Algorithm Suite (Section 2.4.5)
-                            //# *  Encryption Context (Section 2.4.2)
-                            //# *  Frame Length (Section 2.4.6)
-                            nameonly algorithmSuiteId: Option<Crypto.AlgorithmSuiteId>,
-                            nameonly frameLength: Option<int64>
-                          )
+    //= compliance/client-apis/encrypt.txt#2.4
+    //# The following inputs to this behavior MUST be OPTIONAL:
+    //# *  Algorithm Suite (Section 2.4.5)
+    //# *  Encryption Context (Section 2.4.2)
+    //# *  Frame Length (Section 2.4.6)
+    nameonly algorithmSuiteId: Option<Crypto.AlgorithmSuiteId>,
+    nameonly frameLength: Option<int64>
+  )
 
   datatype EncryptOutput = EncryptOutput(
-                             //= compliance/client-apis/encrypt.txt#2.5.1
-                             //# This MUST
-                             //# be a sequence of bytes and conform to the message format
-                             //# specification (../data-format/message.md).
-                             nameonly ciphertext: seq<uint8>,
-                             nameonly encryptionContext: Crypto.EncryptionContext,
-                             nameonly algorithmSuiteId: Crypto.AlgorithmSuiteId
-                           )
+    //= compliance/client-apis/encrypt.txt#2.5.1
+    //# This MUST
+    //# be a sequence of bytes and conform to the message format
+    //# specification (../data-format/message.md).
+    nameonly ciphertext: seq<uint8>,
+    nameonly encryptionContext: Crypto.EncryptionContext,
+    nameonly algorithmSuiteId: Crypto.AlgorithmSuiteId
+  )
 
   //= compliance/client-apis/decrypt.txt#2.5
   //= type=implication
@@ -61,10 +61,10 @@ module {:extern "Dafny.Aws.EncryptionSdk"} Aws.Esdk {
   // an ESDK message, but fail to Decrypt if it is not.
   // TODO: Update Spec accordingly
   datatype DecryptInput = DecryptInput(
-                            nameonly ciphertext: seq<uint8>,
-                            nameonly materialsManager: Option<Crypto.ICryptographicMaterialsManager>,
-                            nameonly keyring: Option<Crypto.IKeyring>
-                          )
+    nameonly ciphertext: seq<uint8>,
+    nameonly materialsManager: Option<Crypto.ICryptographicMaterialsManager>,
+    nameonly keyring: Option<Crypto.IKeyring>
+  )
 
   //= compliance/client-apis/decrypt.txt#2.6
   //= type=implication
@@ -92,15 +92,15 @@ module {:extern "Dafny.Aws.EncryptionSdk"} Aws.Esdk {
   //# The client SHOULD return as an output:
   //#*  Parsed Header (Section 2.6.4)
   datatype DecryptOutput = DecryptOutput(
-                             nameonly plaintext: seq<uint8>,
-                             nameonly encryptionContext: Crypto.EncryptionContext,
-                             nameonly algorithmSuiteId: Crypto.AlgorithmSuiteId
-                           )
+    nameonly plaintext: seq<uint8>,
+    nameonly encryptionContext: Crypto.EncryptionContext,
+    nameonly algorithmSuiteId: Crypto.AlgorithmSuiteId
+  )
 
   datatype AwsEncryptionSdkConfig = AwsEncryptionSdkConfig(
-                                      nameonly commitmentPolicy: Option<Crypto.CommitmentPolicy>,
-                                      nameonly maxEncryptedDataKeys: Option<int64>
-                                    )
+    nameonly commitmentPolicy: Option<Crypto.CommitmentPolicy>,
+    nameonly maxEncryptedDataKeys: Option<int64>
+  )
 
   trait {:termination false} IAwsEncryptionSdkFactory {
     method CreateAwsEncryptionSdk(input: AwsEncryptionSdkConfig) returns (res: Result<IAwsEncryptionSdk, IAwsEncryptionSdkException>)

--- a/src/Generated/KeyManagementService.dfy
+++ b/src/Generated/KeyManagementService.dfy
@@ -13,11 +13,11 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
     | RSAES_OAEP_SHA_256
   type AliasList = seq<AliasListEntry>
   datatype AliasListEntry = AliasListEntry (
-                              nameonly AliasName: Option<AliasNameType> ,
-                              nameonly AliasArn: Option<ArnType> ,
-                              nameonly TargetKeyId: Option<KeyIdType> ,
-                              nameonly CreationDate: Option<string> ,
-                              nameonly LastUpdatedDate: Option<string> )
+    nameonly AliasName: Option<AliasNameType> ,
+    nameonly AliasArn: Option<ArnType> ,
+    nameonly TargetKeyId: Option<KeyIdType> ,
+    nameonly CreationDate: Option<string> ,
+    nameonly LastUpdatedDate: Option<string> )
   type AliasNameType = x: string | IsValid_AliasNameType(x) witness *
   predicate method IsValid_AliasNameType(x: string) {
     ( 1 <= |x| <= 256 )
@@ -43,9 +43,9 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
   type AWSAccountIdType = string
   type BooleanType = bool
   datatype CancelKeyDeletionRequest = CancelKeyDeletionRequest (
-                                        nameonly KeyId: KeyIdType )
+    nameonly KeyId: KeyIdType )
   datatype CancelKeyDeletionResponse = CancelKeyDeletionResponse (
-                                         nameonly KeyId: Option<KeyIdType> )
+    nameonly KeyId: Option<KeyIdType> )
   type CiphertextType = x: seq<uint8> | IsValid_CiphertextType(x) witness *
   predicate method IsValid_CiphertextType(x: seq<uint8>) {
     ( 1 <= |x| <= 6144 )
@@ -125,7 +125,7 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
   }
 
   datatype ConnectCustomKeyStoreRequest = ConnectCustomKeyStoreRequest (
-                                            nameonly CustomKeyStoreId: CustomKeyStoreIdType )
+    nameonly CustomKeyStoreId: CustomKeyStoreIdType )
   datatype ConnectCustomKeyStoreResponse = ConnectCustomKeyStoreResponse (  )
   datatype ConnectionErrorCodeType =
     | INVALID_CREDENTIALS
@@ -144,39 +144,39 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
     | DISCONNECTED
     | DISCONNECTING
   datatype CreateAliasRequest = CreateAliasRequest (
-                                  nameonly AliasName: AliasNameType ,
-                                  nameonly TargetKeyId: KeyIdType )
+    nameonly AliasName: AliasNameType ,
+    nameonly TargetKeyId: KeyIdType )
   datatype CreateCustomKeyStoreRequest = CreateCustomKeyStoreRequest (
-                                           nameonly CustomKeyStoreName: CustomKeyStoreNameType ,
-                                           nameonly CloudHsmClusterId: CloudHsmClusterIdType ,
-                                           nameonly TrustAnchorCertificate: TrustAnchorCertificateType ,
-                                           nameonly KeyStorePassword: KeyStorePasswordType )
+    nameonly CustomKeyStoreName: CustomKeyStoreNameType ,
+    nameonly CloudHsmClusterId: CloudHsmClusterIdType ,
+    nameonly TrustAnchorCertificate: TrustAnchorCertificateType ,
+    nameonly KeyStorePassword: KeyStorePasswordType )
   datatype CreateCustomKeyStoreResponse = CreateCustomKeyStoreResponse (
-                                            nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> )
+    nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> )
   datatype CreateGrantRequest = CreateGrantRequest (
-                                  nameonly KeyId: KeyIdType ,
-                                  nameonly GranteePrincipal: PrincipalIdType ,
-                                  nameonly RetiringPrincipal: Option<PrincipalIdType> ,
-                                  nameonly Operations: GrantOperationList ,
-                                  nameonly Constraints: Option<GrantConstraints> ,
-                                  nameonly GrantTokens: Option<GrantTokenList> ,
-                                  nameonly Name: Option<GrantNameType> )
+    nameonly KeyId: KeyIdType ,
+    nameonly GranteePrincipal: PrincipalIdType ,
+    nameonly RetiringPrincipal: Option<PrincipalIdType> ,
+    nameonly Operations: GrantOperationList ,
+    nameonly Constraints: Option<GrantConstraints> ,
+    nameonly GrantTokens: Option<GrantTokenList> ,
+    nameonly Name: Option<GrantNameType> )
   datatype CreateGrantResponse = CreateGrantResponse (
-                                   nameonly GrantToken: Option<GrantTokenType> ,
-                                   nameonly GrantId: Option<GrantIdType> )
+    nameonly GrantToken: Option<GrantTokenType> ,
+    nameonly GrantId: Option<GrantIdType> )
   datatype CreateKeyRequest = CreateKeyRequest (
-                                nameonly Policy: Option<PolicyType> ,
-                                nameonly Description: Option<DescriptionType> ,
-                                nameonly KeyUsage: Option<KeyUsageType> ,
-                                nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
-                                nameonly KeySpec: Option<KeySpec> ,
-                                nameonly Origin: Option<OriginType> ,
-                                nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
-                                nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> ,
-                                nameonly Tags: Option<TagList> ,
-                                nameonly MultiRegion: Option<NullableBooleanType> )
+    nameonly Policy: Option<PolicyType> ,
+    nameonly Description: Option<DescriptionType> ,
+    nameonly KeyUsage: Option<KeyUsageType> ,
+    nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
+    nameonly KeySpec: Option<KeySpec> ,
+    nameonly Origin: Option<OriginType> ,
+    nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
+    nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> ,
+    nameonly Tags: Option<TagList> ,
+    nameonly MultiRegion: Option<NullableBooleanType> )
   datatype CreateKeyResponse = CreateKeyResponse (
-                                 nameonly KeyMetadata: Option<KeyMetadata> )
+    nameonly KeyMetadata: Option<KeyMetadata> )
   datatype CustomerMasterKeySpec =
     | RSA_2048
     | RSA_3072
@@ -252,13 +252,13 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
 
   type CustomKeyStoresList = seq<CustomKeyStoresListEntry>
   datatype CustomKeyStoresListEntry = CustomKeyStoresListEntry (
-                                        nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
-                                        nameonly CustomKeyStoreName: Option<CustomKeyStoreNameType> ,
-                                        nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> ,
-                                        nameonly TrustAnchorCertificate: Option<TrustAnchorCertificateType> ,
-                                        nameonly ConnectionState: Option<ConnectionStateType> ,
-                                        nameonly ConnectionErrorCode: Option<ConnectionErrorCodeType> ,
-                                        nameonly CreationDate: Option<string> )
+    nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
+    nameonly CustomKeyStoreName: Option<CustomKeyStoreNameType> ,
+    nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> ,
+    nameonly TrustAnchorCertificate: Option<TrustAnchorCertificateType> ,
+    nameonly ConnectionState: Option<ConnectionStateType> ,
+    nameonly ConnectionErrorCode: Option<ConnectionErrorCodeType> ,
+    nameonly CreationDate: Option<string> )
   datatype DataKeyPairSpec =
     | RSA_2048
     | RSA_3072
@@ -271,22 +271,22 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
     | AES_256
     | AES_128
   datatype DecryptRequest = DecryptRequest (
-                              nameonly CiphertextBlob: CiphertextType ,
-                              nameonly EncryptionContext: Option<EncryptionContextType> ,
-                              nameonly GrantTokens: Option<GrantTokenList> ,
-                              nameonly KeyId: Option<KeyIdType> ,
-                              nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
+    nameonly CiphertextBlob: CiphertextType ,
+    nameonly EncryptionContext: Option<EncryptionContextType> ,
+    nameonly GrantTokens: Option<GrantTokenList> ,
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
   datatype DecryptResponse = DecryptResponse (
-                               nameonly KeyId: Option<KeyIdType> ,
-                               nameonly Plaintext: Option<PlaintextType> ,
-                               nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly Plaintext: Option<PlaintextType> ,
+    nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
   datatype DeleteAliasRequest = DeleteAliasRequest (
-                                  nameonly AliasName: AliasNameType )
+    nameonly AliasName: AliasNameType )
   datatype DeleteCustomKeyStoreRequest = DeleteCustomKeyStoreRequest (
-                                           nameonly CustomKeyStoreId: CustomKeyStoreIdType )
+    nameonly CustomKeyStoreId: CustomKeyStoreIdType )
   datatype DeleteCustomKeyStoreResponse = DeleteCustomKeyStoreResponse (  )
   datatype DeleteImportedKeyMaterialRequest = DeleteImportedKeyMaterialRequest (
-                                                nameonly KeyId: KeyIdType )
+    nameonly KeyId: KeyIdType )
   class DependencyTimeoutException extends IKeyManagementServiceException {
     var message: string
 
@@ -302,19 +302,19 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
   }
 
   datatype DescribeCustomKeyStoresRequest = DescribeCustomKeyStoresRequest (
-                                              nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
-                                              nameonly CustomKeyStoreName: Option<CustomKeyStoreNameType> ,
-                                              nameonly Limit: Option<LimitType> ,
-                                              nameonly Marker: Option<MarkerType> )
+    nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
+    nameonly CustomKeyStoreName: Option<CustomKeyStoreNameType> ,
+    nameonly Limit: Option<LimitType> ,
+    nameonly Marker: Option<MarkerType> )
   datatype DescribeCustomKeyStoresResponse = DescribeCustomKeyStoresResponse (
-                                               nameonly CustomKeyStores: Option<CustomKeyStoresList> ,
-                                               nameonly NextMarker: Option<MarkerType> ,
-                                               nameonly Truncated: Option<BooleanType> )
+    nameonly CustomKeyStores: Option<CustomKeyStoresList> ,
+    nameonly NextMarker: Option<MarkerType> ,
+    nameonly Truncated: Option<BooleanType> )
   datatype DescribeKeyRequest = DescribeKeyRequest (
-                                  nameonly KeyId: KeyIdType ,
-                                  nameonly GrantTokens: Option<GrantTokenList> )
+    nameonly KeyId: KeyIdType ,
+    nameonly GrantTokens: Option<GrantTokenList> )
   datatype DescribeKeyResponse = DescribeKeyResponse (
-                                   nameonly KeyMetadata: Option<KeyMetadata> )
+    nameonly KeyMetadata: Option<KeyMetadata> )
   type DescriptionType = x: string | IsValid_DescriptionType(x) witness *
   predicate method IsValid_DescriptionType(x: string) {
     ( 0 <= |x| <= 8192 )
@@ -334,16 +334,16 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
   }
 
   datatype DisableKeyRequest = DisableKeyRequest (
-                                 nameonly KeyId: KeyIdType )
+    nameonly KeyId: KeyIdType )
   datatype DisableKeyRotationRequest = DisableKeyRotationRequest (
-                                         nameonly KeyId: KeyIdType )
+    nameonly KeyId: KeyIdType )
   datatype DisconnectCustomKeyStoreRequest = DisconnectCustomKeyStoreRequest (
-                                               nameonly CustomKeyStoreId: CustomKeyStoreIdType )
+    nameonly CustomKeyStoreId: CustomKeyStoreIdType )
   datatype DisconnectCustomKeyStoreResponse = DisconnectCustomKeyStoreResponse (  )
   datatype EnableKeyRequest = EnableKeyRequest (
-                                nameonly KeyId: KeyIdType )
+    nameonly KeyId: KeyIdType )
   datatype EnableKeyRotationRequest = EnableKeyRotationRequest (
-                                        nameonly KeyId: KeyIdType )
+    nameonly KeyId: KeyIdType )
   datatype EncryptionAlgorithmSpec =
     | SYMMETRIC_DEFAULT
     | RSAES_OAEP_SHA_1
@@ -353,15 +353,15 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
   type EncryptionContextType = map<EncryptionContextKey, EncryptionContextValue>
   type EncryptionContextValue = string
   datatype EncryptRequest = EncryptRequest (
-                              nameonly KeyId: KeyIdType ,
-                              nameonly Plaintext: PlaintextType ,
-                              nameonly EncryptionContext: Option<EncryptionContextType> ,
-                              nameonly GrantTokens: Option<GrantTokenList> ,
-                              nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
+    nameonly KeyId: KeyIdType ,
+    nameonly Plaintext: PlaintextType ,
+    nameonly EncryptionContext: Option<EncryptionContextType> ,
+    nameonly GrantTokens: Option<GrantTokenList> ,
+    nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
   datatype EncryptResponse = EncryptResponse (
-                               nameonly CiphertextBlob: Option<CiphertextType> ,
-                               nameonly KeyId: Option<KeyIdType> ,
-                               nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
+    nameonly CiphertextBlob: Option<CiphertextType> ,
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
   type ErrorMessageType = string
   datatype ExpirationModelType =
     | KEY_MATERIAL_EXPIRES
@@ -381,97 +381,97 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
   }
 
   datatype GenerateDataKeyPairRequest = GenerateDataKeyPairRequest (
-                                          nameonly EncryptionContext: Option<EncryptionContextType> ,
-                                          nameonly KeyId: KeyIdType ,
-                                          nameonly KeyPairSpec: DataKeyPairSpec ,
-                                          nameonly GrantTokens: Option<GrantTokenList> )
+    nameonly EncryptionContext: Option<EncryptionContextType> ,
+    nameonly KeyId: KeyIdType ,
+    nameonly KeyPairSpec: DataKeyPairSpec ,
+    nameonly GrantTokens: Option<GrantTokenList> )
   datatype GenerateDataKeyPairResponse = GenerateDataKeyPairResponse (
-                                           nameonly PrivateKeyCiphertextBlob: Option<CiphertextType> ,
-                                           nameonly PrivateKeyPlaintext: Option<PlaintextType> ,
-                                           nameonly PublicKey: Option<PublicKeyType> ,
-                                           nameonly KeyId: Option<KeyIdType> ,
-                                           nameonly KeyPairSpec: Option<DataKeyPairSpec> )
+    nameonly PrivateKeyCiphertextBlob: Option<CiphertextType> ,
+    nameonly PrivateKeyPlaintext: Option<PlaintextType> ,
+    nameonly PublicKey: Option<PublicKeyType> ,
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly KeyPairSpec: Option<DataKeyPairSpec> )
   datatype GenerateDataKeyPairWithoutPlaintextRequest = GenerateDataKeyPairWithoutPlaintextRequest (
-                                                          nameonly EncryptionContext: Option<EncryptionContextType> ,
-                                                          nameonly KeyId: KeyIdType ,
-                                                          nameonly KeyPairSpec: DataKeyPairSpec ,
-                                                          nameonly GrantTokens: Option<GrantTokenList> )
+    nameonly EncryptionContext: Option<EncryptionContextType> ,
+    nameonly KeyId: KeyIdType ,
+    nameonly KeyPairSpec: DataKeyPairSpec ,
+    nameonly GrantTokens: Option<GrantTokenList> )
   datatype GenerateDataKeyPairWithoutPlaintextResponse = GenerateDataKeyPairWithoutPlaintextResponse (
-                                                           nameonly PrivateKeyCiphertextBlob: Option<CiphertextType> ,
-                                                           nameonly PublicKey: Option<PublicKeyType> ,
-                                                           nameonly KeyId: Option<KeyIdType> ,
-                                                           nameonly KeyPairSpec: Option<DataKeyPairSpec> )
+    nameonly PrivateKeyCiphertextBlob: Option<CiphertextType> ,
+    nameonly PublicKey: Option<PublicKeyType> ,
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly KeyPairSpec: Option<DataKeyPairSpec> )
   datatype GenerateDataKeyRequest = GenerateDataKeyRequest (
-                                      nameonly KeyId: KeyIdType ,
-                                      nameonly EncryptionContext: Option<EncryptionContextType> ,
-                                      nameonly NumberOfBytes: Option<NumberOfBytesType> ,
-                                      nameonly KeySpec: Option<DataKeySpec> ,
-                                      nameonly GrantTokens: Option<GrantTokenList> )
+    nameonly KeyId: KeyIdType ,
+    nameonly EncryptionContext: Option<EncryptionContextType> ,
+    nameonly NumberOfBytes: Option<NumberOfBytesType> ,
+    nameonly KeySpec: Option<DataKeySpec> ,
+    nameonly GrantTokens: Option<GrantTokenList> )
   datatype GenerateDataKeyResponse = GenerateDataKeyResponse (
-                                       nameonly CiphertextBlob: Option<CiphertextType> ,
-                                       nameonly Plaintext: Option<PlaintextType> ,
-                                       nameonly KeyId: Option<KeyIdType> )
+    nameonly CiphertextBlob: Option<CiphertextType> ,
+    nameonly Plaintext: Option<PlaintextType> ,
+    nameonly KeyId: Option<KeyIdType> )
   datatype GenerateDataKeyWithoutPlaintextRequest = GenerateDataKeyWithoutPlaintextRequest (
-                                                      nameonly KeyId: KeyIdType ,
-                                                      nameonly EncryptionContext: Option<EncryptionContextType> ,
-                                                      nameonly KeySpec: Option<DataKeySpec> ,
-                                                      nameonly NumberOfBytes: Option<NumberOfBytesType> ,
-                                                      nameonly GrantTokens: Option<GrantTokenList> )
+    nameonly KeyId: KeyIdType ,
+    nameonly EncryptionContext: Option<EncryptionContextType> ,
+    nameonly KeySpec: Option<DataKeySpec> ,
+    nameonly NumberOfBytes: Option<NumberOfBytesType> ,
+    nameonly GrantTokens: Option<GrantTokenList> )
   datatype GenerateDataKeyWithoutPlaintextResponse = GenerateDataKeyWithoutPlaintextResponse (
-                                                       nameonly CiphertextBlob: Option<CiphertextType> ,
-                                                       nameonly KeyId: Option<KeyIdType> )
+    nameonly CiphertextBlob: Option<CiphertextType> ,
+    nameonly KeyId: Option<KeyIdType> )
   datatype GenerateRandomRequest = GenerateRandomRequest (
-                                     nameonly NumberOfBytes: Option<NumberOfBytesType> ,
-                                     nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> )
+    nameonly NumberOfBytes: Option<NumberOfBytesType> ,
+    nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> )
   datatype GenerateRandomResponse = GenerateRandomResponse (
-                                      nameonly Plaintext: Option<PlaintextType> )
+    nameonly Plaintext: Option<PlaintextType> )
   datatype GetKeyPolicyRequest = GetKeyPolicyRequest (
-                                   nameonly KeyId: KeyIdType ,
-                                   nameonly PolicyName: PolicyNameType )
+    nameonly KeyId: KeyIdType ,
+    nameonly PolicyName: PolicyNameType )
   datatype GetKeyPolicyResponse = GetKeyPolicyResponse (
-                                    nameonly Policy: Option<PolicyType> )
+    nameonly Policy: Option<PolicyType> )
   datatype GetKeyRotationStatusRequest = GetKeyRotationStatusRequest (
-                                           nameonly KeyId: KeyIdType )
+    nameonly KeyId: KeyIdType )
   datatype GetKeyRotationStatusResponse = GetKeyRotationStatusResponse (
-                                            nameonly KeyRotationEnabled: Option<BooleanType> )
+    nameonly KeyRotationEnabled: Option<BooleanType> )
   datatype GetParametersForImportRequest = GetParametersForImportRequest (
-                                             nameonly KeyId: KeyIdType ,
-                                             nameonly WrappingAlgorithm: AlgorithmSpec ,
-                                             nameonly WrappingKeySpec: WrappingKeySpec )
+    nameonly KeyId: KeyIdType ,
+    nameonly WrappingAlgorithm: AlgorithmSpec ,
+    nameonly WrappingKeySpec: WrappingKeySpec )
   datatype GetParametersForImportResponse = GetParametersForImportResponse (
-                                              nameonly KeyId: Option<KeyIdType> ,
-                                              nameonly ImportToken: Option<CiphertextType> ,
-                                              nameonly PublicKey: Option<PlaintextType> ,
-                                              nameonly ParametersValidTo: Option<string> )
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly ImportToken: Option<CiphertextType> ,
+    nameonly PublicKey: Option<PlaintextType> ,
+    nameonly ParametersValidTo: Option<string> )
   datatype GetPublicKeyRequest = GetPublicKeyRequest (
-                                   nameonly KeyId: KeyIdType ,
-                                   nameonly GrantTokens: Option<GrantTokenList> )
+    nameonly KeyId: KeyIdType ,
+    nameonly GrantTokens: Option<GrantTokenList> )
   datatype GetPublicKeyResponse = GetPublicKeyResponse (
-                                    nameonly KeyId: Option<KeyIdType> ,
-                                    nameonly PublicKey: Option<PublicKeyType> ,
-                                    nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
-                                    nameonly KeySpec: Option<KeySpec> ,
-                                    nameonly KeyUsage: Option<KeyUsageType> ,
-                                    nameonly EncryptionAlgorithms: Option<EncryptionAlgorithmSpecList> ,
-                                    nameonly SigningAlgorithms: Option<SigningAlgorithmSpecList> )
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly PublicKey: Option<PublicKeyType> ,
+    nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
+    nameonly KeySpec: Option<KeySpec> ,
+    nameonly KeyUsage: Option<KeyUsageType> ,
+    nameonly EncryptionAlgorithms: Option<EncryptionAlgorithmSpecList> ,
+    nameonly SigningAlgorithms: Option<SigningAlgorithmSpecList> )
   datatype GrantConstraints = GrantConstraints (
-                                nameonly EncryptionContextSubset: Option<EncryptionContextType> ,
-                                nameonly EncryptionContextEquals: Option<EncryptionContextType> )
+    nameonly EncryptionContextSubset: Option<EncryptionContextType> ,
+    nameonly EncryptionContextEquals: Option<EncryptionContextType> )
   type GrantIdType = x: string | IsValid_GrantIdType(x) witness *
   predicate method IsValid_GrantIdType(x: string) {
     ( 1 <= |x| <= 128 )
   }
   type GrantList = seq<GrantListEntry>
   datatype GrantListEntry = GrantListEntry (
-                              nameonly KeyId: Option<KeyIdType> ,
-                              nameonly GrantId: Option<GrantIdType> ,
-                              nameonly Name: Option<GrantNameType> ,
-                              nameonly CreationDate: Option<string> ,
-                              nameonly GranteePrincipal: Option<PrincipalIdType> ,
-                              nameonly RetiringPrincipal: Option<PrincipalIdType> ,
-                              nameonly IssuingAccount: Option<PrincipalIdType> ,
-                              nameonly Operations: Option<GrantOperationList> ,
-                              nameonly Constraints: Option<GrantConstraints> )
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly GrantId: Option<GrantIdType> ,
+    nameonly Name: Option<GrantNameType> ,
+    nameonly CreationDate: Option<string> ,
+    nameonly GranteePrincipal: Option<PrincipalIdType> ,
+    nameonly RetiringPrincipal: Option<PrincipalIdType> ,
+    nameonly IssuingAccount: Option<PrincipalIdType> ,
+    nameonly Operations: Option<GrantOperationList> ,
+    nameonly Constraints: Option<GrantConstraints> )
   type GrantNameType = x: string | IsValid_GrantNameType(x) witness *
   predicate method IsValid_GrantNameType(x: string) {
     ( 1 <= |x| <= 256 )
@@ -501,11 +501,11 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
     ( 1 <= |x| <= 8192 )
   }
   datatype ImportKeyMaterialRequest = ImportKeyMaterialRequest (
-                                        nameonly KeyId: KeyIdType ,
-                                        nameonly ImportToken: CiphertextType ,
-                                        nameonly EncryptedKeyMaterial: CiphertextType ,
-                                        nameonly ValidTo: Option<string> ,
-                                        nameonly ExpirationModel: Option<ExpirationModelType> )
+    nameonly KeyId: KeyIdType ,
+    nameonly ImportToken: CiphertextType ,
+    nameonly EncryptedKeyMaterial: CiphertextType ,
+    nameonly ValidTo: Option<string> ,
+    nameonly ExpirationModel: Option<ExpirationModelType> )
   datatype ImportKeyMaterialResponse = ImportKeyMaterialResponse (  )
   class IncorrectKeyException extends IKeyManagementServiceException {
     var message: string
@@ -667,8 +667,8 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
   }
   type KeyList = seq<KeyListEntry>
   datatype KeyListEntry = KeyListEntry (
-                            nameonly KeyId: Option<KeyIdType> ,
-                            nameonly KeyArn: Option<ArnType> )
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly KeyArn: Option<ArnType> )
   trait IKeyManagementServiceClient {
     predicate {:opaque} CancelKeyDeletionCalledWith ( input: CancelKeyDeletionRequest ) {true}
     predicate {:opaque} CancelKeyDeletionSucceededWith (  input: CancelKeyDeletionRequest , output: CancelKeyDeletionResponse ) {true}
@@ -969,28 +969,28 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
     | AWS
     | CUSTOMER
   datatype KeyMetadata = KeyMetadata (
-                           nameonly AWSAccountId: Option<AWSAccountIdType> ,
-                           nameonly KeyId: KeyIdType ,
-                           nameonly Arn: Option<ArnType> ,
-                           nameonly CreationDate: Option<string> ,
-                           nameonly Enabled: Option<BooleanType> ,
-                           nameonly Description: Option<DescriptionType> ,
-                           nameonly KeyUsage: Option<KeyUsageType> ,
-                           nameonly KeyState: Option<KeyState> ,
-                           nameonly DeletionDate: Option<string> ,
-                           nameonly ValidTo: Option<string> ,
-                           nameonly Origin: Option<OriginType> ,
-                           nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
-                           nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> ,
-                           nameonly ExpirationModel: Option<ExpirationModelType> ,
-                           nameonly KeyManager: Option<KeyManagerType> ,
-                           nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
-                           nameonly KeySpec: Option<KeySpec> ,
-                           nameonly EncryptionAlgorithms: Option<EncryptionAlgorithmSpecList> ,
-                           nameonly SigningAlgorithms: Option<SigningAlgorithmSpecList> ,
-                           nameonly MultiRegion: Option<NullableBooleanType> ,
-                           nameonly MultiRegionConfiguration: Option<MultiRegionConfiguration> ,
-                           nameonly PendingDeletionWindowInDays: Option<PendingWindowInDaysType> )
+    nameonly AWSAccountId: Option<AWSAccountIdType> ,
+    nameonly KeyId: KeyIdType ,
+    nameonly Arn: Option<ArnType> ,
+    nameonly CreationDate: Option<string> ,
+    nameonly Enabled: Option<BooleanType> ,
+    nameonly Description: Option<DescriptionType> ,
+    nameonly KeyUsage: Option<KeyUsageType> ,
+    nameonly KeyState: Option<KeyState> ,
+    nameonly DeletionDate: Option<string> ,
+    nameonly ValidTo: Option<string> ,
+    nameonly Origin: Option<OriginType> ,
+    nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
+    nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> ,
+    nameonly ExpirationModel: Option<ExpirationModelType> ,
+    nameonly KeyManager: Option<KeyManagerType> ,
+    nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
+    nameonly KeySpec: Option<KeySpec> ,
+    nameonly EncryptionAlgorithms: Option<EncryptionAlgorithmSpecList> ,
+    nameonly SigningAlgorithms: Option<SigningAlgorithmSpecList> ,
+    nameonly MultiRegion: Option<NullableBooleanType> ,
+    nameonly MultiRegionConfiguration: Option<MultiRegionConfiguration> ,
+    nameonly PendingDeletionWindowInDays: Option<PendingWindowInDaysType> )
   datatype KeySpec =
     | RSA_2048
     | RSA_3072
@@ -1091,46 +1091,46 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
     ( 1 <= x <= 1000 )
   }
   datatype ListAliasesRequest = ListAliasesRequest (
-                                  nameonly KeyId: Option<KeyIdType> ,
-                                  nameonly Limit: Option<LimitType> ,
-                                  nameonly Marker: Option<MarkerType> )
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly Limit: Option<LimitType> ,
+    nameonly Marker: Option<MarkerType> )
   datatype ListAliasesResponse = ListAliasesResponse (
-                                   nameonly Aliases: Option<AliasList> ,
-                                   nameonly NextMarker: Option<MarkerType> ,
-                                   nameonly Truncated: Option<BooleanType> )
+    nameonly Aliases: Option<AliasList> ,
+    nameonly NextMarker: Option<MarkerType> ,
+    nameonly Truncated: Option<BooleanType> )
   datatype ListGrantsRequest = ListGrantsRequest (
-                                 nameonly Limit: Option<LimitType> ,
-                                 nameonly Marker: Option<MarkerType> ,
-                                 nameonly KeyId: KeyIdType ,
-                                 nameonly GrantId: Option<GrantIdType> ,
-                                 nameonly GranteePrincipal: Option<PrincipalIdType> )
+    nameonly Limit: Option<LimitType> ,
+    nameonly Marker: Option<MarkerType> ,
+    nameonly KeyId: KeyIdType ,
+    nameonly GrantId: Option<GrantIdType> ,
+    nameonly GranteePrincipal: Option<PrincipalIdType> )
   datatype ListGrantsResponse = ListGrantsResponse (
-                                  nameonly Grants: Option<GrantList> ,
-                                  nameonly NextMarker: Option<MarkerType> ,
-                                  nameonly Truncated: Option<BooleanType> )
+    nameonly Grants: Option<GrantList> ,
+    nameonly NextMarker: Option<MarkerType> ,
+    nameonly Truncated: Option<BooleanType> )
   datatype ListKeyPoliciesRequest = ListKeyPoliciesRequest (
-                                      nameonly KeyId: KeyIdType ,
-                                      nameonly Limit: Option<LimitType> ,
-                                      nameonly Marker: Option<MarkerType> )
+    nameonly KeyId: KeyIdType ,
+    nameonly Limit: Option<LimitType> ,
+    nameonly Marker: Option<MarkerType> )
   datatype ListKeyPoliciesResponse = ListKeyPoliciesResponse (
-                                       nameonly PolicyNames: Option<PolicyNameList> ,
-                                       nameonly NextMarker: Option<MarkerType> ,
-                                       nameonly Truncated: Option<BooleanType> )
+    nameonly PolicyNames: Option<PolicyNameList> ,
+    nameonly NextMarker: Option<MarkerType> ,
+    nameonly Truncated: Option<BooleanType> )
   datatype ListKeysRequest = ListKeysRequest (
-                               nameonly Limit: Option<LimitType> ,
-                               nameonly Marker: Option<MarkerType> )
+    nameonly Limit: Option<LimitType> ,
+    nameonly Marker: Option<MarkerType> )
   datatype ListResourceTagsRequest = ListResourceTagsRequest (
-                                       nameonly KeyId: KeyIdType ,
-                                       nameonly Limit: Option<LimitType> ,
-                                       nameonly Marker: Option<MarkerType> )
+    nameonly KeyId: KeyIdType ,
+    nameonly Limit: Option<LimitType> ,
+    nameonly Marker: Option<MarkerType> )
   datatype ListResourceTagsResponse = ListResourceTagsResponse (
-                                        nameonly Tags: Option<TagList> ,
-                                        nameonly NextMarker: Option<MarkerType> ,
-                                        nameonly Truncated: Option<BooleanType> )
+    nameonly Tags: Option<TagList> ,
+    nameonly NextMarker: Option<MarkerType> ,
+    nameonly Truncated: Option<BooleanType> )
   datatype ListRetirableGrantsRequest = ListRetirableGrantsRequest (
-                                          nameonly Limit: Option<LimitType> ,
-                                          nameonly Marker: Option<MarkerType> ,
-                                          nameonly RetiringPrincipal: PrincipalIdType )
+    nameonly Limit: Option<LimitType> ,
+    nameonly Marker: Option<MarkerType> ,
+    nameonly RetiringPrincipal: PrincipalIdType )
   class MalformedPolicyDocumentException extends IKeyManagementServiceException {
     var message: string
 
@@ -1153,12 +1153,12 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
     | RAW
     | DIGEST
   datatype MultiRegionConfiguration = MultiRegionConfiguration (
-                                        nameonly MultiRegionKeyType: Option<MultiRegionKeyType> ,
-                                        nameonly PrimaryKey: Option<MultiRegionKey> ,
-                                        nameonly ReplicaKeys: Option<MultiRegionKeyList> )
+    nameonly MultiRegionKeyType: Option<MultiRegionKeyType> ,
+    nameonly PrimaryKey: Option<MultiRegionKey> ,
+    nameonly ReplicaKeys: Option<MultiRegionKeyList> )
   datatype MultiRegionKey = MultiRegionKey (
-                              nameonly Arn: Option<ArnType> ,
-                              nameonly Region: Option<RegionType> )
+    nameonly Arn: Option<ArnType> ,
+    nameonly Region: Option<RegionType> )
   type MultiRegionKeyList = seq<MultiRegionKey>
   datatype MultiRegionKeyType =
     | PRIMARY
@@ -1212,55 +1212,55 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
     ( 1 <= |x| <= 8192 )
   }
   datatype PutKeyPolicyRequest = PutKeyPolicyRequest (
-                                   nameonly KeyId: KeyIdType ,
-                                   nameonly PolicyName: PolicyNameType ,
-                                   nameonly Policy: PolicyType ,
-                                   nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> )
+    nameonly KeyId: KeyIdType ,
+    nameonly PolicyName: PolicyNameType ,
+    nameonly Policy: PolicyType ,
+    nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> )
   datatype ReEncryptRequest = ReEncryptRequest (
-                                nameonly CiphertextBlob: CiphertextType ,
-                                nameonly SourceEncryptionContext: Option<EncryptionContextType> ,
-                                nameonly SourceKeyId: Option<KeyIdType> ,
-                                nameonly DestinationKeyId: KeyIdType ,
-                                nameonly DestinationEncryptionContext: Option<EncryptionContextType> ,
-                                nameonly SourceEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
-                                nameonly DestinationEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
-                                nameonly GrantTokens: Option<GrantTokenList> )
+    nameonly CiphertextBlob: CiphertextType ,
+    nameonly SourceEncryptionContext: Option<EncryptionContextType> ,
+    nameonly SourceKeyId: Option<KeyIdType> ,
+    nameonly DestinationKeyId: KeyIdType ,
+    nameonly DestinationEncryptionContext: Option<EncryptionContextType> ,
+    nameonly SourceEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
+    nameonly DestinationEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
+    nameonly GrantTokens: Option<GrantTokenList> )
   datatype ReEncryptResponse = ReEncryptResponse (
-                                 nameonly CiphertextBlob: Option<CiphertextType> ,
-                                 nameonly SourceKeyId: Option<KeyIdType> ,
-                                 nameonly KeyId: Option<KeyIdType> ,
-                                 nameonly SourceEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
-                                 nameonly DestinationEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
+    nameonly CiphertextBlob: Option<CiphertextType> ,
+    nameonly SourceKeyId: Option<KeyIdType> ,
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly SourceEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
+    nameonly DestinationEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
   type RegionType = x: string | IsValid_RegionType(x) witness *
   predicate method IsValid_RegionType(x: string) {
     ( 1 <= |x| <= 32 )
   }
   datatype ReplicateKeyRequest = ReplicateKeyRequest (
-                                   nameonly KeyId: KeyIdType ,
-                                   nameonly ReplicaRegion: RegionType ,
-                                   nameonly Policy: Option<PolicyType> ,
-                                   nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> ,
-                                   nameonly Description: Option<DescriptionType> ,
-                                   nameonly Tags: Option<TagList> )
+    nameonly KeyId: KeyIdType ,
+    nameonly ReplicaRegion: RegionType ,
+    nameonly Policy: Option<PolicyType> ,
+    nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> ,
+    nameonly Description: Option<DescriptionType> ,
+    nameonly Tags: Option<TagList> )
   datatype ReplicateKeyResponse = ReplicateKeyResponse (
-                                    nameonly ReplicaKeyMetadata: Option<KeyMetadata> ,
-                                    nameonly ReplicaPolicy: Option<PolicyType> ,
-                                    nameonly ReplicaTags: Option<TagList> )
+    nameonly ReplicaKeyMetadata: Option<KeyMetadata> ,
+    nameonly ReplicaPolicy: Option<PolicyType> ,
+    nameonly ReplicaTags: Option<TagList> )
   datatype RetireGrantRequest = RetireGrantRequest (
-                                  nameonly GrantToken: Option<GrantTokenType> ,
-                                  nameonly KeyId: Option<KeyIdType> ,
-                                  nameonly GrantId: Option<GrantIdType> )
+    nameonly GrantToken: Option<GrantTokenType> ,
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly GrantId: Option<GrantIdType> )
   datatype RevokeGrantRequest = RevokeGrantRequest (
-                                  nameonly KeyId: KeyIdType ,
-                                  nameonly GrantId: GrantIdType )
+    nameonly KeyId: KeyIdType ,
+    nameonly GrantId: GrantIdType )
   datatype ScheduleKeyDeletionRequest = ScheduleKeyDeletionRequest (
-                                          nameonly KeyId: KeyIdType ,
-                                          nameonly PendingWindowInDays: Option<PendingWindowInDaysType> )
+    nameonly KeyId: KeyIdType ,
+    nameonly PendingWindowInDays: Option<PendingWindowInDaysType> )
   datatype ScheduleKeyDeletionResponse = ScheduleKeyDeletionResponse (
-                                           nameonly KeyId: Option<KeyIdType> ,
-                                           nameonly DeletionDate: Option<string> ,
-                                           nameonly KeyState: Option<KeyState> ,
-                                           nameonly PendingWindowInDays: Option<PendingWindowInDaysType> )
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly DeletionDate: Option<string> ,
+    nameonly KeyState: Option<KeyState> ,
+    nameonly PendingWindowInDays: Option<PendingWindowInDaysType> )
   datatype SigningAlgorithmSpec =
     | RSASSA_PSS_SHA_256
     | RSASSA_PSS_SHA_384
@@ -1273,18 +1273,18 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
     | ECDSA_SHA_512
   type SigningAlgorithmSpecList = seq<SigningAlgorithmSpec>
   datatype SignRequest = SignRequest (
-                           nameonly KeyId: KeyIdType ,
-                           nameonly Message: PlaintextType ,
-                           nameonly MessageType: Option<MessageType> ,
-                           nameonly GrantTokens: Option<GrantTokenList> ,
-                           nameonly SigningAlgorithm: SigningAlgorithmSpec )
+    nameonly KeyId: KeyIdType ,
+    nameonly Message: PlaintextType ,
+    nameonly MessageType: Option<MessageType> ,
+    nameonly GrantTokens: Option<GrantTokenList> ,
+    nameonly SigningAlgorithm: SigningAlgorithmSpec )
   datatype SignResponse = SignResponse (
-                            nameonly KeyId: Option<KeyIdType> ,
-                            nameonly Signature: Option<CiphertextType> ,
-                            nameonly SigningAlgorithm: Option<SigningAlgorithmSpec> )
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly Signature: Option<CiphertextType> ,
+    nameonly SigningAlgorithm: Option<SigningAlgorithmSpec> )
   datatype Tag = Tag (
-                   nameonly TagKey: TagKeyType ,
-                   nameonly TagValue: TagValueType )
+    nameonly TagKey: TagKeyType ,
+    nameonly TagValue: TagValueType )
   class TagException extends IKeyManagementServiceException {
     var message: string
 
@@ -1306,8 +1306,8 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
   }
   type TagList = seq<Tag>
   datatype TagResourceRequest = TagResourceRequest (
-                                  nameonly KeyId: KeyIdType ,
-                                  nameonly Tags: TagList )
+    nameonly KeyId: KeyIdType ,
+    nameonly Tags: TagList )
   type TagValueType = x: string | IsValid_TagValueType(x) witness *
   predicate method IsValid_TagValueType(x: string) {
     ( 0 <= |x| <= 256 )
@@ -1331,34 +1331,34 @@ module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
   }
 
   datatype UntagResourceRequest = UntagResourceRequest (
-                                    nameonly KeyId: KeyIdType ,
-                                    nameonly TagKeys: TagKeyList )
+    nameonly KeyId: KeyIdType ,
+    nameonly TagKeys: TagKeyList )
   datatype UpdateAliasRequest = UpdateAliasRequest (
-                                  nameonly AliasName: AliasNameType ,
-                                  nameonly TargetKeyId: KeyIdType )
+    nameonly AliasName: AliasNameType ,
+    nameonly TargetKeyId: KeyIdType )
   datatype UpdateCustomKeyStoreRequest = UpdateCustomKeyStoreRequest (
-                                           nameonly CustomKeyStoreId: CustomKeyStoreIdType ,
-                                           nameonly NewCustomKeyStoreName: Option<CustomKeyStoreNameType> ,
-                                           nameonly KeyStorePassword: Option<KeyStorePasswordType> ,
-                                           nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> )
+    nameonly CustomKeyStoreId: CustomKeyStoreIdType ,
+    nameonly NewCustomKeyStoreName: Option<CustomKeyStoreNameType> ,
+    nameonly KeyStorePassword: Option<KeyStorePasswordType> ,
+    nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> )
   datatype UpdateCustomKeyStoreResponse = UpdateCustomKeyStoreResponse (  )
   datatype UpdateKeyDescriptionRequest = UpdateKeyDescriptionRequest (
-                                           nameonly KeyId: KeyIdType ,
-                                           nameonly Description: DescriptionType )
+    nameonly KeyId: KeyIdType ,
+    nameonly Description: DescriptionType )
   datatype UpdatePrimaryRegionRequest = UpdatePrimaryRegionRequest (
-                                          nameonly KeyId: KeyIdType ,
-                                          nameonly PrimaryRegion: RegionType )
+    nameonly KeyId: KeyIdType ,
+    nameonly PrimaryRegion: RegionType )
   datatype VerifyRequest = VerifyRequest (
-                             nameonly KeyId: KeyIdType ,
-                             nameonly Message: PlaintextType ,
-                             nameonly MessageType: Option<MessageType> ,
-                             nameonly Signature: CiphertextType ,
-                             nameonly SigningAlgorithm: SigningAlgorithmSpec ,
-                             nameonly GrantTokens: Option<GrantTokenList> )
+    nameonly KeyId: KeyIdType ,
+    nameonly Message: PlaintextType ,
+    nameonly MessageType: Option<MessageType> ,
+    nameonly Signature: CiphertextType ,
+    nameonly SigningAlgorithm: SigningAlgorithmSpec ,
+    nameonly GrantTokens: Option<GrantTokenList> )
   datatype VerifyResponse = VerifyResponse (
-                              nameonly KeyId: Option<KeyIdType> ,
-                              nameonly SignatureValid: Option<BooleanType> ,
-                              nameonly SigningAlgorithm: Option<SigningAlgorithmSpec> )
+    nameonly KeyId: Option<KeyIdType> ,
+    nameonly SignatureValid: Option<BooleanType> ,
+    nameonly SigningAlgorithm: Option<SigningAlgorithmSpec> )
   datatype WrappingKeySpec =
     | RSA_2048
 }

--- a/src/Generated/KeyManagementService.dfy
+++ b/src/Generated/KeyManagementService.dfy
@@ -3,1362 +3,1362 @@
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
 include "../StandardLibrary/StandardLibrary.dfy"
 include "../Util/UTF8.dfy"
- module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
- import opened Wrappers
-import opened StandardLibrary.UInt
-import opened UTF8
- datatype AlgorithmSpec =
-	| RSAES_PKCS1_V1_5
-	| RSAES_OAEP_SHA_1
-	| RSAES_OAEP_SHA_256
- type AliasList = seq<AliasListEntry>
- datatype AliasListEntry = AliasListEntry (
-	nameonly AliasName: Option<AliasNameType> ,
-	nameonly AliasArn: Option<ArnType> ,
-	nameonly TargetKeyId: Option<KeyIdType> ,
-	nameonly CreationDate: Option<string> ,
-	nameonly LastUpdatedDate: Option<string> )
- type AliasNameType = x: string | IsValid_AliasNameType(x) witness *
- predicate method IsValid_AliasNameType(x: string) {
- ( 1 <= |x| <= 256 )
-}
- class AlreadyExistsException extends IKeyManagementServiceException {
+module {:extern "Dafny.Com.Amazonaws.Kms"} Com.Amazonaws.Kms {
+  import opened Wrappers
+  import opened StandardLibrary.UInt
+  import opened UTF8
+  datatype AlgorithmSpec =
+    | RSAES_PKCS1_V1_5
+    | RSAES_OAEP_SHA_1
+    | RSAES_OAEP_SHA_256
+  type AliasList = seq<AliasListEntry>
+  datatype AliasListEntry = AliasListEntry (
+                              nameonly AliasName: Option<AliasNameType> ,
+                              nameonly AliasArn: Option<ArnType> ,
+                              nameonly TargetKeyId: Option<KeyIdType> ,
+                              nameonly CreationDate: Option<string> ,
+                              nameonly LastUpdatedDate: Option<string> )
+  type AliasNameType = x: string | IsValid_AliasNameType(x) witness *
+  predicate method IsValid_AliasNameType(x: string) {
+    ( 1 <= |x| <= 256 )
+  }
+  class AlreadyExistsException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- type ArnType = x: string | IsValid_ArnType(x) witness *
- predicate method IsValid_ArnType(x: string) {
- ( 20 <= |x| <= 2048 )
-}
- type AWSAccountIdType = string
- type BooleanType = bool
- datatype CancelKeyDeletionRequest = CancelKeyDeletionRequest (
-	nameonly KeyId: KeyIdType )
- datatype CancelKeyDeletionResponse = CancelKeyDeletionResponse (
-	nameonly KeyId: Option<KeyIdType> )
- type CiphertextType = x: seq<uint8> | IsValid_CiphertextType(x) witness *
- predicate method IsValid_CiphertextType(x: seq<uint8>) {
- ( 1 <= |x| <= 6144 )
-}
- type CloudHsmClusterIdType = x: string | IsValid_CloudHsmClusterIdType(x) witness *
- predicate method IsValid_CloudHsmClusterIdType(x: string) {
- ( 19 <= |x| <= 24 )
-}
- class CloudHsmClusterInUseException extends IKeyManagementServiceException {
+  type ArnType = x: string | IsValid_ArnType(x) witness *
+  predicate method IsValid_ArnType(x: string) {
+    ( 20 <= |x| <= 2048 )
+  }
+  type AWSAccountIdType = string
+  type BooleanType = bool
+  datatype CancelKeyDeletionRequest = CancelKeyDeletionRequest (
+                                        nameonly KeyId: KeyIdType )
+  datatype CancelKeyDeletionResponse = CancelKeyDeletionResponse (
+                                         nameonly KeyId: Option<KeyIdType> )
+  type CiphertextType = x: seq<uint8> | IsValid_CiphertextType(x) witness *
+  predicate method IsValid_CiphertextType(x: seq<uint8>) {
+    ( 1 <= |x| <= 6144 )
+  }
+  type CloudHsmClusterIdType = x: string | IsValid_CloudHsmClusterIdType(x) witness *
+  predicate method IsValid_CloudHsmClusterIdType(x: string) {
+    ( 19 <= |x| <= 24 )
+  }
+  class CloudHsmClusterInUseException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class CloudHsmClusterInvalidConfigurationException extends IKeyManagementServiceException {
+  class CloudHsmClusterInvalidConfigurationException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class CloudHsmClusterNotActiveException extends IKeyManagementServiceException {
+  class CloudHsmClusterNotActiveException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class CloudHsmClusterNotFoundException extends IKeyManagementServiceException {
+  class CloudHsmClusterNotFoundException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class CloudHsmClusterNotRelatedException extends IKeyManagementServiceException {
+  class CloudHsmClusterNotRelatedException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- datatype ConnectCustomKeyStoreRequest = ConnectCustomKeyStoreRequest (
-	nameonly CustomKeyStoreId: CustomKeyStoreIdType )
- datatype ConnectCustomKeyStoreResponse = ConnectCustomKeyStoreResponse (  )
- datatype ConnectionErrorCodeType =
-	| INVALID_CREDENTIALS
-	| CLUSTER_NOT_FOUND
-	| NETWORK_ERRORS
-	| INTERNAL_ERROR
-	| INSUFFICIENT_CLOUDHSM_HSMS
-	| USER_LOCKED_OUT
-	| USER_NOT_FOUND
-	| USER_LOGGED_IN
-	| SUBNET_NOT_FOUND
- datatype ConnectionStateType =
-	| CONNECTED
-	| CONNECTING
-	| FAILED
-	| DISCONNECTED
-	| DISCONNECTING
- datatype CreateAliasRequest = CreateAliasRequest (
-	nameonly AliasName: AliasNameType ,
-	nameonly TargetKeyId: KeyIdType )
- datatype CreateCustomKeyStoreRequest = CreateCustomKeyStoreRequest (
-	nameonly CustomKeyStoreName: CustomKeyStoreNameType ,
-	nameonly CloudHsmClusterId: CloudHsmClusterIdType ,
-	nameonly TrustAnchorCertificate: TrustAnchorCertificateType ,
-	nameonly KeyStorePassword: KeyStorePasswordType )
- datatype CreateCustomKeyStoreResponse = CreateCustomKeyStoreResponse (
-	nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> )
- datatype CreateGrantRequest = CreateGrantRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly GranteePrincipal: PrincipalIdType ,
-	nameonly RetiringPrincipal: Option<PrincipalIdType> ,
-	nameonly Operations: GrantOperationList ,
-	nameonly Constraints: Option<GrantConstraints> ,
-	nameonly GrantTokens: Option<GrantTokenList> ,
-	nameonly Name: Option<GrantNameType> )
- datatype CreateGrantResponse = CreateGrantResponse (
-	nameonly GrantToken: Option<GrantTokenType> ,
-	nameonly GrantId: Option<GrantIdType> )
- datatype CreateKeyRequest = CreateKeyRequest (
-	nameonly Policy: Option<PolicyType> ,
-	nameonly Description: Option<DescriptionType> ,
-	nameonly KeyUsage: Option<KeyUsageType> ,
-	nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
-	nameonly KeySpec: Option<KeySpec> ,
-	nameonly Origin: Option<OriginType> ,
-	nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
-	nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> ,
-	nameonly Tags: Option<TagList> ,
-	nameonly MultiRegion: Option<NullableBooleanType> )
- datatype CreateKeyResponse = CreateKeyResponse (
-	nameonly KeyMetadata: Option<KeyMetadata> )
- datatype CustomerMasterKeySpec =
-	| RSA_2048
-	| RSA_3072
-	| RSA_4096
-	| ECC_NIST_P256
-	| ECC_NIST_P384
-	| ECC_NIST_P521
-	| ECC_SECG_P256K1
-	| SYMMETRIC_DEFAULT
- class CustomKeyStoreHasCMKsException extends IKeyManagementServiceException {
+  datatype ConnectCustomKeyStoreRequest = ConnectCustomKeyStoreRequest (
+                                            nameonly CustomKeyStoreId: CustomKeyStoreIdType )
+  datatype ConnectCustomKeyStoreResponse = ConnectCustomKeyStoreResponse (  )
+  datatype ConnectionErrorCodeType =
+    | INVALID_CREDENTIALS
+    | CLUSTER_NOT_FOUND
+    | NETWORK_ERRORS
+    | INTERNAL_ERROR
+    | INSUFFICIENT_CLOUDHSM_HSMS
+    | USER_LOCKED_OUT
+    | USER_NOT_FOUND
+    | USER_LOGGED_IN
+    | SUBNET_NOT_FOUND
+  datatype ConnectionStateType =
+    | CONNECTED
+    | CONNECTING
+    | FAILED
+    | DISCONNECTED
+    | DISCONNECTING
+  datatype CreateAliasRequest = CreateAliasRequest (
+                                  nameonly AliasName: AliasNameType ,
+                                  nameonly TargetKeyId: KeyIdType )
+  datatype CreateCustomKeyStoreRequest = CreateCustomKeyStoreRequest (
+                                           nameonly CustomKeyStoreName: CustomKeyStoreNameType ,
+                                           nameonly CloudHsmClusterId: CloudHsmClusterIdType ,
+                                           nameonly TrustAnchorCertificate: TrustAnchorCertificateType ,
+                                           nameonly KeyStorePassword: KeyStorePasswordType )
+  datatype CreateCustomKeyStoreResponse = CreateCustomKeyStoreResponse (
+                                            nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> )
+  datatype CreateGrantRequest = CreateGrantRequest (
+                                  nameonly KeyId: KeyIdType ,
+                                  nameonly GranteePrincipal: PrincipalIdType ,
+                                  nameonly RetiringPrincipal: Option<PrincipalIdType> ,
+                                  nameonly Operations: GrantOperationList ,
+                                  nameonly Constraints: Option<GrantConstraints> ,
+                                  nameonly GrantTokens: Option<GrantTokenList> ,
+                                  nameonly Name: Option<GrantNameType> )
+  datatype CreateGrantResponse = CreateGrantResponse (
+                                   nameonly GrantToken: Option<GrantTokenType> ,
+                                   nameonly GrantId: Option<GrantIdType> )
+  datatype CreateKeyRequest = CreateKeyRequest (
+                                nameonly Policy: Option<PolicyType> ,
+                                nameonly Description: Option<DescriptionType> ,
+                                nameonly KeyUsage: Option<KeyUsageType> ,
+                                nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
+                                nameonly KeySpec: Option<KeySpec> ,
+                                nameonly Origin: Option<OriginType> ,
+                                nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
+                                nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> ,
+                                nameonly Tags: Option<TagList> ,
+                                nameonly MultiRegion: Option<NullableBooleanType> )
+  datatype CreateKeyResponse = CreateKeyResponse (
+                                 nameonly KeyMetadata: Option<KeyMetadata> )
+  datatype CustomerMasterKeySpec =
+    | RSA_2048
+    | RSA_3072
+    | RSA_4096
+    | ECC_NIST_P256
+    | ECC_NIST_P384
+    | ECC_NIST_P521
+    | ECC_SECG_P256K1
+    | SYMMETRIC_DEFAULT
+  class CustomKeyStoreHasCMKsException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- type CustomKeyStoreIdType = x: string | IsValid_CustomKeyStoreIdType(x) witness *
- predicate method IsValid_CustomKeyStoreIdType(x: string) {
- ( 1 <= |x| <= 64 )
-}
- class CustomKeyStoreInvalidStateException extends IKeyManagementServiceException {
+  type CustomKeyStoreIdType = x: string | IsValid_CustomKeyStoreIdType(x) witness *
+  predicate method IsValid_CustomKeyStoreIdType(x: string) {
+    ( 1 <= |x| <= 64 )
+  }
+  class CustomKeyStoreInvalidStateException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class CustomKeyStoreNameInUseException extends IKeyManagementServiceException {
+  class CustomKeyStoreNameInUseException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- type CustomKeyStoreNameType = x: string | IsValid_CustomKeyStoreNameType(x) witness *
- predicate method IsValid_CustomKeyStoreNameType(x: string) {
- ( 1 <= |x| <= 256 )
-}
- class CustomKeyStoreNotFoundException extends IKeyManagementServiceException {
+  type CustomKeyStoreNameType = x: string | IsValid_CustomKeyStoreNameType(x) witness *
+  predicate method IsValid_CustomKeyStoreNameType(x: string) {
+    ( 1 <= |x| <= 256 )
+  }
+  class CustomKeyStoreNotFoundException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- type CustomKeyStoresList = seq<CustomKeyStoresListEntry>
- datatype CustomKeyStoresListEntry = CustomKeyStoresListEntry (
-	nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
-	nameonly CustomKeyStoreName: Option<CustomKeyStoreNameType> ,
-	nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> ,
-	nameonly TrustAnchorCertificate: Option<TrustAnchorCertificateType> ,
-	nameonly ConnectionState: Option<ConnectionStateType> ,
-	nameonly ConnectionErrorCode: Option<ConnectionErrorCodeType> ,
-	nameonly CreationDate: Option<string> )
- datatype DataKeyPairSpec =
-	| RSA_2048
-	| RSA_3072
-	| RSA_4096
-	| ECC_NIST_P256
-	| ECC_NIST_P384
-	| ECC_NIST_P521
-	| ECC_SECG_P256K1
- datatype DataKeySpec =
-	| AES_256
-	| AES_128
- datatype DecryptRequest = DecryptRequest (
-	nameonly CiphertextBlob: CiphertextType ,
-	nameonly EncryptionContext: Option<EncryptionContextType> ,
-	nameonly GrantTokens: Option<GrantTokenList> ,
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
- datatype DecryptResponse = DecryptResponse (
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly Plaintext: Option<PlaintextType> ,
-	nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
- datatype DeleteAliasRequest = DeleteAliasRequest (
-	nameonly AliasName: AliasNameType )
- datatype DeleteCustomKeyStoreRequest = DeleteCustomKeyStoreRequest (
-	nameonly CustomKeyStoreId: CustomKeyStoreIdType )
- datatype DeleteCustomKeyStoreResponse = DeleteCustomKeyStoreResponse (  )
- datatype DeleteImportedKeyMaterialRequest = DeleteImportedKeyMaterialRequest (
-	nameonly KeyId: KeyIdType )
- class DependencyTimeoutException extends IKeyManagementServiceException {
+  type CustomKeyStoresList = seq<CustomKeyStoresListEntry>
+  datatype CustomKeyStoresListEntry = CustomKeyStoresListEntry (
+                                        nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
+                                        nameonly CustomKeyStoreName: Option<CustomKeyStoreNameType> ,
+                                        nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> ,
+                                        nameonly TrustAnchorCertificate: Option<TrustAnchorCertificateType> ,
+                                        nameonly ConnectionState: Option<ConnectionStateType> ,
+                                        nameonly ConnectionErrorCode: Option<ConnectionErrorCodeType> ,
+                                        nameonly CreationDate: Option<string> )
+  datatype DataKeyPairSpec =
+    | RSA_2048
+    | RSA_3072
+    | RSA_4096
+    | ECC_NIST_P256
+    | ECC_NIST_P384
+    | ECC_NIST_P521
+    | ECC_SECG_P256K1
+  datatype DataKeySpec =
+    | AES_256
+    | AES_128
+  datatype DecryptRequest = DecryptRequest (
+                              nameonly CiphertextBlob: CiphertextType ,
+                              nameonly EncryptionContext: Option<EncryptionContextType> ,
+                              nameonly GrantTokens: Option<GrantTokenList> ,
+                              nameonly KeyId: Option<KeyIdType> ,
+                              nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
+  datatype DecryptResponse = DecryptResponse (
+                               nameonly KeyId: Option<KeyIdType> ,
+                               nameonly Plaintext: Option<PlaintextType> ,
+                               nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
+  datatype DeleteAliasRequest = DeleteAliasRequest (
+                                  nameonly AliasName: AliasNameType )
+  datatype DeleteCustomKeyStoreRequest = DeleteCustomKeyStoreRequest (
+                                           nameonly CustomKeyStoreId: CustomKeyStoreIdType )
+  datatype DeleteCustomKeyStoreResponse = DeleteCustomKeyStoreResponse (  )
+  datatype DeleteImportedKeyMaterialRequest = DeleteImportedKeyMaterialRequest (
+                                                nameonly KeyId: KeyIdType )
+  class DependencyTimeoutException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- datatype DescribeCustomKeyStoresRequest = DescribeCustomKeyStoresRequest (
-	nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
-	nameonly CustomKeyStoreName: Option<CustomKeyStoreNameType> ,
-	nameonly Limit: Option<LimitType> ,
-	nameonly Marker: Option<MarkerType> )
- datatype DescribeCustomKeyStoresResponse = DescribeCustomKeyStoresResponse (
-	nameonly CustomKeyStores: Option<CustomKeyStoresList> ,
-	nameonly NextMarker: Option<MarkerType> ,
-	nameonly Truncated: Option<BooleanType> )
- datatype DescribeKeyRequest = DescribeKeyRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly GrantTokens: Option<GrantTokenList> )
- datatype DescribeKeyResponse = DescribeKeyResponse (
-	nameonly KeyMetadata: Option<KeyMetadata> )
- type DescriptionType = x: string | IsValid_DescriptionType(x) witness *
- predicate method IsValid_DescriptionType(x: string) {
- ( 0 <= |x| <= 8192 )
-}
- class DisabledException extends IKeyManagementServiceException {
+  datatype DescribeCustomKeyStoresRequest = DescribeCustomKeyStoresRequest (
+                                              nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
+                                              nameonly CustomKeyStoreName: Option<CustomKeyStoreNameType> ,
+                                              nameonly Limit: Option<LimitType> ,
+                                              nameonly Marker: Option<MarkerType> )
+  datatype DescribeCustomKeyStoresResponse = DescribeCustomKeyStoresResponse (
+                                               nameonly CustomKeyStores: Option<CustomKeyStoresList> ,
+                                               nameonly NextMarker: Option<MarkerType> ,
+                                               nameonly Truncated: Option<BooleanType> )
+  datatype DescribeKeyRequest = DescribeKeyRequest (
+                                  nameonly KeyId: KeyIdType ,
+                                  nameonly GrantTokens: Option<GrantTokenList> )
+  datatype DescribeKeyResponse = DescribeKeyResponse (
+                                   nameonly KeyMetadata: Option<KeyMetadata> )
+  type DescriptionType = x: string | IsValid_DescriptionType(x) witness *
+  predicate method IsValid_DescriptionType(x: string) {
+    ( 0 <= |x| <= 8192 )
+  }
+  class DisabledException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- datatype DisableKeyRequest = DisableKeyRequest (
-	nameonly KeyId: KeyIdType )
- datatype DisableKeyRotationRequest = DisableKeyRotationRequest (
-	nameonly KeyId: KeyIdType )
- datatype DisconnectCustomKeyStoreRequest = DisconnectCustomKeyStoreRequest (
-	nameonly CustomKeyStoreId: CustomKeyStoreIdType )
- datatype DisconnectCustomKeyStoreResponse = DisconnectCustomKeyStoreResponse (  )
- datatype EnableKeyRequest = EnableKeyRequest (
-	nameonly KeyId: KeyIdType )
- datatype EnableKeyRotationRequest = EnableKeyRotationRequest (
-	nameonly KeyId: KeyIdType )
- datatype EncryptionAlgorithmSpec =
-	| SYMMETRIC_DEFAULT
-	| RSAES_OAEP_SHA_1
-	| RSAES_OAEP_SHA_256
- type EncryptionAlgorithmSpecList = seq<EncryptionAlgorithmSpec>
- type EncryptionContextKey = string
- type EncryptionContextType = map<EncryptionContextKey, EncryptionContextValue>
- type EncryptionContextValue = string
- datatype EncryptRequest = EncryptRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly Plaintext: PlaintextType ,
-	nameonly EncryptionContext: Option<EncryptionContextType> ,
-	nameonly GrantTokens: Option<GrantTokenList> ,
-	nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
- datatype EncryptResponse = EncryptResponse (
-	nameonly CiphertextBlob: Option<CiphertextType> ,
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
- type ErrorMessageType = string
- datatype ExpirationModelType =
-	| KEY_MATERIAL_EXPIRES
-	| KEY_MATERIAL_DOES_NOT_EXPIRE
- class ExpiredImportTokenException extends IKeyManagementServiceException {
+  datatype DisableKeyRequest = DisableKeyRequest (
+                                 nameonly KeyId: KeyIdType )
+  datatype DisableKeyRotationRequest = DisableKeyRotationRequest (
+                                         nameonly KeyId: KeyIdType )
+  datatype DisconnectCustomKeyStoreRequest = DisconnectCustomKeyStoreRequest (
+                                               nameonly CustomKeyStoreId: CustomKeyStoreIdType )
+  datatype DisconnectCustomKeyStoreResponse = DisconnectCustomKeyStoreResponse (  )
+  datatype EnableKeyRequest = EnableKeyRequest (
+                                nameonly KeyId: KeyIdType )
+  datatype EnableKeyRotationRequest = EnableKeyRotationRequest (
+                                        nameonly KeyId: KeyIdType )
+  datatype EncryptionAlgorithmSpec =
+    | SYMMETRIC_DEFAULT
+    | RSAES_OAEP_SHA_1
+    | RSAES_OAEP_SHA_256
+  type EncryptionAlgorithmSpecList = seq<EncryptionAlgorithmSpec>
+  type EncryptionContextKey = string
+  type EncryptionContextType = map<EncryptionContextKey, EncryptionContextValue>
+  type EncryptionContextValue = string
+  datatype EncryptRequest = EncryptRequest (
+                              nameonly KeyId: KeyIdType ,
+                              nameonly Plaintext: PlaintextType ,
+                              nameonly EncryptionContext: Option<EncryptionContextType> ,
+                              nameonly GrantTokens: Option<GrantTokenList> ,
+                              nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
+  datatype EncryptResponse = EncryptResponse (
+                               nameonly CiphertextBlob: Option<CiphertextType> ,
+                               nameonly KeyId: Option<KeyIdType> ,
+                               nameonly EncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
+  type ErrorMessageType = string
+  datatype ExpirationModelType =
+    | KEY_MATERIAL_EXPIRES
+    | KEY_MATERIAL_DOES_NOT_EXPIRE
+  class ExpiredImportTokenException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- datatype GenerateDataKeyPairRequest = GenerateDataKeyPairRequest (
-	nameonly EncryptionContext: Option<EncryptionContextType> ,
-	nameonly KeyId: KeyIdType ,
-	nameonly KeyPairSpec: DataKeyPairSpec ,
-	nameonly GrantTokens: Option<GrantTokenList> )
- datatype GenerateDataKeyPairResponse = GenerateDataKeyPairResponse (
-	nameonly PrivateKeyCiphertextBlob: Option<CiphertextType> ,
-	nameonly PrivateKeyPlaintext: Option<PlaintextType> ,
-	nameonly PublicKey: Option<PublicKeyType> ,
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly KeyPairSpec: Option<DataKeyPairSpec> )
- datatype GenerateDataKeyPairWithoutPlaintextRequest = GenerateDataKeyPairWithoutPlaintextRequest (
-	nameonly EncryptionContext: Option<EncryptionContextType> ,
-	nameonly KeyId: KeyIdType ,
-	nameonly KeyPairSpec: DataKeyPairSpec ,
-	nameonly GrantTokens: Option<GrantTokenList> )
- datatype GenerateDataKeyPairWithoutPlaintextResponse = GenerateDataKeyPairWithoutPlaintextResponse (
-	nameonly PrivateKeyCiphertextBlob: Option<CiphertextType> ,
-	nameonly PublicKey: Option<PublicKeyType> ,
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly KeyPairSpec: Option<DataKeyPairSpec> )
- datatype GenerateDataKeyRequest = GenerateDataKeyRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly EncryptionContext: Option<EncryptionContextType> ,
-	nameonly NumberOfBytes: Option<NumberOfBytesType> ,
-	nameonly KeySpec: Option<DataKeySpec> ,
-	nameonly GrantTokens: Option<GrantTokenList> )
- datatype GenerateDataKeyResponse = GenerateDataKeyResponse (
-	nameonly CiphertextBlob: Option<CiphertextType> ,
-	nameonly Plaintext: Option<PlaintextType> ,
-	nameonly KeyId: Option<KeyIdType> )
- datatype GenerateDataKeyWithoutPlaintextRequest = GenerateDataKeyWithoutPlaintextRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly EncryptionContext: Option<EncryptionContextType> ,
-	nameonly KeySpec: Option<DataKeySpec> ,
-	nameonly NumberOfBytes: Option<NumberOfBytesType> ,
-	nameonly GrantTokens: Option<GrantTokenList> )
- datatype GenerateDataKeyWithoutPlaintextResponse = GenerateDataKeyWithoutPlaintextResponse (
-	nameonly CiphertextBlob: Option<CiphertextType> ,
-	nameonly KeyId: Option<KeyIdType> )
- datatype GenerateRandomRequest = GenerateRandomRequest (
-	nameonly NumberOfBytes: Option<NumberOfBytesType> ,
-	nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> )
- datatype GenerateRandomResponse = GenerateRandomResponse (
-	nameonly Plaintext: Option<PlaintextType> )
- datatype GetKeyPolicyRequest = GetKeyPolicyRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly PolicyName: PolicyNameType )
- datatype GetKeyPolicyResponse = GetKeyPolicyResponse (
-	nameonly Policy: Option<PolicyType> )
- datatype GetKeyRotationStatusRequest = GetKeyRotationStatusRequest (
-	nameonly KeyId: KeyIdType )
- datatype GetKeyRotationStatusResponse = GetKeyRotationStatusResponse (
-	nameonly KeyRotationEnabled: Option<BooleanType> )
- datatype GetParametersForImportRequest = GetParametersForImportRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly WrappingAlgorithm: AlgorithmSpec ,
-	nameonly WrappingKeySpec: WrappingKeySpec )
- datatype GetParametersForImportResponse = GetParametersForImportResponse (
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly ImportToken: Option<CiphertextType> ,
-	nameonly PublicKey: Option<PlaintextType> ,
-	nameonly ParametersValidTo: Option<string> )
- datatype GetPublicKeyRequest = GetPublicKeyRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly GrantTokens: Option<GrantTokenList> )
- datatype GetPublicKeyResponse = GetPublicKeyResponse (
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly PublicKey: Option<PublicKeyType> ,
-	nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
-	nameonly KeySpec: Option<KeySpec> ,
-	nameonly KeyUsage: Option<KeyUsageType> ,
-	nameonly EncryptionAlgorithms: Option<EncryptionAlgorithmSpecList> ,
-	nameonly SigningAlgorithms: Option<SigningAlgorithmSpecList> )
- datatype GrantConstraints = GrantConstraints (
-	nameonly EncryptionContextSubset: Option<EncryptionContextType> ,
-	nameonly EncryptionContextEquals: Option<EncryptionContextType> )
- type GrantIdType = x: string | IsValid_GrantIdType(x) witness *
- predicate method IsValid_GrantIdType(x: string) {
- ( 1 <= |x| <= 128 )
-}
- type GrantList = seq<GrantListEntry>
- datatype GrantListEntry = GrantListEntry (
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly GrantId: Option<GrantIdType> ,
-	nameonly Name: Option<GrantNameType> ,
-	nameonly CreationDate: Option<string> ,
-	nameonly GranteePrincipal: Option<PrincipalIdType> ,
-	nameonly RetiringPrincipal: Option<PrincipalIdType> ,
-	nameonly IssuingAccount: Option<PrincipalIdType> ,
-	nameonly Operations: Option<GrantOperationList> ,
-	nameonly Constraints: Option<GrantConstraints> )
- type GrantNameType = x: string | IsValid_GrantNameType(x) witness *
- predicate method IsValid_GrantNameType(x: string) {
- ( 1 <= |x| <= 256 )
-}
- datatype GrantOperation =
-	| Decrypt
-	| Encrypt
-	| GenerateDataKey
-	| GenerateDataKeyWithoutPlaintext
-	| ReEncryptFrom
-	| ReEncryptTo
-	| Sign
-	| Verify
-	| GetPublicKey
-	| CreateGrant
-	| RetireGrant
-	| DescribeKey
-	| GenerateDataKeyPair
-	| GenerateDataKeyPairWithoutPlaintext
- type GrantOperationList = seq<GrantOperation>
- type GrantTokenList = x: seq<GrantTokenType> | IsValid_GrantTokenList(x) witness *
- predicate method IsValid_GrantTokenList(x: seq<GrantTokenType>) {
- ( 0 <= |x| <= 10 )
-}
- type GrantTokenType = x: string | IsValid_GrantTokenType(x) witness *
- predicate method IsValid_GrantTokenType(x: string) {
- ( 1 <= |x| <= 8192 )
-}
- datatype ImportKeyMaterialRequest = ImportKeyMaterialRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly ImportToken: CiphertextType ,
-	nameonly EncryptedKeyMaterial: CiphertextType ,
-	nameonly ValidTo: Option<string> ,
-	nameonly ExpirationModel: Option<ExpirationModelType> )
- datatype ImportKeyMaterialResponse = ImportKeyMaterialResponse (  )
- class IncorrectKeyException extends IKeyManagementServiceException {
+  datatype GenerateDataKeyPairRequest = GenerateDataKeyPairRequest (
+                                          nameonly EncryptionContext: Option<EncryptionContextType> ,
+                                          nameonly KeyId: KeyIdType ,
+                                          nameonly KeyPairSpec: DataKeyPairSpec ,
+                                          nameonly GrantTokens: Option<GrantTokenList> )
+  datatype GenerateDataKeyPairResponse = GenerateDataKeyPairResponse (
+                                           nameonly PrivateKeyCiphertextBlob: Option<CiphertextType> ,
+                                           nameonly PrivateKeyPlaintext: Option<PlaintextType> ,
+                                           nameonly PublicKey: Option<PublicKeyType> ,
+                                           nameonly KeyId: Option<KeyIdType> ,
+                                           nameonly KeyPairSpec: Option<DataKeyPairSpec> )
+  datatype GenerateDataKeyPairWithoutPlaintextRequest = GenerateDataKeyPairWithoutPlaintextRequest (
+                                                          nameonly EncryptionContext: Option<EncryptionContextType> ,
+                                                          nameonly KeyId: KeyIdType ,
+                                                          nameonly KeyPairSpec: DataKeyPairSpec ,
+                                                          nameonly GrantTokens: Option<GrantTokenList> )
+  datatype GenerateDataKeyPairWithoutPlaintextResponse = GenerateDataKeyPairWithoutPlaintextResponse (
+                                                           nameonly PrivateKeyCiphertextBlob: Option<CiphertextType> ,
+                                                           nameonly PublicKey: Option<PublicKeyType> ,
+                                                           nameonly KeyId: Option<KeyIdType> ,
+                                                           nameonly KeyPairSpec: Option<DataKeyPairSpec> )
+  datatype GenerateDataKeyRequest = GenerateDataKeyRequest (
+                                      nameonly KeyId: KeyIdType ,
+                                      nameonly EncryptionContext: Option<EncryptionContextType> ,
+                                      nameonly NumberOfBytes: Option<NumberOfBytesType> ,
+                                      nameonly KeySpec: Option<DataKeySpec> ,
+                                      nameonly GrantTokens: Option<GrantTokenList> )
+  datatype GenerateDataKeyResponse = GenerateDataKeyResponse (
+                                       nameonly CiphertextBlob: Option<CiphertextType> ,
+                                       nameonly Plaintext: Option<PlaintextType> ,
+                                       nameonly KeyId: Option<KeyIdType> )
+  datatype GenerateDataKeyWithoutPlaintextRequest = GenerateDataKeyWithoutPlaintextRequest (
+                                                      nameonly KeyId: KeyIdType ,
+                                                      nameonly EncryptionContext: Option<EncryptionContextType> ,
+                                                      nameonly KeySpec: Option<DataKeySpec> ,
+                                                      nameonly NumberOfBytes: Option<NumberOfBytesType> ,
+                                                      nameonly GrantTokens: Option<GrantTokenList> )
+  datatype GenerateDataKeyWithoutPlaintextResponse = GenerateDataKeyWithoutPlaintextResponse (
+                                                       nameonly CiphertextBlob: Option<CiphertextType> ,
+                                                       nameonly KeyId: Option<KeyIdType> )
+  datatype GenerateRandomRequest = GenerateRandomRequest (
+                                     nameonly NumberOfBytes: Option<NumberOfBytesType> ,
+                                     nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> )
+  datatype GenerateRandomResponse = GenerateRandomResponse (
+                                      nameonly Plaintext: Option<PlaintextType> )
+  datatype GetKeyPolicyRequest = GetKeyPolicyRequest (
+                                   nameonly KeyId: KeyIdType ,
+                                   nameonly PolicyName: PolicyNameType )
+  datatype GetKeyPolicyResponse = GetKeyPolicyResponse (
+                                    nameonly Policy: Option<PolicyType> )
+  datatype GetKeyRotationStatusRequest = GetKeyRotationStatusRequest (
+                                           nameonly KeyId: KeyIdType )
+  datatype GetKeyRotationStatusResponse = GetKeyRotationStatusResponse (
+                                            nameonly KeyRotationEnabled: Option<BooleanType> )
+  datatype GetParametersForImportRequest = GetParametersForImportRequest (
+                                             nameonly KeyId: KeyIdType ,
+                                             nameonly WrappingAlgorithm: AlgorithmSpec ,
+                                             nameonly WrappingKeySpec: WrappingKeySpec )
+  datatype GetParametersForImportResponse = GetParametersForImportResponse (
+                                              nameonly KeyId: Option<KeyIdType> ,
+                                              nameonly ImportToken: Option<CiphertextType> ,
+                                              nameonly PublicKey: Option<PlaintextType> ,
+                                              nameonly ParametersValidTo: Option<string> )
+  datatype GetPublicKeyRequest = GetPublicKeyRequest (
+                                   nameonly KeyId: KeyIdType ,
+                                   nameonly GrantTokens: Option<GrantTokenList> )
+  datatype GetPublicKeyResponse = GetPublicKeyResponse (
+                                    nameonly KeyId: Option<KeyIdType> ,
+                                    nameonly PublicKey: Option<PublicKeyType> ,
+                                    nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
+                                    nameonly KeySpec: Option<KeySpec> ,
+                                    nameonly KeyUsage: Option<KeyUsageType> ,
+                                    nameonly EncryptionAlgorithms: Option<EncryptionAlgorithmSpecList> ,
+                                    nameonly SigningAlgorithms: Option<SigningAlgorithmSpecList> )
+  datatype GrantConstraints = GrantConstraints (
+                                nameonly EncryptionContextSubset: Option<EncryptionContextType> ,
+                                nameonly EncryptionContextEquals: Option<EncryptionContextType> )
+  type GrantIdType = x: string | IsValid_GrantIdType(x) witness *
+  predicate method IsValid_GrantIdType(x: string) {
+    ( 1 <= |x| <= 128 )
+  }
+  type GrantList = seq<GrantListEntry>
+  datatype GrantListEntry = GrantListEntry (
+                              nameonly KeyId: Option<KeyIdType> ,
+                              nameonly GrantId: Option<GrantIdType> ,
+                              nameonly Name: Option<GrantNameType> ,
+                              nameonly CreationDate: Option<string> ,
+                              nameonly GranteePrincipal: Option<PrincipalIdType> ,
+                              nameonly RetiringPrincipal: Option<PrincipalIdType> ,
+                              nameonly IssuingAccount: Option<PrincipalIdType> ,
+                              nameonly Operations: Option<GrantOperationList> ,
+                              nameonly Constraints: Option<GrantConstraints> )
+  type GrantNameType = x: string | IsValid_GrantNameType(x) witness *
+  predicate method IsValid_GrantNameType(x: string) {
+    ( 1 <= |x| <= 256 )
+  }
+  datatype GrantOperation =
+    | Decrypt
+    | Encrypt
+    | GenerateDataKey
+    | GenerateDataKeyWithoutPlaintext
+    | ReEncryptFrom
+    | ReEncryptTo
+    | Sign
+    | Verify
+    | GetPublicKey
+    | CreateGrant
+    | RetireGrant
+    | DescribeKey
+    | GenerateDataKeyPair
+    | GenerateDataKeyPairWithoutPlaintext
+  type GrantOperationList = seq<GrantOperation>
+  type GrantTokenList = x: seq<GrantTokenType> | IsValid_GrantTokenList(x) witness *
+  predicate method IsValid_GrantTokenList(x: seq<GrantTokenType>) {
+    ( 0 <= |x| <= 10 )
+  }
+  type GrantTokenType = x: string | IsValid_GrantTokenType(x) witness *
+  predicate method IsValid_GrantTokenType(x: string) {
+    ( 1 <= |x| <= 8192 )
+  }
+  datatype ImportKeyMaterialRequest = ImportKeyMaterialRequest (
+                                        nameonly KeyId: KeyIdType ,
+                                        nameonly ImportToken: CiphertextType ,
+                                        nameonly EncryptedKeyMaterial: CiphertextType ,
+                                        nameonly ValidTo: Option<string> ,
+                                        nameonly ExpirationModel: Option<ExpirationModelType> )
+  datatype ImportKeyMaterialResponse = ImportKeyMaterialResponse (  )
+  class IncorrectKeyException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class IncorrectKeyMaterialException extends IKeyManagementServiceException {
+  class IncorrectKeyMaterialException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class IncorrectTrustAnchorException extends IKeyManagementServiceException {
+  class IncorrectTrustAnchorException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class InvalidAliasNameException extends IKeyManagementServiceException {
+  class InvalidAliasNameException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class InvalidArnException extends IKeyManagementServiceException {
+  class InvalidArnException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class InvalidCiphertextException extends IKeyManagementServiceException {
+  class InvalidCiphertextException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class InvalidGrantIdException extends IKeyManagementServiceException {
+  class InvalidGrantIdException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class InvalidGrantTokenException extends IKeyManagementServiceException {
+  class InvalidGrantTokenException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class InvalidImportTokenException extends IKeyManagementServiceException {
+  class InvalidImportTokenException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class InvalidKeyUsageException extends IKeyManagementServiceException {
+  class InvalidKeyUsageException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class InvalidMarkerException extends IKeyManagementServiceException {
+  class InvalidMarkerException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- type KeyIdType = x: string | IsValid_KeyIdType(x) witness *
- predicate method IsValid_KeyIdType(x: string) {
- ( 1 <= |x| <= 2048 )
-}
- type KeyList = seq<KeyListEntry>
- datatype KeyListEntry = KeyListEntry (
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly KeyArn: Option<ArnType> )
- trait IKeyManagementServiceClient {
- predicate {:opaque} CancelKeyDeletionCalledWith ( input: CancelKeyDeletionRequest ) {true}
- predicate {:opaque} CancelKeyDeletionSucceededWith (  input: CancelKeyDeletionRequest , output: CancelKeyDeletionResponse ) {true}
- method CancelKeyDeletion ( input: CancelKeyDeletionRequest ) returns  ( output: Result<CancelKeyDeletionResponse, IKeyManagementServiceException> )
-	ensures CancelKeyDeletionCalledWith (  input )
-	ensures output.Success? ==> CancelKeyDeletionSucceededWith (  input , output.value )
+  type KeyIdType = x: string | IsValid_KeyIdType(x) witness *
+  predicate method IsValid_KeyIdType(x: string) {
+    ( 1 <= |x| <= 2048 )
+  }
+  type KeyList = seq<KeyListEntry>
+  datatype KeyListEntry = KeyListEntry (
+                            nameonly KeyId: Option<KeyIdType> ,
+                            nameonly KeyArn: Option<ArnType> )
+  trait IKeyManagementServiceClient {
+    predicate {:opaque} CancelKeyDeletionCalledWith ( input: CancelKeyDeletionRequest ) {true}
+    predicate {:opaque} CancelKeyDeletionSucceededWith (  input: CancelKeyDeletionRequest , output: CancelKeyDeletionResponse ) {true}
+    method CancelKeyDeletion ( input: CancelKeyDeletionRequest ) returns  ( output: Result<CancelKeyDeletionResponse, IKeyManagementServiceException> )
+      ensures CancelKeyDeletionCalledWith (  input )
+      ensures output.Success? ==> CancelKeyDeletionSucceededWith (  input , output.value )
 
- predicate {:opaque} ConnectCustomKeyStoreCalledWith ( input: ConnectCustomKeyStoreRequest ) {true}
- predicate {:opaque} ConnectCustomKeyStoreSucceededWith (  input: ConnectCustomKeyStoreRequest , output: ConnectCustomKeyStoreResponse ) {true}
- method ConnectCustomKeyStore ( input: ConnectCustomKeyStoreRequest ) returns  ( output: Result<ConnectCustomKeyStoreResponse, IKeyManagementServiceException> )
-	ensures ConnectCustomKeyStoreCalledWith (  input )
-	ensures output.Success? ==> ConnectCustomKeyStoreSucceededWith (  input , output.value )
+    predicate {:opaque} ConnectCustomKeyStoreCalledWith ( input: ConnectCustomKeyStoreRequest ) {true}
+    predicate {:opaque} ConnectCustomKeyStoreSucceededWith (  input: ConnectCustomKeyStoreRequest , output: ConnectCustomKeyStoreResponse ) {true}
+    method ConnectCustomKeyStore ( input: ConnectCustomKeyStoreRequest ) returns  ( output: Result<ConnectCustomKeyStoreResponse, IKeyManagementServiceException> )
+      ensures ConnectCustomKeyStoreCalledWith (  input )
+      ensures output.Success? ==> ConnectCustomKeyStoreSucceededWith (  input , output.value )
 
- predicate {:opaque} CreateAliasCalledWith ( input: CreateAliasRequest ) {true}
- predicate {:opaque} CreateAliasSucceededWith (  input: CreateAliasRequest ) {true}
- method CreateAlias ( input: CreateAliasRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures CreateAliasCalledWith (  input )
-	ensures output.Success? ==> CreateAliasSucceededWith (  input )
+    predicate {:opaque} CreateAliasCalledWith ( input: CreateAliasRequest ) {true}
+    predicate {:opaque} CreateAliasSucceededWith (  input: CreateAliasRequest ) {true}
+    method CreateAlias ( input: CreateAliasRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures CreateAliasCalledWith (  input )
+      ensures output.Success? ==> CreateAliasSucceededWith (  input )
 
- predicate {:opaque} CreateCustomKeyStoreCalledWith ( input: CreateCustomKeyStoreRequest ) {true}
- predicate {:opaque} CreateCustomKeyStoreSucceededWith (  input: CreateCustomKeyStoreRequest , output: CreateCustomKeyStoreResponse ) {true}
- method CreateCustomKeyStore ( input: CreateCustomKeyStoreRequest ) returns  ( output: Result<CreateCustomKeyStoreResponse, IKeyManagementServiceException> )
-	ensures CreateCustomKeyStoreCalledWith (  input )
-	ensures output.Success? ==> CreateCustomKeyStoreSucceededWith (  input , output.value )
+    predicate {:opaque} CreateCustomKeyStoreCalledWith ( input: CreateCustomKeyStoreRequest ) {true}
+    predicate {:opaque} CreateCustomKeyStoreSucceededWith (  input: CreateCustomKeyStoreRequest , output: CreateCustomKeyStoreResponse ) {true}
+    method CreateCustomKeyStore ( input: CreateCustomKeyStoreRequest ) returns  ( output: Result<CreateCustomKeyStoreResponse, IKeyManagementServiceException> )
+      ensures CreateCustomKeyStoreCalledWith (  input )
+      ensures output.Success? ==> CreateCustomKeyStoreSucceededWith (  input , output.value )
 
- predicate {:opaque} CreateGrantCalledWith ( input: CreateGrantRequest ) {true}
- predicate {:opaque} CreateGrantSucceededWith (  input: CreateGrantRequest , output: CreateGrantResponse ) {true}
- method CreateGrant ( input: CreateGrantRequest ) returns  ( output: Result<CreateGrantResponse, IKeyManagementServiceException> )
-	ensures CreateGrantCalledWith (  input )
-	ensures output.Success? ==> CreateGrantSucceededWith (  input , output.value )
+    predicate {:opaque} CreateGrantCalledWith ( input: CreateGrantRequest ) {true}
+    predicate {:opaque} CreateGrantSucceededWith (  input: CreateGrantRequest , output: CreateGrantResponse ) {true}
+    method CreateGrant ( input: CreateGrantRequest ) returns  ( output: Result<CreateGrantResponse, IKeyManagementServiceException> )
+      ensures CreateGrantCalledWith (  input )
+      ensures output.Success? ==> CreateGrantSucceededWith (  input , output.value )
 
- predicate {:opaque} CreateKeyCalledWith ( input: CreateKeyRequest ) {true}
- predicate {:opaque} CreateKeySucceededWith (  input: CreateKeyRequest , output: CreateKeyResponse ) {true}
- method CreateKey ( input: CreateKeyRequest ) returns  ( output: Result<CreateKeyResponse, IKeyManagementServiceException> )
-	ensures CreateKeyCalledWith (  input )
-	ensures output.Success? ==> CreateKeySucceededWith (  input , output.value )
+    predicate {:opaque} CreateKeyCalledWith ( input: CreateKeyRequest ) {true}
+    predicate {:opaque} CreateKeySucceededWith (  input: CreateKeyRequest , output: CreateKeyResponse ) {true}
+    method CreateKey ( input: CreateKeyRequest ) returns  ( output: Result<CreateKeyResponse, IKeyManagementServiceException> )
+      ensures CreateKeyCalledWith (  input )
+      ensures output.Success? ==> CreateKeySucceededWith (  input , output.value )
 
- predicate {:opaque} DecryptCalledWith ( input: DecryptRequest ) {true}
- predicate {:opaque} DecryptSucceededWith (  input: DecryptRequest , output: DecryptResponse ) {true}
- method Decrypt ( input: DecryptRequest ) returns  ( output: Result<DecryptResponse, IKeyManagementServiceException> )
-	ensures DecryptCalledWith (  input )
-	ensures output.Success? ==> DecryptSucceededWith (  input , output.value )
+    predicate {:opaque} DecryptCalledWith ( input: DecryptRequest ) {true}
+    predicate {:opaque} DecryptSucceededWith (  input: DecryptRequest , output: DecryptResponse ) {true}
+    method Decrypt ( input: DecryptRequest ) returns  ( output: Result<DecryptResponse, IKeyManagementServiceException> )
+      ensures DecryptCalledWith (  input )
+      ensures output.Success? ==> DecryptSucceededWith (  input , output.value )
 
- predicate {:opaque} DeleteAliasCalledWith ( input: DeleteAliasRequest ) {true}
- predicate {:opaque} DeleteAliasSucceededWith (  input: DeleteAliasRequest ) {true}
- method DeleteAlias ( input: DeleteAliasRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures DeleteAliasCalledWith (  input )
-	ensures output.Success? ==> DeleteAliasSucceededWith (  input )
+    predicate {:opaque} DeleteAliasCalledWith ( input: DeleteAliasRequest ) {true}
+    predicate {:opaque} DeleteAliasSucceededWith (  input: DeleteAliasRequest ) {true}
+    method DeleteAlias ( input: DeleteAliasRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures DeleteAliasCalledWith (  input )
+      ensures output.Success? ==> DeleteAliasSucceededWith (  input )
 
- predicate {:opaque} DeleteCustomKeyStoreCalledWith ( input: DeleteCustomKeyStoreRequest ) {true}
- predicate {:opaque} DeleteCustomKeyStoreSucceededWith (  input: DeleteCustomKeyStoreRequest , output: DeleteCustomKeyStoreResponse ) {true}
- method DeleteCustomKeyStore ( input: DeleteCustomKeyStoreRequest ) returns  ( output: Result<DeleteCustomKeyStoreResponse, IKeyManagementServiceException> )
-	ensures DeleteCustomKeyStoreCalledWith (  input )
-	ensures output.Success? ==> DeleteCustomKeyStoreSucceededWith (  input , output.value )
+    predicate {:opaque} DeleteCustomKeyStoreCalledWith ( input: DeleteCustomKeyStoreRequest ) {true}
+    predicate {:opaque} DeleteCustomKeyStoreSucceededWith (  input: DeleteCustomKeyStoreRequest , output: DeleteCustomKeyStoreResponse ) {true}
+    method DeleteCustomKeyStore ( input: DeleteCustomKeyStoreRequest ) returns  ( output: Result<DeleteCustomKeyStoreResponse, IKeyManagementServiceException> )
+      ensures DeleteCustomKeyStoreCalledWith (  input )
+      ensures output.Success? ==> DeleteCustomKeyStoreSucceededWith (  input , output.value )
 
- predicate {:opaque} DeleteImportedKeyMaterialCalledWith ( input: DeleteImportedKeyMaterialRequest ) {true}
- predicate {:opaque} DeleteImportedKeyMaterialSucceededWith (  input: DeleteImportedKeyMaterialRequest ) {true}
- method DeleteImportedKeyMaterial ( input: DeleteImportedKeyMaterialRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures DeleteImportedKeyMaterialCalledWith (  input )
-	ensures output.Success? ==> DeleteImportedKeyMaterialSucceededWith (  input )
+    predicate {:opaque} DeleteImportedKeyMaterialCalledWith ( input: DeleteImportedKeyMaterialRequest ) {true}
+    predicate {:opaque} DeleteImportedKeyMaterialSucceededWith (  input: DeleteImportedKeyMaterialRequest ) {true}
+    method DeleteImportedKeyMaterial ( input: DeleteImportedKeyMaterialRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures DeleteImportedKeyMaterialCalledWith (  input )
+      ensures output.Success? ==> DeleteImportedKeyMaterialSucceededWith (  input )
 
- predicate {:opaque} DescribeCustomKeyStoresCalledWith ( input: DescribeCustomKeyStoresRequest ) {true}
- predicate {:opaque} DescribeCustomKeyStoresSucceededWith (  input: DescribeCustomKeyStoresRequest , output: DescribeCustomKeyStoresResponse ) {true}
- method DescribeCustomKeyStores ( input: DescribeCustomKeyStoresRequest ) returns  ( output: Result<DescribeCustomKeyStoresResponse, IKeyManagementServiceException> )
-	ensures DescribeCustomKeyStoresCalledWith (  input )
-	ensures output.Success? ==> DescribeCustomKeyStoresSucceededWith (  input , output.value )
+    predicate {:opaque} DescribeCustomKeyStoresCalledWith ( input: DescribeCustomKeyStoresRequest ) {true}
+    predicate {:opaque} DescribeCustomKeyStoresSucceededWith (  input: DescribeCustomKeyStoresRequest , output: DescribeCustomKeyStoresResponse ) {true}
+    method DescribeCustomKeyStores ( input: DescribeCustomKeyStoresRequest ) returns  ( output: Result<DescribeCustomKeyStoresResponse, IKeyManagementServiceException> )
+      ensures DescribeCustomKeyStoresCalledWith (  input )
+      ensures output.Success? ==> DescribeCustomKeyStoresSucceededWith (  input , output.value )
 
- predicate {:opaque} DescribeKeyCalledWith ( input: DescribeKeyRequest ) {true}
- predicate {:opaque} DescribeKeySucceededWith (  input: DescribeKeyRequest , output: DescribeKeyResponse ) {true}
- method DescribeKey ( input: DescribeKeyRequest ) returns  ( output: Result<DescribeKeyResponse, IKeyManagementServiceException> )
-	ensures DescribeKeyCalledWith (  input )
-	ensures output.Success? ==> DescribeKeySucceededWith (  input , output.value )
+    predicate {:opaque} DescribeKeyCalledWith ( input: DescribeKeyRequest ) {true}
+    predicate {:opaque} DescribeKeySucceededWith (  input: DescribeKeyRequest , output: DescribeKeyResponse ) {true}
+    method DescribeKey ( input: DescribeKeyRequest ) returns  ( output: Result<DescribeKeyResponse, IKeyManagementServiceException> )
+      ensures DescribeKeyCalledWith (  input )
+      ensures output.Success? ==> DescribeKeySucceededWith (  input , output.value )
 
- predicate {:opaque} DisableKeyCalledWith ( input: DisableKeyRequest ) {true}
- predicate {:opaque} DisableKeySucceededWith (  input: DisableKeyRequest ) {true}
- method DisableKey ( input: DisableKeyRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures DisableKeyCalledWith (  input )
-	ensures output.Success? ==> DisableKeySucceededWith (  input )
+    predicate {:opaque} DisableKeyCalledWith ( input: DisableKeyRequest ) {true}
+    predicate {:opaque} DisableKeySucceededWith (  input: DisableKeyRequest ) {true}
+    method DisableKey ( input: DisableKeyRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures DisableKeyCalledWith (  input )
+      ensures output.Success? ==> DisableKeySucceededWith (  input )
 
- predicate {:opaque} DisableKeyRotationCalledWith ( input: DisableKeyRotationRequest ) {true}
- predicate {:opaque} DisableKeyRotationSucceededWith (  input: DisableKeyRotationRequest ) {true}
- method DisableKeyRotation ( input: DisableKeyRotationRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures DisableKeyRotationCalledWith (  input )
-	ensures output.Success? ==> DisableKeyRotationSucceededWith (  input )
+    predicate {:opaque} DisableKeyRotationCalledWith ( input: DisableKeyRotationRequest ) {true}
+    predicate {:opaque} DisableKeyRotationSucceededWith (  input: DisableKeyRotationRequest ) {true}
+    method DisableKeyRotation ( input: DisableKeyRotationRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures DisableKeyRotationCalledWith (  input )
+      ensures output.Success? ==> DisableKeyRotationSucceededWith (  input )
 
- predicate {:opaque} DisconnectCustomKeyStoreCalledWith ( input: DisconnectCustomKeyStoreRequest ) {true}
- predicate {:opaque} DisconnectCustomKeyStoreSucceededWith (  input: DisconnectCustomKeyStoreRequest , output: DisconnectCustomKeyStoreResponse ) {true}
- method DisconnectCustomKeyStore ( input: DisconnectCustomKeyStoreRequest ) returns  ( output: Result<DisconnectCustomKeyStoreResponse, IKeyManagementServiceException> )
-	ensures DisconnectCustomKeyStoreCalledWith (  input )
-	ensures output.Success? ==> DisconnectCustomKeyStoreSucceededWith (  input , output.value )
+    predicate {:opaque} DisconnectCustomKeyStoreCalledWith ( input: DisconnectCustomKeyStoreRequest ) {true}
+    predicate {:opaque} DisconnectCustomKeyStoreSucceededWith (  input: DisconnectCustomKeyStoreRequest , output: DisconnectCustomKeyStoreResponse ) {true}
+    method DisconnectCustomKeyStore ( input: DisconnectCustomKeyStoreRequest ) returns  ( output: Result<DisconnectCustomKeyStoreResponse, IKeyManagementServiceException> )
+      ensures DisconnectCustomKeyStoreCalledWith (  input )
+      ensures output.Success? ==> DisconnectCustomKeyStoreSucceededWith (  input , output.value )
 
- predicate {:opaque} EnableKeyCalledWith ( input: EnableKeyRequest ) {true}
- predicate {:opaque} EnableKeySucceededWith (  input: EnableKeyRequest ) {true}
- method EnableKey ( input: EnableKeyRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures EnableKeyCalledWith (  input )
-	ensures output.Success? ==> EnableKeySucceededWith (  input )
+    predicate {:opaque} EnableKeyCalledWith ( input: EnableKeyRequest ) {true}
+    predicate {:opaque} EnableKeySucceededWith (  input: EnableKeyRequest ) {true}
+    method EnableKey ( input: EnableKeyRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures EnableKeyCalledWith (  input )
+      ensures output.Success? ==> EnableKeySucceededWith (  input )
 
- predicate {:opaque} EnableKeyRotationCalledWith ( input: EnableKeyRotationRequest ) {true}
- predicate {:opaque} EnableKeyRotationSucceededWith (  input: EnableKeyRotationRequest ) {true}
- method EnableKeyRotation ( input: EnableKeyRotationRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures EnableKeyRotationCalledWith (  input )
-	ensures output.Success? ==> EnableKeyRotationSucceededWith (  input )
+    predicate {:opaque} EnableKeyRotationCalledWith ( input: EnableKeyRotationRequest ) {true}
+    predicate {:opaque} EnableKeyRotationSucceededWith (  input: EnableKeyRotationRequest ) {true}
+    method EnableKeyRotation ( input: EnableKeyRotationRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures EnableKeyRotationCalledWith (  input )
+      ensures output.Success? ==> EnableKeyRotationSucceededWith (  input )
 
- predicate {:opaque} EncryptCalledWith ( input: EncryptRequest ) {true}
- predicate {:opaque} EncryptSucceededWith (  input: EncryptRequest , output: EncryptResponse ) {true}
- method Encrypt ( input: EncryptRequest ) returns  ( output: Result<EncryptResponse, IKeyManagementServiceException> )
-	ensures EncryptCalledWith (  input )
-	ensures output.Success? ==> EncryptSucceededWith (  input , output.value )
+    predicate {:opaque} EncryptCalledWith ( input: EncryptRequest ) {true}
+    predicate {:opaque} EncryptSucceededWith (  input: EncryptRequest , output: EncryptResponse ) {true}
+    method Encrypt ( input: EncryptRequest ) returns  ( output: Result<EncryptResponse, IKeyManagementServiceException> )
+      ensures EncryptCalledWith (  input )
+      ensures output.Success? ==> EncryptSucceededWith (  input , output.value )
 
- predicate {:opaque} GenerateDataKeyCalledWith ( input: GenerateDataKeyRequest ) {true}
- predicate {:opaque} GenerateDataKeySucceededWith (  input: GenerateDataKeyRequest , output: GenerateDataKeyResponse ) {true}
- method GenerateDataKey ( input: GenerateDataKeyRequest ) returns  ( output: Result<GenerateDataKeyResponse, IKeyManagementServiceException> )
-	ensures GenerateDataKeyCalledWith (  input )
-	ensures output.Success? ==> GenerateDataKeySucceededWith (  input , output.value )
+    predicate {:opaque} GenerateDataKeyCalledWith ( input: GenerateDataKeyRequest ) {true}
+    predicate {:opaque} GenerateDataKeySucceededWith (  input: GenerateDataKeyRequest , output: GenerateDataKeyResponse ) {true}
+    method GenerateDataKey ( input: GenerateDataKeyRequest ) returns  ( output: Result<GenerateDataKeyResponse, IKeyManagementServiceException> )
+      ensures GenerateDataKeyCalledWith (  input )
+      ensures output.Success? ==> GenerateDataKeySucceededWith (  input , output.value )
 
- predicate {:opaque} GenerateDataKeyPairCalledWith ( input: GenerateDataKeyPairRequest ) {true}
- predicate {:opaque} GenerateDataKeyPairSucceededWith (  input: GenerateDataKeyPairRequest , output: GenerateDataKeyPairResponse ) {true}
- method GenerateDataKeyPair ( input: GenerateDataKeyPairRequest ) returns  ( output: Result<GenerateDataKeyPairResponse, IKeyManagementServiceException> )
-	ensures GenerateDataKeyPairCalledWith (  input )
-	ensures output.Success? ==> GenerateDataKeyPairSucceededWith (  input , output.value )
+    predicate {:opaque} GenerateDataKeyPairCalledWith ( input: GenerateDataKeyPairRequest ) {true}
+    predicate {:opaque} GenerateDataKeyPairSucceededWith (  input: GenerateDataKeyPairRequest , output: GenerateDataKeyPairResponse ) {true}
+    method GenerateDataKeyPair ( input: GenerateDataKeyPairRequest ) returns  ( output: Result<GenerateDataKeyPairResponse, IKeyManagementServiceException> )
+      ensures GenerateDataKeyPairCalledWith (  input )
+      ensures output.Success? ==> GenerateDataKeyPairSucceededWith (  input , output.value )
 
- predicate {:opaque} GenerateDataKeyPairWithoutPlaintextCalledWith ( input: GenerateDataKeyPairWithoutPlaintextRequest ) {true}
- predicate {:opaque} GenerateDataKeyPairWithoutPlaintextSucceededWith (  input: GenerateDataKeyPairWithoutPlaintextRequest , output: GenerateDataKeyPairWithoutPlaintextResponse ) {true}
- method GenerateDataKeyPairWithoutPlaintext ( input: GenerateDataKeyPairWithoutPlaintextRequest ) returns  ( output: Result<GenerateDataKeyPairWithoutPlaintextResponse, IKeyManagementServiceException> )
-	ensures GenerateDataKeyPairWithoutPlaintextCalledWith (  input )
-	ensures output.Success? ==> GenerateDataKeyPairWithoutPlaintextSucceededWith (  input , output.value )
+    predicate {:opaque} GenerateDataKeyPairWithoutPlaintextCalledWith ( input: GenerateDataKeyPairWithoutPlaintextRequest ) {true}
+    predicate {:opaque} GenerateDataKeyPairWithoutPlaintextSucceededWith (  input: GenerateDataKeyPairWithoutPlaintextRequest , output: GenerateDataKeyPairWithoutPlaintextResponse ) {true}
+    method GenerateDataKeyPairWithoutPlaintext ( input: GenerateDataKeyPairWithoutPlaintextRequest ) returns  ( output: Result<GenerateDataKeyPairWithoutPlaintextResponse, IKeyManagementServiceException> )
+      ensures GenerateDataKeyPairWithoutPlaintextCalledWith (  input )
+      ensures output.Success? ==> GenerateDataKeyPairWithoutPlaintextSucceededWith (  input , output.value )
 
- predicate {:opaque} GenerateDataKeyWithoutPlaintextCalledWith ( input: GenerateDataKeyWithoutPlaintextRequest ) {true}
- predicate {:opaque} GenerateDataKeyWithoutPlaintextSucceededWith (  input: GenerateDataKeyWithoutPlaintextRequest , output: GenerateDataKeyWithoutPlaintextResponse ) {true}
- method GenerateDataKeyWithoutPlaintext ( input: GenerateDataKeyWithoutPlaintextRequest ) returns  ( output: Result<GenerateDataKeyWithoutPlaintextResponse, IKeyManagementServiceException> )
-	ensures GenerateDataKeyWithoutPlaintextCalledWith (  input )
-	ensures output.Success? ==> GenerateDataKeyWithoutPlaintextSucceededWith (  input , output.value )
+    predicate {:opaque} GenerateDataKeyWithoutPlaintextCalledWith ( input: GenerateDataKeyWithoutPlaintextRequest ) {true}
+    predicate {:opaque} GenerateDataKeyWithoutPlaintextSucceededWith (  input: GenerateDataKeyWithoutPlaintextRequest , output: GenerateDataKeyWithoutPlaintextResponse ) {true}
+    method GenerateDataKeyWithoutPlaintext ( input: GenerateDataKeyWithoutPlaintextRequest ) returns  ( output: Result<GenerateDataKeyWithoutPlaintextResponse, IKeyManagementServiceException> )
+      ensures GenerateDataKeyWithoutPlaintextCalledWith (  input )
+      ensures output.Success? ==> GenerateDataKeyWithoutPlaintextSucceededWith (  input , output.value )
 
- predicate {:opaque} GenerateRandomCalledWith ( input: GenerateRandomRequest ) {true}
- predicate {:opaque} GenerateRandomSucceededWith (  input: GenerateRandomRequest , output: GenerateRandomResponse ) {true}
- method GenerateRandom ( input: GenerateRandomRequest ) returns  ( output: Result<GenerateRandomResponse, IKeyManagementServiceException> )
-	ensures GenerateRandomCalledWith (  input )
-	ensures output.Success? ==> GenerateRandomSucceededWith (  input , output.value )
+    predicate {:opaque} GenerateRandomCalledWith ( input: GenerateRandomRequest ) {true}
+    predicate {:opaque} GenerateRandomSucceededWith (  input: GenerateRandomRequest , output: GenerateRandomResponse ) {true}
+    method GenerateRandom ( input: GenerateRandomRequest ) returns  ( output: Result<GenerateRandomResponse, IKeyManagementServiceException> )
+      ensures GenerateRandomCalledWith (  input )
+      ensures output.Success? ==> GenerateRandomSucceededWith (  input , output.value )
 
- predicate {:opaque} GetKeyPolicyCalledWith ( input: GetKeyPolicyRequest ) {true}
- predicate {:opaque} GetKeyPolicySucceededWith (  input: GetKeyPolicyRequest , output: GetKeyPolicyResponse ) {true}
- method GetKeyPolicy ( input: GetKeyPolicyRequest ) returns  ( output: Result<GetKeyPolicyResponse, IKeyManagementServiceException> )
-	ensures GetKeyPolicyCalledWith (  input )
-	ensures output.Success? ==> GetKeyPolicySucceededWith (  input , output.value )
+    predicate {:opaque} GetKeyPolicyCalledWith ( input: GetKeyPolicyRequest ) {true}
+    predicate {:opaque} GetKeyPolicySucceededWith (  input: GetKeyPolicyRequest , output: GetKeyPolicyResponse ) {true}
+    method GetKeyPolicy ( input: GetKeyPolicyRequest ) returns  ( output: Result<GetKeyPolicyResponse, IKeyManagementServiceException> )
+      ensures GetKeyPolicyCalledWith (  input )
+      ensures output.Success? ==> GetKeyPolicySucceededWith (  input , output.value )
 
- predicate {:opaque} GetKeyRotationStatusCalledWith ( input: GetKeyRotationStatusRequest ) {true}
- predicate {:opaque} GetKeyRotationStatusSucceededWith (  input: GetKeyRotationStatusRequest , output: GetKeyRotationStatusResponse ) {true}
- method GetKeyRotationStatus ( input: GetKeyRotationStatusRequest ) returns  ( output: Result<GetKeyRotationStatusResponse, IKeyManagementServiceException> )
-	ensures GetKeyRotationStatusCalledWith (  input )
-	ensures output.Success? ==> GetKeyRotationStatusSucceededWith (  input , output.value )
+    predicate {:opaque} GetKeyRotationStatusCalledWith ( input: GetKeyRotationStatusRequest ) {true}
+    predicate {:opaque} GetKeyRotationStatusSucceededWith (  input: GetKeyRotationStatusRequest , output: GetKeyRotationStatusResponse ) {true}
+    method GetKeyRotationStatus ( input: GetKeyRotationStatusRequest ) returns  ( output: Result<GetKeyRotationStatusResponse, IKeyManagementServiceException> )
+      ensures GetKeyRotationStatusCalledWith (  input )
+      ensures output.Success? ==> GetKeyRotationStatusSucceededWith (  input , output.value )
 
- predicate {:opaque} GetParametersForImportCalledWith ( input: GetParametersForImportRequest ) {true}
- predicate {:opaque} GetParametersForImportSucceededWith (  input: GetParametersForImportRequest , output: GetParametersForImportResponse ) {true}
- method GetParametersForImport ( input: GetParametersForImportRequest ) returns  ( output: Result<GetParametersForImportResponse, IKeyManagementServiceException> )
-	ensures GetParametersForImportCalledWith (  input )
-	ensures output.Success? ==> GetParametersForImportSucceededWith (  input , output.value )
+    predicate {:opaque} GetParametersForImportCalledWith ( input: GetParametersForImportRequest ) {true}
+    predicate {:opaque} GetParametersForImportSucceededWith (  input: GetParametersForImportRequest , output: GetParametersForImportResponse ) {true}
+    method GetParametersForImport ( input: GetParametersForImportRequest ) returns  ( output: Result<GetParametersForImportResponse, IKeyManagementServiceException> )
+      ensures GetParametersForImportCalledWith (  input )
+      ensures output.Success? ==> GetParametersForImportSucceededWith (  input , output.value )
 
- predicate {:opaque} GetPublicKeyCalledWith ( input: GetPublicKeyRequest ) {true}
- predicate {:opaque} GetPublicKeySucceededWith (  input: GetPublicKeyRequest , output: GetPublicKeyResponse ) {true}
- method GetPublicKey ( input: GetPublicKeyRequest ) returns  ( output: Result<GetPublicKeyResponse, IKeyManagementServiceException> )
-	ensures GetPublicKeyCalledWith (  input )
-	ensures output.Success? ==> GetPublicKeySucceededWith (  input , output.value )
+    predicate {:opaque} GetPublicKeyCalledWith ( input: GetPublicKeyRequest ) {true}
+    predicate {:opaque} GetPublicKeySucceededWith (  input: GetPublicKeyRequest , output: GetPublicKeyResponse ) {true}
+    method GetPublicKey ( input: GetPublicKeyRequest ) returns  ( output: Result<GetPublicKeyResponse, IKeyManagementServiceException> )
+      ensures GetPublicKeyCalledWith (  input )
+      ensures output.Success? ==> GetPublicKeySucceededWith (  input , output.value )
 
- predicate {:opaque} ImportKeyMaterialCalledWith ( input: ImportKeyMaterialRequest ) {true}
- predicate {:opaque} ImportKeyMaterialSucceededWith (  input: ImportKeyMaterialRequest , output: ImportKeyMaterialResponse ) {true}
- method ImportKeyMaterial ( input: ImportKeyMaterialRequest ) returns  ( output: Result<ImportKeyMaterialResponse, IKeyManagementServiceException> )
-	ensures ImportKeyMaterialCalledWith (  input )
-	ensures output.Success? ==> ImportKeyMaterialSucceededWith (  input , output.value )
+    predicate {:opaque} ImportKeyMaterialCalledWith ( input: ImportKeyMaterialRequest ) {true}
+    predicate {:opaque} ImportKeyMaterialSucceededWith (  input: ImportKeyMaterialRequest , output: ImportKeyMaterialResponse ) {true}
+    method ImportKeyMaterial ( input: ImportKeyMaterialRequest ) returns  ( output: Result<ImportKeyMaterialResponse, IKeyManagementServiceException> )
+      ensures ImportKeyMaterialCalledWith (  input )
+      ensures output.Success? ==> ImportKeyMaterialSucceededWith (  input , output.value )
 
- predicate {:opaque} ListAliasesCalledWith ( input: ListAliasesRequest ) {true}
- predicate {:opaque} ListAliasesSucceededWith (  input: ListAliasesRequest , output: ListAliasesResponse ) {true}
- method ListAliases ( input: ListAliasesRequest ) returns  ( output: Result<ListAliasesResponse, IKeyManagementServiceException> )
-	ensures ListAliasesCalledWith (  input )
-	ensures output.Success? ==> ListAliasesSucceededWith (  input , output.value )
+    predicate {:opaque} ListAliasesCalledWith ( input: ListAliasesRequest ) {true}
+    predicate {:opaque} ListAliasesSucceededWith (  input: ListAliasesRequest , output: ListAliasesResponse ) {true}
+    method ListAliases ( input: ListAliasesRequest ) returns  ( output: Result<ListAliasesResponse, IKeyManagementServiceException> )
+      ensures ListAliasesCalledWith (  input )
+      ensures output.Success? ==> ListAliasesSucceededWith (  input , output.value )
 
- predicate {:opaque} ListGrantsCalledWith ( input: ListGrantsRequest ) {true}
- predicate {:opaque} ListGrantsSucceededWith (  input: ListGrantsRequest , output: ListGrantsResponse ) {true}
- method ListGrants ( input: ListGrantsRequest ) returns  ( output: Result<ListGrantsResponse, IKeyManagementServiceException> )
-	ensures ListGrantsCalledWith (  input )
-	ensures output.Success? ==> ListGrantsSucceededWith (  input , output.value )
+    predicate {:opaque} ListGrantsCalledWith ( input: ListGrantsRequest ) {true}
+    predicate {:opaque} ListGrantsSucceededWith (  input: ListGrantsRequest , output: ListGrantsResponse ) {true}
+    method ListGrants ( input: ListGrantsRequest ) returns  ( output: Result<ListGrantsResponse, IKeyManagementServiceException> )
+      ensures ListGrantsCalledWith (  input )
+      ensures output.Success? ==> ListGrantsSucceededWith (  input , output.value )
 
- predicate {:opaque} ListKeyPoliciesCalledWith ( input: ListKeyPoliciesRequest ) {true}
- predicate {:opaque} ListKeyPoliciesSucceededWith (  input: ListKeyPoliciesRequest , output: ListKeyPoliciesResponse ) {true}
- method ListKeyPolicies ( input: ListKeyPoliciesRequest ) returns  ( output: Result<ListKeyPoliciesResponse, IKeyManagementServiceException> )
-	ensures ListKeyPoliciesCalledWith (  input )
-	ensures output.Success? ==> ListKeyPoliciesSucceededWith (  input , output.value )
+    predicate {:opaque} ListKeyPoliciesCalledWith ( input: ListKeyPoliciesRequest ) {true}
+    predicate {:opaque} ListKeyPoliciesSucceededWith (  input: ListKeyPoliciesRequest , output: ListKeyPoliciesResponse ) {true}
+    method ListKeyPolicies ( input: ListKeyPoliciesRequest ) returns  ( output: Result<ListKeyPoliciesResponse, IKeyManagementServiceException> )
+      ensures ListKeyPoliciesCalledWith (  input )
+      ensures output.Success? ==> ListKeyPoliciesSucceededWith (  input , output.value )
 
- predicate {:opaque} ListResourceTagsCalledWith ( input: ListResourceTagsRequest ) {true}
- predicate {:opaque} ListResourceTagsSucceededWith (  input: ListResourceTagsRequest , output: ListResourceTagsResponse ) {true}
- method ListResourceTags ( input: ListResourceTagsRequest ) returns  ( output: Result<ListResourceTagsResponse, IKeyManagementServiceException> )
-	ensures ListResourceTagsCalledWith (  input )
-	ensures output.Success? ==> ListResourceTagsSucceededWith (  input , output.value )
+    predicate {:opaque} ListResourceTagsCalledWith ( input: ListResourceTagsRequest ) {true}
+    predicate {:opaque} ListResourceTagsSucceededWith (  input: ListResourceTagsRequest , output: ListResourceTagsResponse ) {true}
+    method ListResourceTags ( input: ListResourceTagsRequest ) returns  ( output: Result<ListResourceTagsResponse, IKeyManagementServiceException> )
+      ensures ListResourceTagsCalledWith (  input )
+      ensures output.Success? ==> ListResourceTagsSucceededWith (  input , output.value )
 
- predicate {:opaque} PutKeyPolicyCalledWith ( input: PutKeyPolicyRequest ) {true}
- predicate {:opaque} PutKeyPolicySucceededWith (  input: PutKeyPolicyRequest ) {true}
- method PutKeyPolicy ( input: PutKeyPolicyRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures PutKeyPolicyCalledWith (  input )
-	ensures output.Success? ==> PutKeyPolicySucceededWith (  input )
+    predicate {:opaque} PutKeyPolicyCalledWith ( input: PutKeyPolicyRequest ) {true}
+    predicate {:opaque} PutKeyPolicySucceededWith (  input: PutKeyPolicyRequest ) {true}
+    method PutKeyPolicy ( input: PutKeyPolicyRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures PutKeyPolicyCalledWith (  input )
+      ensures output.Success? ==> PutKeyPolicySucceededWith (  input )
 
- predicate {:opaque} ReEncryptCalledWith ( input: ReEncryptRequest ) {true}
- predicate {:opaque} ReEncryptSucceededWith (  input: ReEncryptRequest , output: ReEncryptResponse ) {true}
- method ReEncrypt ( input: ReEncryptRequest ) returns  ( output: Result<ReEncryptResponse, IKeyManagementServiceException> )
-	ensures ReEncryptCalledWith (  input )
-	ensures output.Success? ==> ReEncryptSucceededWith (  input , output.value )
+    predicate {:opaque} ReEncryptCalledWith ( input: ReEncryptRequest ) {true}
+    predicate {:opaque} ReEncryptSucceededWith (  input: ReEncryptRequest , output: ReEncryptResponse ) {true}
+    method ReEncrypt ( input: ReEncryptRequest ) returns  ( output: Result<ReEncryptResponse, IKeyManagementServiceException> )
+      ensures ReEncryptCalledWith (  input )
+      ensures output.Success? ==> ReEncryptSucceededWith (  input , output.value )
 
- predicate {:opaque} ReplicateKeyCalledWith ( input: ReplicateKeyRequest ) {true}
- predicate {:opaque} ReplicateKeySucceededWith (  input: ReplicateKeyRequest , output: ReplicateKeyResponse ) {true}
- method ReplicateKey ( input: ReplicateKeyRequest ) returns  ( output: Result<ReplicateKeyResponse, IKeyManagementServiceException> )
-	ensures ReplicateKeyCalledWith (  input )
-	ensures output.Success? ==> ReplicateKeySucceededWith (  input , output.value )
+    predicate {:opaque} ReplicateKeyCalledWith ( input: ReplicateKeyRequest ) {true}
+    predicate {:opaque} ReplicateKeySucceededWith (  input: ReplicateKeyRequest , output: ReplicateKeyResponse ) {true}
+    method ReplicateKey ( input: ReplicateKeyRequest ) returns  ( output: Result<ReplicateKeyResponse, IKeyManagementServiceException> )
+      ensures ReplicateKeyCalledWith (  input )
+      ensures output.Success? ==> ReplicateKeySucceededWith (  input , output.value )
 
- predicate {:opaque} RetireGrantCalledWith ( input: RetireGrantRequest ) {true}
- predicate {:opaque} RetireGrantSucceededWith (  input: RetireGrantRequest ) {true}
- method RetireGrant ( input: RetireGrantRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures RetireGrantCalledWith (  input )
-	ensures output.Success? ==> RetireGrantSucceededWith (  input )
+    predicate {:opaque} RetireGrantCalledWith ( input: RetireGrantRequest ) {true}
+    predicate {:opaque} RetireGrantSucceededWith (  input: RetireGrantRequest ) {true}
+    method RetireGrant ( input: RetireGrantRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures RetireGrantCalledWith (  input )
+      ensures output.Success? ==> RetireGrantSucceededWith (  input )
 
- predicate {:opaque} RevokeGrantCalledWith ( input: RevokeGrantRequest ) {true}
- predicate {:opaque} RevokeGrantSucceededWith (  input: RevokeGrantRequest ) {true}
- method RevokeGrant ( input: RevokeGrantRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures RevokeGrantCalledWith (  input )
-	ensures output.Success? ==> RevokeGrantSucceededWith (  input )
+    predicate {:opaque} RevokeGrantCalledWith ( input: RevokeGrantRequest ) {true}
+    predicate {:opaque} RevokeGrantSucceededWith (  input: RevokeGrantRequest ) {true}
+    method RevokeGrant ( input: RevokeGrantRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures RevokeGrantCalledWith (  input )
+      ensures output.Success? ==> RevokeGrantSucceededWith (  input )
 
- predicate {:opaque} ScheduleKeyDeletionCalledWith ( input: ScheduleKeyDeletionRequest ) {true}
- predicate {:opaque} ScheduleKeyDeletionSucceededWith (  input: ScheduleKeyDeletionRequest , output: ScheduleKeyDeletionResponse ) {true}
- method ScheduleKeyDeletion ( input: ScheduleKeyDeletionRequest ) returns  ( output: Result<ScheduleKeyDeletionResponse, IKeyManagementServiceException> )
-	ensures ScheduleKeyDeletionCalledWith (  input )
-	ensures output.Success? ==> ScheduleKeyDeletionSucceededWith (  input , output.value )
+    predicate {:opaque} ScheduleKeyDeletionCalledWith ( input: ScheduleKeyDeletionRequest ) {true}
+    predicate {:opaque} ScheduleKeyDeletionSucceededWith (  input: ScheduleKeyDeletionRequest , output: ScheduleKeyDeletionResponse ) {true}
+    method ScheduleKeyDeletion ( input: ScheduleKeyDeletionRequest ) returns  ( output: Result<ScheduleKeyDeletionResponse, IKeyManagementServiceException> )
+      ensures ScheduleKeyDeletionCalledWith (  input )
+      ensures output.Success? ==> ScheduleKeyDeletionSucceededWith (  input , output.value )
 
- predicate {:opaque} SignCalledWith ( input: SignRequest ) {true}
- predicate {:opaque} SignSucceededWith (  input: SignRequest , output: SignResponse ) {true}
- method Sign ( input: SignRequest ) returns  ( output: Result<SignResponse, IKeyManagementServiceException> )
-	ensures SignCalledWith (  input )
-	ensures output.Success? ==> SignSucceededWith (  input , output.value )
+    predicate {:opaque} SignCalledWith ( input: SignRequest ) {true}
+    predicate {:opaque} SignSucceededWith (  input: SignRequest , output: SignResponse ) {true}
+    method Sign ( input: SignRequest ) returns  ( output: Result<SignResponse, IKeyManagementServiceException> )
+      ensures SignCalledWith (  input )
+      ensures output.Success? ==> SignSucceededWith (  input , output.value )
 
- predicate {:opaque} TagResourceCalledWith ( input: TagResourceRequest ) {true}
- predicate {:opaque} TagResourceSucceededWith (  input: TagResourceRequest ) {true}
- method TagResource ( input: TagResourceRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures TagResourceCalledWith (  input )
-	ensures output.Success? ==> TagResourceSucceededWith (  input )
+    predicate {:opaque} TagResourceCalledWith ( input: TagResourceRequest ) {true}
+    predicate {:opaque} TagResourceSucceededWith (  input: TagResourceRequest ) {true}
+    method TagResource ( input: TagResourceRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures TagResourceCalledWith (  input )
+      ensures output.Success? ==> TagResourceSucceededWith (  input )
 
- predicate {:opaque} UntagResourceCalledWith ( input: UntagResourceRequest ) {true}
- predicate {:opaque} UntagResourceSucceededWith (  input: UntagResourceRequest ) {true}
- method UntagResource ( input: UntagResourceRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures UntagResourceCalledWith (  input )
-	ensures output.Success? ==> UntagResourceSucceededWith (  input )
+    predicate {:opaque} UntagResourceCalledWith ( input: UntagResourceRequest ) {true}
+    predicate {:opaque} UntagResourceSucceededWith (  input: UntagResourceRequest ) {true}
+    method UntagResource ( input: UntagResourceRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures UntagResourceCalledWith (  input )
+      ensures output.Success? ==> UntagResourceSucceededWith (  input )
 
- predicate {:opaque} UpdateAliasCalledWith ( input: UpdateAliasRequest ) {true}
- predicate {:opaque} UpdateAliasSucceededWith (  input: UpdateAliasRequest ) {true}
- method UpdateAlias ( input: UpdateAliasRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures UpdateAliasCalledWith (  input )
-	ensures output.Success? ==> UpdateAliasSucceededWith (  input )
+    predicate {:opaque} UpdateAliasCalledWith ( input: UpdateAliasRequest ) {true}
+    predicate {:opaque} UpdateAliasSucceededWith (  input: UpdateAliasRequest ) {true}
+    method UpdateAlias ( input: UpdateAliasRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures UpdateAliasCalledWith (  input )
+      ensures output.Success? ==> UpdateAliasSucceededWith (  input )
 
- predicate {:opaque} UpdateCustomKeyStoreCalledWith ( input: UpdateCustomKeyStoreRequest ) {true}
- predicate {:opaque} UpdateCustomKeyStoreSucceededWith (  input: UpdateCustomKeyStoreRequest , output: UpdateCustomKeyStoreResponse ) {true}
- method UpdateCustomKeyStore ( input: UpdateCustomKeyStoreRequest ) returns  ( output: Result<UpdateCustomKeyStoreResponse, IKeyManagementServiceException> )
-	ensures UpdateCustomKeyStoreCalledWith (  input )
-	ensures output.Success? ==> UpdateCustomKeyStoreSucceededWith (  input , output.value )
+    predicate {:opaque} UpdateCustomKeyStoreCalledWith ( input: UpdateCustomKeyStoreRequest ) {true}
+    predicate {:opaque} UpdateCustomKeyStoreSucceededWith (  input: UpdateCustomKeyStoreRequest , output: UpdateCustomKeyStoreResponse ) {true}
+    method UpdateCustomKeyStore ( input: UpdateCustomKeyStoreRequest ) returns  ( output: Result<UpdateCustomKeyStoreResponse, IKeyManagementServiceException> )
+      ensures UpdateCustomKeyStoreCalledWith (  input )
+      ensures output.Success? ==> UpdateCustomKeyStoreSucceededWith (  input , output.value )
 
- predicate {:opaque} UpdateKeyDescriptionCalledWith ( input: UpdateKeyDescriptionRequest ) {true}
- predicate {:opaque} UpdateKeyDescriptionSucceededWith (  input: UpdateKeyDescriptionRequest ) {true}
- method UpdateKeyDescription ( input: UpdateKeyDescriptionRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures UpdateKeyDescriptionCalledWith (  input )
-	ensures output.Success? ==> UpdateKeyDescriptionSucceededWith (  input )
+    predicate {:opaque} UpdateKeyDescriptionCalledWith ( input: UpdateKeyDescriptionRequest ) {true}
+    predicate {:opaque} UpdateKeyDescriptionSucceededWith (  input: UpdateKeyDescriptionRequest ) {true}
+    method UpdateKeyDescription ( input: UpdateKeyDescriptionRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures UpdateKeyDescriptionCalledWith (  input )
+      ensures output.Success? ==> UpdateKeyDescriptionSucceededWith (  input )
 
- predicate {:opaque} UpdatePrimaryRegionCalledWith ( input: UpdatePrimaryRegionRequest ) {true}
- predicate {:opaque} UpdatePrimaryRegionSucceededWith (  input: UpdatePrimaryRegionRequest ) {true}
- method UpdatePrimaryRegion ( input: UpdatePrimaryRegionRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
-	ensures UpdatePrimaryRegionCalledWith (  input )
-	ensures output.Success? ==> UpdatePrimaryRegionSucceededWith (  input )
+    predicate {:opaque} UpdatePrimaryRegionCalledWith ( input: UpdatePrimaryRegionRequest ) {true}
+    predicate {:opaque} UpdatePrimaryRegionSucceededWith (  input: UpdatePrimaryRegionRequest ) {true}
+    method UpdatePrimaryRegion ( input: UpdatePrimaryRegionRequest ) returns  ( output: Result<(), IKeyManagementServiceException> )
+      ensures UpdatePrimaryRegionCalledWith (  input )
+      ensures output.Success? ==> UpdatePrimaryRegionSucceededWith (  input )
 
- predicate {:opaque} VerifyCalledWith ( input: VerifyRequest ) {true}
- predicate {:opaque} VerifySucceededWith (  input: VerifyRequest , output: VerifyResponse ) {true}
- method Verify ( input: VerifyRequest ) returns  ( output: Result<VerifyResponse, IKeyManagementServiceException> )
-	ensures VerifyCalledWith (  input )
-	ensures output.Success? ==> VerifySucceededWith (  input , output.value )
+    predicate {:opaque} VerifyCalledWith ( input: VerifyRequest ) {true}
+    predicate {:opaque} VerifySucceededWith (  input: VerifyRequest , output: VerifyResponse ) {true}
+    method Verify ( input: VerifyRequest ) returns  ( output: Result<VerifyResponse, IKeyManagementServiceException> )
+      ensures VerifyCalledWith (  input )
+      ensures output.Success? ==> VerifySucceededWith (  input , output.value )
 
-}
- trait IKeyManagementServiceException {
+  }
+  trait IKeyManagementServiceException {
     function method GetMessage(): (message: string) reads this
-}
+  }
 
- class UnknownKeyManagementServiceError extends IKeyManagementServiceException {
+  class UnknownKeyManagementServiceError extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- datatype KeyManagerType =
-	| AWS
-	| CUSTOMER
- datatype KeyMetadata = KeyMetadata (
-	nameonly AWSAccountId: Option<AWSAccountIdType> ,
-	nameonly KeyId: KeyIdType ,
-	nameonly Arn: Option<ArnType> ,
-	nameonly CreationDate: Option<string> ,
-	nameonly Enabled: Option<BooleanType> ,
-	nameonly Description: Option<DescriptionType> ,
-	nameonly KeyUsage: Option<KeyUsageType> ,
-	nameonly KeyState: Option<KeyState> ,
-	nameonly DeletionDate: Option<string> ,
-	nameonly ValidTo: Option<string> ,
-	nameonly Origin: Option<OriginType> ,
-	nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
-	nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> ,
-	nameonly ExpirationModel: Option<ExpirationModelType> ,
-	nameonly KeyManager: Option<KeyManagerType> ,
-	nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
-	nameonly KeySpec: Option<KeySpec> ,
-	nameonly EncryptionAlgorithms: Option<EncryptionAlgorithmSpecList> ,
-	nameonly SigningAlgorithms: Option<SigningAlgorithmSpecList> ,
-	nameonly MultiRegion: Option<NullableBooleanType> ,
-	nameonly MultiRegionConfiguration: Option<MultiRegionConfiguration> ,
-	nameonly PendingDeletionWindowInDays: Option<PendingWindowInDaysType> )
- datatype KeySpec =
-	| RSA_2048
-	| RSA_3072
-	| RSA_4096
-	| ECC_NIST_P256
-	| ECC_NIST_P384
-	| ECC_NIST_P521
-	| ECC_SECG_P256K1
-	| SYMMETRIC_DEFAULT
- datatype KeyState =
-	| Creating
-	| Enabled
-	| Disabled
-	| PendingDeletion
-	| PendingImport
-	| PendingReplicaDeletion
-	| Unavailable
-	| Updating
- type KeyStorePasswordType = x: string | IsValid_KeyStorePasswordType(x) witness *
- predicate method IsValid_KeyStorePasswordType(x: string) {
- ( 7 <= |x| <= 32 )
-}
- class KeyUnavailableException extends IKeyManagementServiceException {
+  datatype KeyManagerType =
+    | AWS
+    | CUSTOMER
+  datatype KeyMetadata = KeyMetadata (
+                           nameonly AWSAccountId: Option<AWSAccountIdType> ,
+                           nameonly KeyId: KeyIdType ,
+                           nameonly Arn: Option<ArnType> ,
+                           nameonly CreationDate: Option<string> ,
+                           nameonly Enabled: Option<BooleanType> ,
+                           nameonly Description: Option<DescriptionType> ,
+                           nameonly KeyUsage: Option<KeyUsageType> ,
+                           nameonly KeyState: Option<KeyState> ,
+                           nameonly DeletionDate: Option<string> ,
+                           nameonly ValidTo: Option<string> ,
+                           nameonly Origin: Option<OriginType> ,
+                           nameonly CustomKeyStoreId: Option<CustomKeyStoreIdType> ,
+                           nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> ,
+                           nameonly ExpirationModel: Option<ExpirationModelType> ,
+                           nameonly KeyManager: Option<KeyManagerType> ,
+                           nameonly CustomerMasterKeySpec: Option<CustomerMasterKeySpec> ,
+                           nameonly KeySpec: Option<KeySpec> ,
+                           nameonly EncryptionAlgorithms: Option<EncryptionAlgorithmSpecList> ,
+                           nameonly SigningAlgorithms: Option<SigningAlgorithmSpecList> ,
+                           nameonly MultiRegion: Option<NullableBooleanType> ,
+                           nameonly MultiRegionConfiguration: Option<MultiRegionConfiguration> ,
+                           nameonly PendingDeletionWindowInDays: Option<PendingWindowInDaysType> )
+  datatype KeySpec =
+    | RSA_2048
+    | RSA_3072
+    | RSA_4096
+    | ECC_NIST_P256
+    | ECC_NIST_P384
+    | ECC_NIST_P521
+    | ECC_SECG_P256K1
+    | SYMMETRIC_DEFAULT
+  datatype KeyState =
+    | Creating
+    | Enabled
+    | Disabled
+    | PendingDeletion
+    | PendingImport
+    | PendingReplicaDeletion
+    | Unavailable
+    | Updating
+  type KeyStorePasswordType = x: string | IsValid_KeyStorePasswordType(x) witness *
+  predicate method IsValid_KeyStorePasswordType(x: string) {
+    ( 7 <= |x| <= 32 )
+  }
+  class KeyUnavailableException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- datatype KeyUsageType =
-	| SIGN_VERIFY
-	| ENCRYPT_DECRYPT
- class KMSInternalException extends IKeyManagementServiceException {
+  datatype KeyUsageType =
+    | SIGN_VERIFY
+    | ENCRYPT_DECRYPT
+  class KMSInternalException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class KMSInvalidSignatureException extends IKeyManagementServiceException {
+  class KMSInvalidSignatureException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class KMSInvalidStateException extends IKeyManagementServiceException {
+  class KMSInvalidStateException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- class LimitExceededException extends IKeyManagementServiceException {
+  class LimitExceededException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- type LimitType = x: int32 | IsValid_LimitType(x) witness *
- predicate method IsValid_LimitType(x: int32) {
- ( 1 <= x <= 1000 )
-}
- datatype ListAliasesRequest = ListAliasesRequest (
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly Limit: Option<LimitType> ,
-	nameonly Marker: Option<MarkerType> )
- datatype ListAliasesResponse = ListAliasesResponse (
-	nameonly Aliases: Option<AliasList> ,
-	nameonly NextMarker: Option<MarkerType> ,
-	nameonly Truncated: Option<BooleanType> )
- datatype ListGrantsRequest = ListGrantsRequest (
-	nameonly Limit: Option<LimitType> ,
-	nameonly Marker: Option<MarkerType> ,
-	nameonly KeyId: KeyIdType ,
-	nameonly GrantId: Option<GrantIdType> ,
-	nameonly GranteePrincipal: Option<PrincipalIdType> )
- datatype ListGrantsResponse = ListGrantsResponse (
-	nameonly Grants: Option<GrantList> ,
-	nameonly NextMarker: Option<MarkerType> ,
-	nameonly Truncated: Option<BooleanType> )
- datatype ListKeyPoliciesRequest = ListKeyPoliciesRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly Limit: Option<LimitType> ,
-	nameonly Marker: Option<MarkerType> )
- datatype ListKeyPoliciesResponse = ListKeyPoliciesResponse (
-	nameonly PolicyNames: Option<PolicyNameList> ,
-	nameonly NextMarker: Option<MarkerType> ,
-	nameonly Truncated: Option<BooleanType> )
- datatype ListKeysRequest = ListKeysRequest (
-	nameonly Limit: Option<LimitType> ,
-	nameonly Marker: Option<MarkerType> )
- datatype ListResourceTagsRequest = ListResourceTagsRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly Limit: Option<LimitType> ,
-	nameonly Marker: Option<MarkerType> )
- datatype ListResourceTagsResponse = ListResourceTagsResponse (
-	nameonly Tags: Option<TagList> ,
-	nameonly NextMarker: Option<MarkerType> ,
-	nameonly Truncated: Option<BooleanType> )
- datatype ListRetirableGrantsRequest = ListRetirableGrantsRequest (
-	nameonly Limit: Option<LimitType> ,
-	nameonly Marker: Option<MarkerType> ,
-	nameonly RetiringPrincipal: PrincipalIdType )
- class MalformedPolicyDocumentException extends IKeyManagementServiceException {
+  type LimitType = x: int32 | IsValid_LimitType(x) witness *
+  predicate method IsValid_LimitType(x: int32) {
+    ( 1 <= x <= 1000 )
+  }
+  datatype ListAliasesRequest = ListAliasesRequest (
+                                  nameonly KeyId: Option<KeyIdType> ,
+                                  nameonly Limit: Option<LimitType> ,
+                                  nameonly Marker: Option<MarkerType> )
+  datatype ListAliasesResponse = ListAliasesResponse (
+                                   nameonly Aliases: Option<AliasList> ,
+                                   nameonly NextMarker: Option<MarkerType> ,
+                                   nameonly Truncated: Option<BooleanType> )
+  datatype ListGrantsRequest = ListGrantsRequest (
+                                 nameonly Limit: Option<LimitType> ,
+                                 nameonly Marker: Option<MarkerType> ,
+                                 nameonly KeyId: KeyIdType ,
+                                 nameonly GrantId: Option<GrantIdType> ,
+                                 nameonly GranteePrincipal: Option<PrincipalIdType> )
+  datatype ListGrantsResponse = ListGrantsResponse (
+                                  nameonly Grants: Option<GrantList> ,
+                                  nameonly NextMarker: Option<MarkerType> ,
+                                  nameonly Truncated: Option<BooleanType> )
+  datatype ListKeyPoliciesRequest = ListKeyPoliciesRequest (
+                                      nameonly KeyId: KeyIdType ,
+                                      nameonly Limit: Option<LimitType> ,
+                                      nameonly Marker: Option<MarkerType> )
+  datatype ListKeyPoliciesResponse = ListKeyPoliciesResponse (
+                                       nameonly PolicyNames: Option<PolicyNameList> ,
+                                       nameonly NextMarker: Option<MarkerType> ,
+                                       nameonly Truncated: Option<BooleanType> )
+  datatype ListKeysRequest = ListKeysRequest (
+                               nameonly Limit: Option<LimitType> ,
+                               nameonly Marker: Option<MarkerType> )
+  datatype ListResourceTagsRequest = ListResourceTagsRequest (
+                                       nameonly KeyId: KeyIdType ,
+                                       nameonly Limit: Option<LimitType> ,
+                                       nameonly Marker: Option<MarkerType> )
+  datatype ListResourceTagsResponse = ListResourceTagsResponse (
+                                        nameonly Tags: Option<TagList> ,
+                                        nameonly NextMarker: Option<MarkerType> ,
+                                        nameonly Truncated: Option<BooleanType> )
+  datatype ListRetirableGrantsRequest = ListRetirableGrantsRequest (
+                                          nameonly Limit: Option<LimitType> ,
+                                          nameonly Marker: Option<MarkerType> ,
+                                          nameonly RetiringPrincipal: PrincipalIdType )
+  class MalformedPolicyDocumentException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- type MarkerType = x: string | IsValid_MarkerType(x) witness *
- predicate method IsValid_MarkerType(x: string) {
- ( 1 <= |x| <= 1024 )
-}
- datatype MessageType =
-	| RAW
-	| DIGEST
- datatype MultiRegionConfiguration = MultiRegionConfiguration (
-	nameonly MultiRegionKeyType: Option<MultiRegionKeyType> ,
-	nameonly PrimaryKey: Option<MultiRegionKey> ,
-	nameonly ReplicaKeys: Option<MultiRegionKeyList> )
- datatype MultiRegionKey = MultiRegionKey (
-	nameonly Arn: Option<ArnType> ,
-	nameonly Region: Option<RegionType> )
- type MultiRegionKeyList = seq<MultiRegionKey>
- datatype MultiRegionKeyType =
-	| PRIMARY
-	| REPLICA
- class NotFoundException extends IKeyManagementServiceException {
+  type MarkerType = x: string | IsValid_MarkerType(x) witness *
+  predicate method IsValid_MarkerType(x: string) {
+    ( 1 <= |x| <= 1024 )
+  }
+  datatype MessageType =
+    | RAW
+    | DIGEST
+  datatype MultiRegionConfiguration = MultiRegionConfiguration (
+                                        nameonly MultiRegionKeyType: Option<MultiRegionKeyType> ,
+                                        nameonly PrimaryKey: Option<MultiRegionKey> ,
+                                        nameonly ReplicaKeys: Option<MultiRegionKeyList> )
+  datatype MultiRegionKey = MultiRegionKey (
+                              nameonly Arn: Option<ArnType> ,
+                              nameonly Region: Option<RegionType> )
+  type MultiRegionKeyList = seq<MultiRegionKey>
+  datatype MultiRegionKeyType =
+    | PRIMARY
+    | REPLICA
+  class NotFoundException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- type NullableBooleanType = bool
- type NumberOfBytesType = x: int32 | IsValid_NumberOfBytesType(x) witness *
- predicate method IsValid_NumberOfBytesType(x: int32) {
- ( 1 <= x <= 1024 )
-}
- datatype OriginType =
-	| AWS_KMS
-	| EXTERNAL
-	| AWS_CLOUDHSM
- type PendingWindowInDaysType = x: int32 | IsValid_PendingWindowInDaysType(x) witness *
- predicate method IsValid_PendingWindowInDaysType(x: int32) {
- ( 1 <= x <= 365 )
-}
- type PlaintextType = x: seq<uint8> | IsValid_PlaintextType(x) witness *
- predicate method IsValid_PlaintextType(x: seq<uint8>) {
- ( 1 <= |x| <= 4096 )
-}
- type PolicyNameList = seq<PolicyNameType>
- type PolicyNameType = x: string | IsValid_PolicyNameType(x) witness *
- predicate method IsValid_PolicyNameType(x: string) {
- ( 1 <= |x| <= 128 )
-}
- type PolicyType = x: string | IsValid_PolicyType(x) witness *
- predicate method IsValid_PolicyType(x: string) {
- ( 1 <= |x| <= 131072 )
-}
- type PrincipalIdType = x: string | IsValid_PrincipalIdType(x) witness *
- predicate method IsValid_PrincipalIdType(x: string) {
- ( 1 <= |x| <= 256 )
-}
- type PublicKeyType = x: seq<uint8> | IsValid_PublicKeyType(x) witness *
- predicate method IsValid_PublicKeyType(x: seq<uint8>) {
- ( 1 <= |x| <= 8192 )
-}
- datatype PutKeyPolicyRequest = PutKeyPolicyRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly PolicyName: PolicyNameType ,
-	nameonly Policy: PolicyType ,
-	nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> )
- datatype ReEncryptRequest = ReEncryptRequest (
-	nameonly CiphertextBlob: CiphertextType ,
-	nameonly SourceEncryptionContext: Option<EncryptionContextType> ,
-	nameonly SourceKeyId: Option<KeyIdType> ,
-	nameonly DestinationKeyId: KeyIdType ,
-	nameonly DestinationEncryptionContext: Option<EncryptionContextType> ,
-	nameonly SourceEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
-	nameonly DestinationEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
-	nameonly GrantTokens: Option<GrantTokenList> )
- datatype ReEncryptResponse = ReEncryptResponse (
-	nameonly CiphertextBlob: Option<CiphertextType> ,
-	nameonly SourceKeyId: Option<KeyIdType> ,
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly SourceEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
-	nameonly DestinationEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
- type RegionType = x: string | IsValid_RegionType(x) witness *
- predicate method IsValid_RegionType(x: string) {
- ( 1 <= |x| <= 32 )
-}
- datatype ReplicateKeyRequest = ReplicateKeyRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly ReplicaRegion: RegionType ,
-	nameonly Policy: Option<PolicyType> ,
-	nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> ,
-	nameonly Description: Option<DescriptionType> ,
-	nameonly Tags: Option<TagList> )
- datatype ReplicateKeyResponse = ReplicateKeyResponse (
-	nameonly ReplicaKeyMetadata: Option<KeyMetadata> ,
-	nameonly ReplicaPolicy: Option<PolicyType> ,
-	nameonly ReplicaTags: Option<TagList> )
- datatype RetireGrantRequest = RetireGrantRequest (
-	nameonly GrantToken: Option<GrantTokenType> ,
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly GrantId: Option<GrantIdType> )
- datatype RevokeGrantRequest = RevokeGrantRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly GrantId: GrantIdType )
- datatype ScheduleKeyDeletionRequest = ScheduleKeyDeletionRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly PendingWindowInDays: Option<PendingWindowInDaysType> )
- datatype ScheduleKeyDeletionResponse = ScheduleKeyDeletionResponse (
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly DeletionDate: Option<string> ,
-	nameonly KeyState: Option<KeyState> ,
-	nameonly PendingWindowInDays: Option<PendingWindowInDaysType> )
- datatype SigningAlgorithmSpec =
-	| RSASSA_PSS_SHA_256
-	| RSASSA_PSS_SHA_384
-	| RSASSA_PSS_SHA_512
-	| RSASSA_PKCS1_V1_5_SHA_256
-	| RSASSA_PKCS1_V1_5_SHA_384
-	| RSASSA_PKCS1_V1_5_SHA_512
-	| ECDSA_SHA_256
-	| ECDSA_SHA_384
-	| ECDSA_SHA_512
- type SigningAlgorithmSpecList = seq<SigningAlgorithmSpec>
- datatype SignRequest = SignRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly Message: PlaintextType ,
-	nameonly MessageType: Option<MessageType> ,
-	nameonly GrantTokens: Option<GrantTokenList> ,
-	nameonly SigningAlgorithm: SigningAlgorithmSpec )
- datatype SignResponse = SignResponse (
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly Signature: Option<CiphertextType> ,
-	nameonly SigningAlgorithm: Option<SigningAlgorithmSpec> )
- datatype Tag = Tag (
-	nameonly TagKey: TagKeyType ,
-	nameonly TagValue: TagValueType )
- class TagException extends IKeyManagementServiceException {
+  type NullableBooleanType = bool
+  type NumberOfBytesType = x: int32 | IsValid_NumberOfBytesType(x) witness *
+  predicate method IsValid_NumberOfBytesType(x: int32) {
+    ( 1 <= x <= 1024 )
+  }
+  datatype OriginType =
+    | AWS_KMS
+    | EXTERNAL
+    | AWS_CLOUDHSM
+  type PendingWindowInDaysType = x: int32 | IsValid_PendingWindowInDaysType(x) witness *
+  predicate method IsValid_PendingWindowInDaysType(x: int32) {
+    ( 1 <= x <= 365 )
+  }
+  type PlaintextType = x: seq<uint8> | IsValid_PlaintextType(x) witness *
+  predicate method IsValid_PlaintextType(x: seq<uint8>) {
+    ( 1 <= |x| <= 4096 )
+  }
+  type PolicyNameList = seq<PolicyNameType>
+  type PolicyNameType = x: string | IsValid_PolicyNameType(x) witness *
+  predicate method IsValid_PolicyNameType(x: string) {
+    ( 1 <= |x| <= 128 )
+  }
+  type PolicyType = x: string | IsValid_PolicyType(x) witness *
+  predicate method IsValid_PolicyType(x: string) {
+    ( 1 <= |x| <= 131072 )
+  }
+  type PrincipalIdType = x: string | IsValid_PrincipalIdType(x) witness *
+  predicate method IsValid_PrincipalIdType(x: string) {
+    ( 1 <= |x| <= 256 )
+  }
+  type PublicKeyType = x: seq<uint8> | IsValid_PublicKeyType(x) witness *
+  predicate method IsValid_PublicKeyType(x: seq<uint8>) {
+    ( 1 <= |x| <= 8192 )
+  }
+  datatype PutKeyPolicyRequest = PutKeyPolicyRequest (
+                                   nameonly KeyId: KeyIdType ,
+                                   nameonly PolicyName: PolicyNameType ,
+                                   nameonly Policy: PolicyType ,
+                                   nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> )
+  datatype ReEncryptRequest = ReEncryptRequest (
+                                nameonly CiphertextBlob: CiphertextType ,
+                                nameonly SourceEncryptionContext: Option<EncryptionContextType> ,
+                                nameonly SourceKeyId: Option<KeyIdType> ,
+                                nameonly DestinationKeyId: KeyIdType ,
+                                nameonly DestinationEncryptionContext: Option<EncryptionContextType> ,
+                                nameonly SourceEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
+                                nameonly DestinationEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
+                                nameonly GrantTokens: Option<GrantTokenList> )
+  datatype ReEncryptResponse = ReEncryptResponse (
+                                 nameonly CiphertextBlob: Option<CiphertextType> ,
+                                 nameonly SourceKeyId: Option<KeyIdType> ,
+                                 nameonly KeyId: Option<KeyIdType> ,
+                                 nameonly SourceEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> ,
+                                 nameonly DestinationEncryptionAlgorithm: Option<EncryptionAlgorithmSpec> )
+  type RegionType = x: string | IsValid_RegionType(x) witness *
+  predicate method IsValid_RegionType(x: string) {
+    ( 1 <= |x| <= 32 )
+  }
+  datatype ReplicateKeyRequest = ReplicateKeyRequest (
+                                   nameonly KeyId: KeyIdType ,
+                                   nameonly ReplicaRegion: RegionType ,
+                                   nameonly Policy: Option<PolicyType> ,
+                                   nameonly BypassPolicyLockoutSafetyCheck: Option<BooleanType> ,
+                                   nameonly Description: Option<DescriptionType> ,
+                                   nameonly Tags: Option<TagList> )
+  datatype ReplicateKeyResponse = ReplicateKeyResponse (
+                                    nameonly ReplicaKeyMetadata: Option<KeyMetadata> ,
+                                    nameonly ReplicaPolicy: Option<PolicyType> ,
+                                    nameonly ReplicaTags: Option<TagList> )
+  datatype RetireGrantRequest = RetireGrantRequest (
+                                  nameonly GrantToken: Option<GrantTokenType> ,
+                                  nameonly KeyId: Option<KeyIdType> ,
+                                  nameonly GrantId: Option<GrantIdType> )
+  datatype RevokeGrantRequest = RevokeGrantRequest (
+                                  nameonly KeyId: KeyIdType ,
+                                  nameonly GrantId: GrantIdType )
+  datatype ScheduleKeyDeletionRequest = ScheduleKeyDeletionRequest (
+                                          nameonly KeyId: KeyIdType ,
+                                          nameonly PendingWindowInDays: Option<PendingWindowInDaysType> )
+  datatype ScheduleKeyDeletionResponse = ScheduleKeyDeletionResponse (
+                                           nameonly KeyId: Option<KeyIdType> ,
+                                           nameonly DeletionDate: Option<string> ,
+                                           nameonly KeyState: Option<KeyState> ,
+                                           nameonly PendingWindowInDays: Option<PendingWindowInDaysType> )
+  datatype SigningAlgorithmSpec =
+    | RSASSA_PSS_SHA_256
+    | RSASSA_PSS_SHA_384
+    | RSASSA_PSS_SHA_512
+    | RSASSA_PKCS1_V1_5_SHA_256
+    | RSASSA_PKCS1_V1_5_SHA_384
+    | RSASSA_PKCS1_V1_5_SHA_512
+    | ECDSA_SHA_256
+    | ECDSA_SHA_384
+    | ECDSA_SHA_512
+  type SigningAlgorithmSpecList = seq<SigningAlgorithmSpec>
+  datatype SignRequest = SignRequest (
+                           nameonly KeyId: KeyIdType ,
+                           nameonly Message: PlaintextType ,
+                           nameonly MessageType: Option<MessageType> ,
+                           nameonly GrantTokens: Option<GrantTokenList> ,
+                           nameonly SigningAlgorithm: SigningAlgorithmSpec )
+  datatype SignResponse = SignResponse (
+                            nameonly KeyId: Option<KeyIdType> ,
+                            nameonly Signature: Option<CiphertextType> ,
+                            nameonly SigningAlgorithm: Option<SigningAlgorithmSpec> )
+  datatype Tag = Tag (
+                   nameonly TagKey: TagKeyType ,
+                   nameonly TagValue: TagValueType )
+  class TagException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- type TagKeyList = seq<TagKeyType>
- type TagKeyType = x: string | IsValid_TagKeyType(x) witness *
- predicate method IsValid_TagKeyType(x: string) {
- ( 1 <= |x| <= 128 )
-}
- type TagList = seq<Tag>
- datatype TagResourceRequest = TagResourceRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly Tags: TagList )
- type TagValueType = x: string | IsValid_TagValueType(x) witness *
- predicate method IsValid_TagValueType(x: string) {
- ( 0 <= |x| <= 256 )
-}
- type TrustAnchorCertificateType = x: string | IsValid_TrustAnchorCertificateType(x) witness *
- predicate method IsValid_TrustAnchorCertificateType(x: string) {
- ( 1 <= |x| <= 5000 )
-}
- class UnsupportedOperationException extends IKeyManagementServiceException {
+  type TagKeyList = seq<TagKeyType>
+  type TagKeyType = x: string | IsValid_TagKeyType(x) witness *
+  predicate method IsValid_TagKeyType(x: string) {
+    ( 1 <= |x| <= 128 )
+  }
+  type TagList = seq<Tag>
+  datatype TagResourceRequest = TagResourceRequest (
+                                  nameonly KeyId: KeyIdType ,
+                                  nameonly Tags: TagList )
+  type TagValueType = x: string | IsValid_TagValueType(x) witness *
+  predicate method IsValid_TagValueType(x: string) {
+    ( 0 <= |x| <= 256 )
+  }
+  type TrustAnchorCertificateType = x: string | IsValid_TrustAnchorCertificateType(x) witness *
+  predicate method IsValid_TrustAnchorCertificateType(x: string) {
+    ( 1 <= |x| <= 5000 )
+  }
+  class UnsupportedOperationException extends IKeyManagementServiceException {
     var message: string
 
     constructor (message: string) {
-        this.message := message;
+      this.message := message;
     }
 
     function method GetMessage(): (message: string)
-        reads this
+      reads this
     {
-        this.message
+      this.message
     }
-}
+  }
 
- datatype UntagResourceRequest = UntagResourceRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly TagKeys: TagKeyList )
- datatype UpdateAliasRequest = UpdateAliasRequest (
-	nameonly AliasName: AliasNameType ,
-	nameonly TargetKeyId: KeyIdType )
- datatype UpdateCustomKeyStoreRequest = UpdateCustomKeyStoreRequest (
-	nameonly CustomKeyStoreId: CustomKeyStoreIdType ,
-	nameonly NewCustomKeyStoreName: Option<CustomKeyStoreNameType> ,
-	nameonly KeyStorePassword: Option<KeyStorePasswordType> ,
-	nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> )
- datatype UpdateCustomKeyStoreResponse = UpdateCustomKeyStoreResponse (  )
- datatype UpdateKeyDescriptionRequest = UpdateKeyDescriptionRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly Description: DescriptionType )
- datatype UpdatePrimaryRegionRequest = UpdatePrimaryRegionRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly PrimaryRegion: RegionType )
- datatype VerifyRequest = VerifyRequest (
-	nameonly KeyId: KeyIdType ,
-	nameonly Message: PlaintextType ,
-	nameonly MessageType: Option<MessageType> ,
-	nameonly Signature: CiphertextType ,
-	nameonly SigningAlgorithm: SigningAlgorithmSpec ,
-	nameonly GrantTokens: Option<GrantTokenList> )
- datatype VerifyResponse = VerifyResponse (
-	nameonly KeyId: Option<KeyIdType> ,
-	nameonly SignatureValid: Option<BooleanType> ,
-	nameonly SigningAlgorithm: Option<SigningAlgorithmSpec> )
- datatype WrappingKeySpec =
-	| RSA_2048
+  datatype UntagResourceRequest = UntagResourceRequest (
+                                    nameonly KeyId: KeyIdType ,
+                                    nameonly TagKeys: TagKeyList )
+  datatype UpdateAliasRequest = UpdateAliasRequest (
+                                  nameonly AliasName: AliasNameType ,
+                                  nameonly TargetKeyId: KeyIdType )
+  datatype UpdateCustomKeyStoreRequest = UpdateCustomKeyStoreRequest (
+                                           nameonly CustomKeyStoreId: CustomKeyStoreIdType ,
+                                           nameonly NewCustomKeyStoreName: Option<CustomKeyStoreNameType> ,
+                                           nameonly KeyStorePassword: Option<KeyStorePasswordType> ,
+                                           nameonly CloudHsmClusterId: Option<CloudHsmClusterIdType> )
+  datatype UpdateCustomKeyStoreResponse = UpdateCustomKeyStoreResponse (  )
+  datatype UpdateKeyDescriptionRequest = UpdateKeyDescriptionRequest (
+                                           nameonly KeyId: KeyIdType ,
+                                           nameonly Description: DescriptionType )
+  datatype UpdatePrimaryRegionRequest = UpdatePrimaryRegionRequest (
+                                          nameonly KeyId: KeyIdType ,
+                                          nameonly PrimaryRegion: RegionType )
+  datatype VerifyRequest = VerifyRequest (
+                             nameonly KeyId: KeyIdType ,
+                             nameonly Message: PlaintextType ,
+                             nameonly MessageType: Option<MessageType> ,
+                             nameonly Signature: CiphertextType ,
+                             nameonly SigningAlgorithm: SigningAlgorithmSpec ,
+                             nameonly GrantTokens: Option<GrantTokenList> )
+  datatype VerifyResponse = VerifyResponse (
+                              nameonly KeyId: Option<KeyIdType> ,
+                              nameonly SignatureValid: Option<BooleanType> ,
+                              nameonly SigningAlgorithm: Option<SigningAlgorithmSpec> )
+  datatype WrappingKeySpec =
+    | RSA_2048
 }

--- a/src/SDK/AwsEncryptionSdk.dfy
+++ b/src/SDK/AwsEncryptionSdk.dfy
@@ -53,774 +53,774 @@ module {:extern "Dafny.Aws.EncryptionSdk.AwsEncryptionSdk"} AwsEncryptionSdk {
   const DEFAULT_COMMITMENT_POLICY : Crypto.CommitmentPolicy := Crypto.REQUIRE_ENCRYPT_REQUIRE_DECRYPT;
 
   class AwsEncryptionSdk extends Esdk.IAwsEncryptionSdk {
-        const config: Esdk.AwsEncryptionSdkConfig;
+    const config: Esdk.AwsEncryptionSdkConfig;
 
-        //= compliance/client-apis/client.txt#2.4
-        //= type=implication
-        //# Once a commitment policy (Section 2.4.1) has been set it SHOULD be
-        //# immutable.
-        const commitmentPolicy: Crypto.CommitmentPolicy;
-        const maxEncryptedDataKeys: Option<posInt64>;
+    //= compliance/client-apis/client.txt#2.4
+    //= type=implication
+    //# Once a commitment policy (Section 2.4.1) has been set it SHOULD be
+    //# immutable.
+    const commitmentPolicy: Crypto.CommitmentPolicy;
+    const maxEncryptedDataKeys: Option<posInt64>;
 
-        const materialProviders: Crypto.IAwsCryptographicMaterialProviders;
+    const materialProviders: Crypto.IAwsCryptographicMaterialProviders;
 
-        const RESERVED_ENCRYPTION_CONTEXT := UTF8.Encode("aws-crypto-").value;
+    const RESERVED_ENCRYPTION_CONTEXT := UTF8.Encode("aws-crypto-").value;
 
-        //= compliance/client-apis/client.txt#2.4
-        //= type=implication
-        //# On client initialization, the caller MUST have the option to provide
-        //# a:
-        //#*  commitment policy (Section 2.4.1)
-        //#*  maximum number of encrypted data keys (Section 2.4.2)
+    //= compliance/client-apis/client.txt#2.4
+    //= type=implication
+    //# On client initialization, the caller MUST have the option to provide
+    //# a:
+    //#*  commitment policy (Section 2.4.1)
+    //#*  maximum number of encrypted data keys (Section 2.4.2)
 
-        constructor (config: Esdk.AwsEncryptionSdkConfig)
-            requires config.maxEncryptedDataKeys.Some? ==> config.maxEncryptedDataKeys.value > 0
+    constructor (config: Esdk.AwsEncryptionSdkConfig)
+      requires config.maxEncryptedDataKeys.Some? ==> config.maxEncryptedDataKeys.value > 0
 
-            ensures this.config == config
+      ensures this.config == config
 
-            //= compliance/client-apis/client.txt#2.4
-            //= type=implication
-            //# If no commitment policy (Section 2.4.1) is provided the default MUST
-            //# be REQUIRE_ENCRYPT_REQUIRE_DECRYPT (../framework/algorithm-
-            //# suites.md#require_encrypt_require_decrypt).
-            ensures config.commitmentPolicy.None? ==>
-              && this.commitmentPolicy == DEFAULT_COMMITMENT_POLICY
+      //= compliance/client-apis/client.txt#2.4
+      //= type=implication
+      //# If no commitment policy (Section 2.4.1) is provided the default MUST
+      //# be REQUIRE_ENCRYPT_REQUIRE_DECRYPT (../framework/algorithm-
+      //# suites.md#require_encrypt_require_decrypt).
+      ensures config.commitmentPolicy.None? ==>
+                && this.commitmentPolicy == DEFAULT_COMMITMENT_POLICY
 
-            ensures config.commitmentPolicy.Some? ==>
+      ensures config.commitmentPolicy.Some? ==>
                 this.commitmentPolicy == config.commitmentPolicy.value
 
-            //= compliance/client-apis/client.txt#2.4
-            //# If no maximum number of
-            //# encrypted data keys (Section 2.4.2) is provided the default MUST
-            //# result in no limit on the number of encrypted data keys (aside from
-            //# the limit imposed by the message format (../format/message-
-            //# header.md)).
-            // This is a citation, not an implication, as setting the maxEDK as an option
-            // does not enforce the specified behavior at all.
-            //= compliance/client-apis/client.txt#2.4.2
-            //= type=implication
-            //# Callers MUST have a way to disable
-            //# this limit.
-            ensures
-            || (
-                && this.maxEncryptedDataKeys.None?
-                && config.maxEncryptedDataKeys.None?
-            )
-            || (
-                && this.maxEncryptedDataKeys.Some?
-                && config.maxEncryptedDataKeys.Some?
-                && this.maxEncryptedDataKeys.value as int64 == config.maxEncryptedDataKeys.value
-            )
-        {
-            this.config := config;
+      //= compliance/client-apis/client.txt#2.4
+      //# If no maximum number of
+      //# encrypted data keys (Section 2.4.2) is provided the default MUST
+      //# result in no limit on the number of encrypted data keys (aside from
+      //# the limit imposed by the message format (../format/message-
+      //# header.md)).
+      // This is a citation, not an implication, as setting the maxEDK as an option
+      // does not enforce the specified behavior at all.
+      //= compliance/client-apis/client.txt#2.4.2
+      //= type=implication
+      //# Callers MUST have a way to disable
+      //# this limit.
+      ensures
+        || (
+             && this.maxEncryptedDataKeys.None?
+             && config.maxEncryptedDataKeys.None?
+           )
+        || (
+             && this.maxEncryptedDataKeys.Some?
+             && config.maxEncryptedDataKeys.Some?
+             && this.maxEncryptedDataKeys.value as int64 == config.maxEncryptedDataKeys.value
+           )
+    {
+      this.config := config;
 
-            if (config.maxEncryptedDataKeys.None?) {
-                this.maxEncryptedDataKeys := None();
-            } else {
-                this.maxEncryptedDataKeys := Some(config.maxEncryptedDataKeys.value as posInt64);
-            }
+      if (config.maxEncryptedDataKeys.None?) {
+        this.maxEncryptedDataKeys := None();
+      } else {
+        this.maxEncryptedDataKeys := Some(config.maxEncryptedDataKeys.value as posInt64);
+      }
 
-            if config.commitmentPolicy.None? {
-                this.commitmentPolicy := DEFAULT_COMMITMENT_POLICY;
-            } else {
-                this.commitmentPolicy := config.commitmentPolicy.value;
-            }
+      if config.commitmentPolicy.None? {
+        this.commitmentPolicy := DEFAULT_COMMITMENT_POLICY;
+      } else {
+        this.commitmentPolicy := config.commitmentPolicy.value;
+      }
 
-            this.materialProviders := new Client.AwsCryptographicMaterialProviders();
-        }
+      this.materialProviders := new Client.AwsCryptographicMaterialProviders();
+    }
 
-        // Doing this conversion at each error site would allow us to emit more specific error types.
-        // But we don't have specific error types right now,
-        // and to use them,
-        // we'd have to instantiate errors within their own statements since they need to be allocated via `new`.
-        // This is tedious and obscures the already-long business logic.
-        //
-        // We can safely refactor this at a later date to use more specific error types,
-        // because errors are abstracted by the common error trait.
-        // So for expedience, we put the business logic in an internal method,
-        // and provide this facade that wraps any failure message inside the generic error type.
-        method Encrypt(input: Esdk.EncryptInput)
-            returns (res: Result<Esdk.EncryptOutput, Esdk.IAwsEncryptionSdkException>)
-        {
-            var encryptResult, _ := EncryptInternal(input);
-            var withConvertedError := Esdk.AwsEncryptionSdkException.WrapResultString(encryptResult);
-            return withConvertedError;
-        }
+    // Doing this conversion at each error site would allow us to emit more specific error types.
+    // But we don't have specific error types right now,
+    // and to use them,
+    // we'd have to instantiate errors within their own statements since they need to be allocated via `new`.
+    // This is tedious and obscures the already-long business logic.
+    //
+    // We can safely refactor this at a later date to use more specific error types,
+    // because errors are abstracted by the common error trait.
+    // So for expedience, we put the business logic in an internal method,
+    // and provide this facade that wraps any failure message inside the generic error type.
+    method Encrypt(input: Esdk.EncryptInput)
+      returns (res: Result<Esdk.EncryptOutput, Esdk.IAwsEncryptionSdkException>)
+    {
+      var encryptResult, _ := EncryptInternal(input);
+      var withConvertedError := Esdk.AwsEncryptionSdkException.WrapResultString(encryptResult);
+      return withConvertedError;
+    }
 
-        method EncryptInternal(input: Esdk.EncryptInput)
-            returns (
-                res: Result<Esdk.EncryptOutput, string>,
-                // Used for verification
-                ghost ghostMaterials: Option<Crypto.EncryptionMaterials>
-            )
-        //= compliance/client-apis/encrypt.txt#2.6.1
-        //= type=implication
-        //# If an input algorithm suite (Section 2.4.5) is provided that is not
-        //# supported by the commitment policy (client.md#commitment-policy)
-        //# configured in the client (client.md) encrypt MUST yield an error.
-        //
-        //= compliance/client-apis/client.txt#2.4.2.1
-        //= type=implication
-        //# *  encrypt (encrypt.md) MUST only support algorithm suites that have
-        //# a Key Commitment (../framework/algorithm-suites.md#algorithm-
-        //# suites-encryption-key-derivation-settings) value of False
-        //
-        //= compliance/client-apis/client.txt#2.4.2.2
-        //= type=implication
-        //# *  encrypt (encrypt.md) MUST only support algorithm suites that have
-        //# a Key Commitment (../framework/algorithm-suites.md#algorithm-
-        //# suites-encryption-key-derivation-settings) value of True
-        //
-        //= compliance/client-apis/client.txt#2.4.2.3
-        //= type=implication
-        //# *  encrypt (encrypt.md) MUST only support algorithm suites that have
-        //# a Key Commitment (../framework/algorithm-suites.md#algorithm-
-        //# suites-encryption-key-derivation-settings) value of True
-        ensures
+    method EncryptInternal(input: Esdk.EncryptInput)
+      returns (
+        res: Result<Esdk.EncryptOutput, string>,
+        // Used for verification
+        ghost ghostMaterials: Option<Crypto.EncryptionMaterials>
+      )
+      //= compliance/client-apis/encrypt.txt#2.6.1
+      //= type=implication
+      //# If an input algorithm suite (Section 2.4.5) is provided that is not
+      //# supported by the commitment policy (client.md#commitment-policy)
+      //# configured in the client (client.md) encrypt MUST yield an error.
+      //
+      //= compliance/client-apis/client.txt#2.4.2.1
+      //= type=implication
+      //# *  encrypt (encrypt.md) MUST only support algorithm suites that have
+      //# a Key Commitment (../framework/algorithm-suites.md#algorithm-
+      //# suites-encryption-key-derivation-settings) value of False
+      //
+      //= compliance/client-apis/client.txt#2.4.2.2
+      //= type=implication
+      //# *  encrypt (encrypt.md) MUST only support algorithm suites that have
+      //# a Key Commitment (../framework/algorithm-suites.md#algorithm-
+      //# suites-encryption-key-derivation-settings) value of True
+      //
+      //= compliance/client-apis/client.txt#2.4.2.3
+      //= type=implication
+      //# *  encrypt (encrypt.md) MUST only support algorithm suites that have
+      //# a Key Commitment (../framework/algorithm-suites.md#algorithm-
+      //# suites-encryption-key-derivation-settings) value of True
+      ensures
         (
-            && input.algorithmSuiteId.Some?
-            && var valid := Client.SpecificationClient()
-                    .ValidateCommitmentPolicyOnEncrypt(input.algorithmSuiteId.value, this.commitmentPolicy);
-            && valid.Failure?
+          && input.algorithmSuiteId.Some?
+          && var valid := Client.SpecificationClient()
+                          .ValidateCommitmentPolicyOnEncrypt(input.algorithmSuiteId.value, this.commitmentPolicy);
+          && valid.Failure?
         )
         ==>
-            res.Failure?
+          res.Failure?
 
-       //= compliance/client-apis/encrypt.txt#2.4.6
-       //= type=implication
-       //# This value
-       //# MUST be greater than 0 and MUST NOT exceed the value 2^32 - 1.
-        ensures
-            && input.frameLength.Some?
-            && (input.frameLength.value <= 0 || input.frameLength.value > 0xFFFF_FFFF)
+      //= compliance/client-apis/encrypt.txt#2.4.6
+      //= type=implication
+      //# This value
+      //# MUST be greater than 0 and MUST NOT exceed the value 2^32 - 1.
+      ensures
+        && input.frameLength.Some?
+        && (input.frameLength.value <= 0 || input.frameLength.value > 0xFFFF_FFFF)
         ==>
-            res.Failure?
+          res.Failure?
 
-        //= compliance/client-apis/encrypt.txt#2.6.1
-        //= type=implication
-        //# If the number of
-        //# encrypted data keys (../framework/structures.md#encrypted-data-keys)
-        //# on the encryption materials (../framework/structures.md#encryption-
-        //# materials) is greater than the maximum number of encrypted data keys
-        //# (client.md#maximum-number-of-encrypted-data-keys) configured in the
-        //# client (client.md) encrypt MUST yield an error.
-        ensures
-            && this.maxEncryptedDataKeys.Some?
-            && ghostMaterials.Some?
-            && |ghostMaterials.value.encryptedDataKeys| > this.maxEncryptedDataKeys.value as int
+      //= compliance/client-apis/encrypt.txt#2.6.1
+      //= type=implication
+      //# If the number of
+      //# encrypted data keys (../framework/structures.md#encrypted-data-keys)
+      //# on the encryption materials (../framework/structures.md#encryption-
+      //# materials) is greater than the maximum number of encrypted data keys
+      //# (client.md#maximum-number-of-encrypted-data-keys) configured in the
+      //# client (client.md) encrypt MUST yield an error.
+      ensures
+        && this.maxEncryptedDataKeys.Some?
+        && ghostMaterials.Some?
+        && |ghostMaterials.value.encryptedDataKeys| > this.maxEncryptedDataKeys.value as int
         ==>
-            res.Failure?
-        {
-            ghostMaterials := None;
+          res.Failure?
+    {
+      ghostMaterials := None;
 
-            var frameLength : FrameLength := EncryptDecryptHelpers.DEFAULT_FRAME_LENGTH;
-            if input.frameLength.Some? {
-              :- Need(
-                0 < input.frameLength.value <= 0xFFFF_FFFF,
-                "FrameLength must be greater than 0 and less than 2^32"
-              );
-              frameLength := input.frameLength.value;
-            }
+      var frameLength : FrameLength := EncryptDecryptHelpers.DEFAULT_FRAME_LENGTH;
+      if input.frameLength.Some? {
+        :- Need(
+             0 < input.frameLength.value <= 0xFFFF_FFFF,
+             "FrameLength must be greater than 0 and less than 2^32"
+           );
+        frameLength := input.frameLength.value;
+      }
 
-            if input.encryptionContext.Some? {
-                var _ :- ValidateEncryptionContext(input.encryptionContext.value);
-            }
+      if input.encryptionContext.Some? {
+        var _ :- ValidateEncryptionContext(input.encryptionContext.value);
+      }
 
-            var cmm :- CreateCmmFromInput(input.materialsManager, input.keyring);
+      var cmm :- CreateCmmFromInput(input.materialsManager, input.keyring);
 
-            //= compliance/client-apis/encrypt.txt#2.4.5
-            //# The algorithm suite (../framework/algorithm-suite.md) that SHOULD be
-            //# used for encryption.
-            var algorithmSuiteId := input.algorithmSuiteId;
+      //= compliance/client-apis/encrypt.txt#2.4.5
+      //# The algorithm suite (../framework/algorithm-suite.md) that SHOULD be
+      //# used for encryption.
+      var algorithmSuiteId := input.algorithmSuiteId;
 
-            if algorithmSuiteId.Some? {
-                var _ :- Client.SpecificationClient()
-                    .ValidateCommitmentPolicyOnEncrypt(algorithmSuiteId.value, this.commitmentPolicy);
-            }
+      if algorithmSuiteId.Some? {
+        var _ :- Client.SpecificationClient()
+                 .ValidateCommitmentPolicyOnEncrypt(algorithmSuiteId.value, this.commitmentPolicy);
+      }
 
-            // int64 fits 9 exabytes so we're never going to actually hit this. But if we don't
-            // include this the verifier is not convinced that we can cast the size to int64
-            :- Need(|input.plaintext| < INT64_MAX_LIMIT, "Plaintext exceeds maximum allowed size");
-            var materials :- GetEncryptionMaterials(
-                cmm,
-                algorithmSuiteId,
-                input.encryptionContext,
-                //= compliance/client-apis/encrypt.txt#2.6.1
-                //# *  Max Plaintext Length: If the input plaintext (Section 2.4.1) has
-                //# known length, this length MUST be used.
-                |input.plaintext| as int64
-            );
-            ghostMaterials := Some(materials);
+      // int64 fits 9 exabytes so we're never going to actually hit this. But if we don't
+      // include this the verifier is not convinced that we can cast the size to int64
+      :- Need(|input.plaintext| < INT64_MAX_LIMIT, "Plaintext exceeds maximum allowed size");
+      var materials :- GetEncryptionMaterials(
+                         cmm,
+                         algorithmSuiteId,
+                         input.encryptionContext,
+                         //= compliance/client-apis/encrypt.txt#2.6.1
+                         //# *  Max Plaintext Length: If the input plaintext (Section 2.4.1) has
+                         //# known length, this length MUST be used.
+                         |input.plaintext| as int64
+                       );
+      ghostMaterials := Some(materials);
 
-            var _ :- ValidateMaxEncryptedDataKeys(materials.encryptedDataKeys);
+      var _ :- ValidateMaxEncryptedDataKeys(materials.encryptedDataKeys);
 
-            //= compliance/client-apis/encrypt.txt#2.6.1
-            //# If this
-            //# algorithm suite (../framework/algorithm-suites.md) is not supported
-            //# by the commitment policy (client.md#commitment-policy) configured in
-            //# the client (client.md) encrypt MUST yield an error.
-            var algorithmAllowed := Client.SpecificationClient()
-                    .ValidateCommitmentPolicyOnEncrypt(materials.algorithmSuiteId, this.commitmentPolicy);
-            :- Need(
-                algorithmAllowed.Success?,
-                "CMM return algorithm suite not supported by our commitment policy"
-            );
+      //= compliance/client-apis/encrypt.txt#2.6.1
+      //# If this
+      //# algorithm suite (../framework/algorithm-suites.md) is not supported
+      //# by the commitment policy (client.md#commitment-policy) configured in
+      //# the client (client.md) encrypt MUST yield an error.
+      var algorithmAllowed := Client.SpecificationClient()
+                              .ValidateCommitmentPolicyOnEncrypt(materials.algorithmSuiteId, this.commitmentPolicy);
+      :- Need(
+           algorithmAllowed.Success?,
+           "CMM return algorithm suite not supported by our commitment policy"
+         );
 
-            var encryptedDataKeys: SerializableTypes.ESDKEncryptedDataKeys := materials.encryptedDataKeys;
+      var encryptedDataKeys: SerializableTypes.ESDKEncryptedDataKeys := materials.encryptedDataKeys;
 
-            //= compliance/client-apis/encrypt.txt#2.6.1
-            //# The algorithm suite (../framework/algorithm-suites.md) used in all
-            //# aspects of this operation MUST be the algorithm suite in the
-            //# encryption materials (../framework/structures.md#encryption-
-            //# materials) returned from the Get Encryption Materials (../framework/
-            //# cmm-interface.md#get-encryption-materials) call.
-            var suite := Client.SpecificationClient().GetSuite(materials.algorithmSuiteId);
-            var messageId: HeaderTypes.MessageId :- GenerateMessageId(suite);
+      //= compliance/client-apis/encrypt.txt#2.6.1
+      //# The algorithm suite (../framework/algorithm-suites.md) used in all
+      //# aspects of this operation MUST be the algorithm suite in the
+      //# encryption materials (../framework/structures.md#encryption-
+      //# materials) returned from the Get Encryption Materials (../framework/
+      //# cmm-interface.md#get-encryption-materials) call.
+      var suite := Client.SpecificationClient().GetSuite(materials.algorithmSuiteId);
+      var messageId: HeaderTypes.MessageId :- GenerateMessageId(suite);
 
-            var maybeDerivedDataKeys := KeyDerivation.DeriveKeys(
-                messageId, materials.plaintextDataKey.value, suite
-            );
-            :- Need(maybeDerivedDataKeys.Success?, "Failed to derive data keys");
-            var derivedDataKeys := maybeDerivedDataKeys.value;
+      var maybeDerivedDataKeys := KeyDerivation.DeriveKeys(
+                                    messageId, materials.plaintextDataKey.value, suite
+                                  );
+      :- Need(maybeDerivedDataKeys.Success?, "Failed to derive data keys");
+      var derivedDataKeys := maybeDerivedDataKeys.value;
 
-            var maybeHeader := BuildHeaderForEncrypt(
-                messageId,
-                suite,
-                materials.encryptionContext,
-                encryptedDataKeys,
-                frameLength as uint32,
-                derivedDataKeys
-            );
+      var maybeHeader := BuildHeaderForEncrypt(
+                           messageId,
+                           suite,
+                           materials.encryptionContext,
+                           encryptedDataKeys,
+                           frameLength as uint32,
+                           derivedDataKeys
+                         );
 
-            :- Need(maybeHeader.Success?, "Failed to build header body");
-            var header := maybeHeader.value;
+      :- Need(maybeHeader.Success?, "Failed to build header body");
+      var header := maybeHeader.value;
 
-            // Encrypt the given plaintext into the framed message
-            var framedMessage :- MessageBody.EncryptMessageBody(
-                input.plaintext,
-                header,
-                derivedDataKeys.dataKey
-            );
+      // Encrypt the given plaintext into the framed message
+      var framedMessage :- MessageBody.EncryptMessageBody(
+                             input.plaintext,
+                             header,
+                             derivedDataKeys.dataKey
+                           );
 
-            if framedMessage.finalFrame.header.suite.signature.ECDSA? {
-                //= compliance/client-apis/encrypt.txt#2.7.2
-                //# If the algorithm suite (../framework/algorithm-suites.md) contains a
-                //# signature algorithm (../framework/algorithm-suites.md#signature-
-                //# algorithm), this operation MUST calculate a signature over the
-                //# message, and the output encrypted message (Section 2.5.1) MUST
-                //# contain a message footer (../data-format/message-footer.md).
+      if framedMessage.finalFrame.header.suite.signature.ECDSA? {
+        //= compliance/client-apis/encrypt.txt#2.7.2
+        //# If the algorithm suite (../framework/algorithm-suites.md) contains a
+        //# signature algorithm (../framework/algorithm-suites.md#signature-
+        //# algorithm), this operation MUST calculate a signature over the
+        //# message, and the output encrypted message (Section 2.5.1) MUST
+        //# contain a message footer (../data-format/message-footer.md).
 
-                //= compliance/client-apis/encrypt.txt#2.6
-                //# If the encryption materials gathered (Section 2.6.1) has a
-                //# algorithm suite including a signature algorithm (../framework/
-                //# algorithm-suites.md#signature-algorithm), the encrypt operation
-                //# MUST perform this step.
+        //= compliance/client-apis/encrypt.txt#2.6
+        //# If the encryption materials gathered (Section 2.6.1) has a
+        //# algorithm suite including a signature algorithm (../framework/
+        //# algorithm-suites.md#signature-algorithm), the encrypt operation
+        //# MUST perform this step.
 
-                //= compliance/data-format/message-footer.txt#2.3
-                //# When an algorithm suite (../framework/algorithm-suites.md) includes a
-                //# signature algorithm (../framework/algorithm-suites.md#signature-
-                //# algorithm), the message (message.md) MUST contain a footer.
+        //= compliance/data-format/message-footer.txt#2.3
+        //# When an algorithm suite (../framework/algorithm-suites.md) includes a
+        //# signature algorithm (../framework/algorithm-suites.md#signature-
+        //# algorithm), the message (message.md) MUST contain a footer.
 
-                var msg :- EncryptDecryptHelpers.SerializeMessageWithoutSignature(framedMessage, suite);
-                var ecdsaParams := framedMessage.finalFrame.header.suite.signature.curve;
-                // TODO: This should just work, but Proof is difficult
-                :- Need(materials.signingKey.Some?, "Missing signing key.");
+        var msg :- EncryptDecryptHelpers.SerializeMessageWithoutSignature(framedMessage, suite);
+        var ecdsaParams := framedMessage.finalFrame.header.suite.signature.curve;
+        // TODO: This should just work, but Proof is difficult
+        :- Need(materials.signingKey.Some?, "Missing signing key.");
 
-                //= compliance/client-apis/encrypt.txt#2.7.2
-                //# To calculate a signature, this operation MUST use the signature
-                //# algorithm (../framework/algorithm-suites.md#signature-algorithm)
-                //# specified by the algorithm suite (../framework/algorithm-suites.md),
-                //# with the following input:
-                //#*  the signature key is the signing key (../framework/
-                //#   structures.md#signing-key) in the encryption materials
-                //#   (../framework/structures.md#encryption-materials)
-                //#*  the input to sign is the concatenation of the serialization of the
-                //#   message header (../data-format/message-header.md) and message body
-                //#   (../data-format/message-body.md)
-                var bytes :- Signature.Sign(ecdsaParams, materials.signingKey.value, msg);
-                :- Need(|bytes| == ecdsaParams.SignatureLength() as int, "Malformed response from Sign().");
+        //= compliance/client-apis/encrypt.txt#2.7.2
+        //# To calculate a signature, this operation MUST use the signature
+        //# algorithm (../framework/algorithm-suites.md#signature-algorithm)
+        //# specified by the algorithm suite (../framework/algorithm-suites.md),
+        //# with the following input:
+        //#*  the signature key is the signing key (../framework/
+        //#   structures.md#signing-key) in the encryption materials
+        //#   (../framework/structures.md#encryption-materials)
+        //#*  the input to sign is the concatenation of the serialization of the
+        //#   message header (../data-format/message-header.md) and message body
+        //#   (../data-format/message-body.md)
+        var bytes :- Signature.Sign(ecdsaParams, materials.signingKey.value, msg);
+        :- Need(|bytes| == ecdsaParams.SignatureLength() as int, "Malformed response from Sign().");
 
-                //= compliance/client-apis/encrypt.txt#2.7.2
-                //# This operation MUST then serialize a message footer with the
-                //# following specifics:
+        //= compliance/client-apis/encrypt.txt#2.7.2
+        //# This operation MUST then serialize a message footer with the
+        //# following specifics:
 
-                //= compliance/client-apis/encrypt.txt#2.7.2
-                //# *  Signature Length (../data-format/message-footer.md#signature-
-                //# length): MUST be the length of the output of the calculation
-                //# above.
+        //= compliance/client-apis/encrypt.txt#2.7.2
+        //# *  Signature Length (../data-format/message-footer.md#signature-
+        //# length): MUST be the length of the output of the calculation
+        //# above.
 
-                //= compliance/client-apis/encrypt.txt#2.7.2
-                //# *  Signature (../data-format/message-footer.md#signature): MUST be
-                //# the output of the calculation above.
-                var signature := UInt16ToSeq(|bytes| as uint16) + bytes;
+        //= compliance/client-apis/encrypt.txt#2.7.2
+        //# *  Signature (../data-format/message-footer.md#signature): MUST be
+        //# the output of the calculation above.
+        var signature := UInt16ToSeq(|bytes| as uint16) + bytes;
 
-                //= compliance/client-apis/encrypt.txt#2.7.2
-                //# The encrypted message output by this operation MUST have a message
-                //# footer equal to the message footer calculated in this step.
-                msg := msg + signature;
-                // TODO: Come back and prove this
-                // assert msg == SerializeMessageWithSignature(framedMessage, signature); // Header, frames and signature can be serialized into the stream
+        //= compliance/client-apis/encrypt.txt#2.7.2
+        //# The encrypted message output by this operation MUST have a message
+        //# footer equal to the message footer calculated in this step.
+        msg := msg + signature;
+        // TODO: Come back and prove this
+        // assert msg == SerializeMessageWithSignature(framedMessage, signature); // Header, frames and signature can be serialized into the stream
 
-                //= compliance/client-apis/encrypt.txt#2.5
-                //# This behavior MUST output the following if the behavior is
-                //# successful:
-                //# *  Encrypted Message (Section 2.5.1)
-                //# *  Encryption Context (Section 2.4.2)
-                //# *  Algorithm Suite (Section 2.4.5)
-                return Success(
-                    Esdk.EncryptOutput(
-                        ciphertext := msg,
-                        encryptionContext := header.encryptionContext,
-                        algorithmSuiteId := header.suite.id
-                    )
-                ), ghostMaterials;
-            } else {
-                //= compliance/client-apis/encrypt.txt#2.6
-                //# Otherwise the encrypt operation MUST
-                //# NOT perform this step.
-                var msg :- EncryptDecryptHelpers.SerializeMessageWithoutSignature(framedMessage, suite);
-                return Success(
-                    Esdk.EncryptOutput(
-                        ciphertext := msg,
-                        encryptionContext := header.encryptionContext,
-                        algorithmSuiteId := header.suite.id
-                    )
-                ), ghostMaterials;
-            }
-        }
+        //= compliance/client-apis/encrypt.txt#2.5
+        //# This behavior MUST output the following if the behavior is
+        //# successful:
+        //# *  Encrypted Message (Section 2.5.1)
+        //# *  Encryption Context (Section 2.4.2)
+        //# *  Algorithm Suite (Section 2.4.5)
+        return Success(
+                 Esdk.EncryptOutput(
+                   ciphertext := msg,
+                   encryptionContext := header.encryptionContext,
+                   algorithmSuiteId := header.suite.id
+                 )
+               ), ghostMaterials;
+      } else {
+        //= compliance/client-apis/encrypt.txt#2.6
+        //# Otherwise the encrypt operation MUST
+        //# NOT perform this step.
+        var msg :- EncryptDecryptHelpers.SerializeMessageWithoutSignature(framedMessage, suite);
+        return Success(
+                 Esdk.EncryptOutput(
+                   ciphertext := msg,
+                   encryptionContext := header.encryptionContext,
+                   algorithmSuiteId := header.suite.id
+                 )
+               ), ghostMaterials;
+      }
+    }
 
-        method GetEncryptionMaterials(
-            cmm: Crypto.ICryptographicMaterialsManager,
-            algorithmSuiteId: Option<Crypto.AlgorithmSuiteId>,
-            inputEncryptionContext: Option<Crypto.EncryptionContext>,
-            maxPlaintextLength: int64
-        ) returns (res: Result<Crypto.EncryptionMaterials, string>)
+    method GetEncryptionMaterials(
+      cmm: Crypto.ICryptographicMaterialsManager,
+      algorithmSuiteId: Option<Crypto.AlgorithmSuiteId>,
+      inputEncryptionContext: Option<Crypto.EncryptionContext>,
+      maxPlaintextLength: int64
+    ) returns (res: Result<Crypto.EncryptionMaterials, string>)
 
-        ensures res.Success? ==>
-            && Client.Materials.EncryptionMaterialsWithPlaintextDataKey(res.value)
+      ensures res.Success? ==>
+                && Client.Materials.EncryptionMaterialsWithPlaintextDataKey(res.value)
 
-        ensures res.Success? ==>
-            && SerializableTypes.IsESDKEncryptionContext(res.value.encryptionContext)
+      ensures res.Success? ==>
+                && SerializableTypes.IsESDKEncryptionContext(res.value.encryptionContext)
 
-        ensures res.Success? ==>
-            && HasUint16Len(res.value.encryptedDataKeys)
+      ensures res.Success? ==>
+                && HasUint16Len(res.value.encryptedDataKeys)
 
-        ensures res.Success? ==>
-            && forall edk | edk in res.value.encryptedDataKeys
+      ensures res.Success? ==>
+                && forall edk | edk in res.value.encryptedDataKeys
                 :: SerializableTypes.IsESDKEncryptedDataKey(edk)
-        {
-            var encryptionContext : Crypto.EncryptionContext;
-            if inputEncryptionContext.Some? {
-                encryptionContext := inputEncryptionContext.value;
-            } else {
-                encryptionContext := map[];
-            }
+    {
+      var encryptionContext : Crypto.EncryptionContext;
+      if inputEncryptionContext.Some? {
+        encryptionContext := inputEncryptionContext.value;
+      } else {
+        encryptionContext := map[];
+      }
 
-            var encMatRequest := Crypto.GetEncryptionMaterialsInput(
-                encryptionContext:=encryptionContext,
-                commitmentPolicy:=this.commitmentPolicy,
-                algorithmSuiteId:=algorithmSuiteId,
-                maxPlaintextLength:=Option.Some(maxPlaintextLength)
-            );
+      var encMatRequest := Crypto.GetEncryptionMaterialsInput(
+                             encryptionContext:=encryptionContext,
+                             commitmentPolicy:=this.commitmentPolicy,
+                             algorithmSuiteId:=algorithmSuiteId,
+                             maxPlaintextLength:=Option.Some(maxPlaintextLength)
+                           );
 
-            //= compliance/client-apis/encrypt.txt#2.6.1
-            //# This operation MUST obtain this set of encryption
-            //# materials (../framework/structures.md#encryption-materials) by
-            //# calling Get Encryption Materials (../framework/cmm-interface.md#get-
-            //# encryption-materials) on a CMM (../framework/cmm-interface.md).
-            var getEncMatResult := cmm.GetEncryptionMaterials(encMatRequest);
-            var output :- match getEncMatResult {
-                case Success(value) => Success(value)
-                case Failure(exception) => Failure(exception.GetMessage())
-            };
+      //= compliance/client-apis/encrypt.txt#2.6.1
+      //# This operation MUST obtain this set of encryption
+      //# materials (../framework/structures.md#encryption-materials) by
+      //# calling Get Encryption Materials (../framework/cmm-interface.md#get-
+      //# encryption-materials) on a CMM (../framework/cmm-interface.md).
+      var getEncMatResult := cmm.GetEncryptionMaterials(encMatRequest);
+      var output :- match getEncMatResult {
+                      case Success(value) => Success(value)
+                      case Failure(exception) => Failure(exception.GetMessage())
+                    };
 
-            var materials := output.encryptionMaterials;
+      var materials := output.encryptionMaterials;
 
-            // Validations to ensure we got back materials that we can use
-            :- Need(
-                Client.Materials.EncryptionMaterialsWithPlaintextDataKey(materials),
-                "CMM returned invalid EncryptionMaterials"
-            );
-            :- Need(
-                SerializableTypes.IsESDKEncryptionContext(materials.encryptionContext),
-                "CMM failed to return serializable encryption materials."
-            );
-            :- Need(HasUint16Len(materials.encryptedDataKeys), "CMM returned EDKs that exceed the allowed maximum.");
-            :- Need(forall edk | edk in materials.encryptedDataKeys
-                :: SerializableTypes.IsESDKEncryptedDataKey(edk),
-                "CMM returned non-serializable encrypted data key.");
+      // Validations to ensure we got back materials that we can use
+      :- Need(
+           Client.Materials.EncryptionMaterialsWithPlaintextDataKey(materials),
+           "CMM returned invalid EncryptionMaterials"
+         );
+      :- Need(
+           SerializableTypes.IsESDKEncryptionContext(materials.encryptionContext),
+           "CMM failed to return serializable encryption materials."
+         );
+      :- Need(HasUint16Len(materials.encryptedDataKeys), "CMM returned EDKs that exceed the allowed maximum.");
+      :- Need(forall edk | edk in materials.encryptedDataKeys
+              :: SerializableTypes.IsESDKEncryptedDataKey(edk),
+              "CMM returned non-serializable encrypted data key.");
 
-            return Success(materials);
-        }
+      return Success(materials);
+    }
 
-        /*
-         * Helper method for taking optional input keyrings/CMMs and returning a CMM,
-         * either directly the one that was provided or a new default CMM from the
-         * provided keyring.
-         */
-        method CreateCmmFromInput(
-            inputCmm: Option<Crypto.ICryptographicMaterialsManager>,
-            inputKeyring: Option<Crypto.IKeyring>
-        ) returns (res: Result<Crypto.ICryptographicMaterialsManager, string>)
+    /*
+     * Helper method for taking optional input keyrings/CMMs and returning a CMM,
+     * either directly the one that was provided or a new default CMM from the
+     * provided keyring.
+     */
+    method CreateCmmFromInput(
+      inputCmm: Option<Crypto.ICryptographicMaterialsManager>,
+      inputKeyring: Option<Crypto.IKeyring>
+    ) returns (res: Result<Crypto.ICryptographicMaterialsManager, string>)
+
+      //= compliance/client-apis/encrypt.txt#2.6.1
+      //= type=implication
+      //# The
+      //# CMM used MUST be the input CMM, if supplied.
+
+      //= compliance/client-apis/decrypt.txt#2.7.2
+      //= type=implication
+      //# The CMM used MUST be the input CMM, if supplied.
+      ensures
+        && res.Success?
+        && inputCmm.Some?
+        ==>
+          res.value == inputCmm.value
+
+      ensures
+        && inputCmm.Some?
+        && inputKeyring.Some?
+        ==>
+          res.Failure?
+
+      ensures
+        && inputCmm.None?
+        && inputKeyring.None?
+        ==>
+          res.Failure?
+
+    {
+      :- Need(inputCmm.None? || inputKeyring.None?, "Cannot provide both a keyring and a CMM");
+      :- Need(inputCmm.Some? || inputKeyring.Some?, "Must provide either a keyring or a CMM");
+
+      var cmm : Crypto.ICryptographicMaterialsManager;
+      if inputCmm.Some? {
+        return Success(inputCmm.value);
+      } else {
+        // Each of these three citations refer to creating a default CMM from
+        // the input keyring.
 
         //= compliance/client-apis/encrypt.txt#2.6.1
-        //= type=implication
-        //# The
-        //# CMM used MUST be the input CMM, if supplied.
+        //# If instead the caller
+        //# supplied a keyring (../framework/keyring-interface.md), this behavior
+        //# MUST use a default CMM (../framework/default-cmm.md) constructed
+        //# using the caller-supplied keyring as input.
+
+        //= compliance/client-apis/decrypt.txt#2.5.3
+        //# If the Keyring is provided as the input, the client MUST construct a
+        //# default CMM (../framework/default-cmm.md) that uses this keyring, to
+        //# obtain the decryption materials (../framework/
+        //# structures.md#decryption-materials) that is required for decryption.
 
         //= compliance/client-apis/decrypt.txt#2.7.2
-        //= type=implication
-        //# The CMM used MUST be the input CMM, if supplied.
-        ensures
-            && res.Success?
-            && inputCmm.Some?
+        //# If a CMM is not
+        //# supplied as the input, the decrypt operation MUST construct a default
+        //# CMM (../framework/default-cmm.md) from the input keyring
+        //# (../framework/keyring-interface.md).
+        var createCmmOutput := this.materialProviders
+                               .CreateDefaultCryptographicMaterialsManager(Crypto.CreateDefaultCryptographicMaterialsManagerInput(
+                                                                                                                         keyring := inputKeyring.value
+                                                                                                                       )
+                               );
+        :- Need (createCmmOutput.Success?, "Failed to create default CMM");
+        return Success(createCmmOutput.value);
+      }
+    }
+
+    /*
+     * Generate a message id of appropriate length for the given algorithm suite.
+     */
+    method GenerateMessageId(
+      suite: Client.AlgorithmSuites.AlgorithmSuite
+    ) returns (res: Result<HeaderTypes.MessageId, string>)
+
+      ensures
+        && res.Success?
+        && suite.messageVersion == 1
         ==>
-            res.value == inputCmm.value
+          |res.value| == HeaderTypes.MESSAGE_ID_LEN_V1
 
-        ensures
-            && inputCmm.Some?
-            && inputKeyring.Some?
+      ensures
+        && res.Success?
+        && suite.messageVersion == 2
         ==>
-            res.Failure?
+          |res.value| == HeaderTypes.MESSAGE_ID_LEN_V2
+    {
+      var id;
+      if suite.messageVersion == 1 {
+        id :- Random.GenerateBytes(HeaderTypes.MESSAGE_ID_LEN_V1 as int32);
+      } else {
+        id :- Random.GenerateBytes(HeaderTypes.MESSAGE_ID_LEN_V2 as int32);
+      }
 
-        ensures
-            && inputCmm.None?
-            && inputKeyring.None?
+      return Success(id);
+    }
+
+    method BuildHeaderBody(
+      messageId: HeaderTypes.MessageId,
+      suite: Client.AlgorithmSuites.AlgorithmSuite,
+      encryptionContext: EncryptionContext.ESDKCanonicalEncryptionContext,
+      encryptedDataKeys: SerializableTypes.ESDKEncryptedDataKeys,
+      frameLength: uint32,
+      suiteData: Option<seq<uint8>>
+    ) returns (res: HeaderTypes.HeaderBody)
+
+      //= compliance/data-format/message-header.txt#2.5.2
+      //= type=implication
+      //# The length of the suite data field MUST be equal to
+      //# the Algorithm Suite Data Length (../framework/algorithm-
+      //# suites.md#algorithm-suite-data-length) value of the algorithm suite
+      //# (../framework/algorithm-suites.md) specified by the Algorithm Suite
+      //# ID (Section 2.5.1.5) field.
+      requires suite.commitment.HKDF? ==>
+                 && suiteData.Some?
+                 && |suiteData.value| == suite.commitment.outputKeyLength as int
+
+      // This ensures that our header is internally consistent with respect to
+      // commitment (e.g. creating the right header version for the given suite)
+      ensures Header.HeaderVersionSupportsCommitment?(suite, res)
+
+      // Correct construction of V2 headers
+      ensures
+        && suite.commitment.HKDF?
         ==>
-            res.Failure?
-
-        {
-            :- Need(inputCmm.None? || inputKeyring.None?, "Cannot provide both a keyring and a CMM");
-            :- Need(inputCmm.Some? || inputKeyring.Some?, "Must provide either a keyring or a CMM");
-
-            var cmm : Crypto.ICryptographicMaterialsManager;
-            if inputCmm.Some? {
-                return Success(inputCmm.value);
-            } else {
-                // Each of these three citations refer to creating a default CMM from
-                // the input keyring.
-
-                //= compliance/client-apis/encrypt.txt#2.6.1
-                //# If instead the caller
-                //# supplied a keyring (../framework/keyring-interface.md), this behavior
-                //# MUST use a default CMM (../framework/default-cmm.md) constructed
-                //# using the caller-supplied keyring as input.
-
-                //= compliance/client-apis/decrypt.txt#2.5.3
-                //# If the Keyring is provided as the input, the client MUST construct a
-                //# default CMM (../framework/default-cmm.md) that uses this keyring, to
-                //# obtain the decryption materials (../framework/
-                //# structures.md#decryption-materials) that is required for decryption.
-
-                //= compliance/client-apis/decrypt.txt#2.7.2
-                //# If a CMM is not
-                //# supplied as the input, the decrypt operation MUST construct a default
-                //# CMM (../framework/default-cmm.md) from the input keyring
-                //# (../framework/keyring-interface.md).
-                var createCmmOutput := this.materialProviders
-                    .CreateDefaultCryptographicMaterialsManager(Crypto.CreateDefaultCryptographicMaterialsManagerInput(
-                        keyring := inputKeyring.value
+          && var esdkAlgorithmSuiteId := SerializableTypes.GetESDKAlgorithmSuiteId(suite.id);
+          && res == HeaderTypes.HeaderBody.V2HeaderBody(
+                      esdkSuiteId := esdkAlgorithmSuiteId,
+                      messageId := messageId,
+                      encryptionContext := encryptionContext,
+                      encryptedDataKeys := encryptedDataKeys,
+                      contentType := HeaderTypes.ContentType.Framed,
+                      frameLength := frameLength,
+                      suiteData := suiteData.value
                     )
-                );
-                :- Need (createCmmOutput.Success?, "Failed to create default CMM");
-                return Success(createCmmOutput.value);
-            }
-        }
 
-        /*
-         * Generate a message id of appropriate length for the given algorithm suite.
-         */
-        method GenerateMessageId(
-            suite: Client.AlgorithmSuites.AlgorithmSuite
-        ) returns (res: Result<HeaderTypes.MessageId, string>)
-
-        ensures
-            && res.Success?
-            && suite.messageVersion == 1
+      // Correct construction of V1 headers
+      ensures
+        && suite.commitment.None?
         ==>
-            |res.value| == HeaderTypes.MESSAGE_ID_LEN_V1
+          && var esdkAlgorithmSuiteId := SerializableTypes.GetESDKAlgorithmSuiteId(suite.id);
+          && res == HeaderTypes.HeaderBody.V1HeaderBody(
+                      messageType := HeaderTypes.MessageType.TYPE_CUSTOMER_AED,
+                      esdkSuiteId := esdkAlgorithmSuiteId,
+                      messageId := messageId,
+                      encryptionContext := encryptionContext,
+                      encryptedDataKeys := encryptedDataKeys,
+                      contentType := HeaderTypes.ContentType.Framed,
+                      headerIvLength := suite.encrypt.ivLength as nat,
+                      frameLength := frameLength
+                    )
+    {
+      var esdkAlgorithmSuiteId := SerializableTypes.GetESDKAlgorithmSuiteId(suite.id);
 
-        ensures
-            && res.Success?
-            && suite.messageVersion == 2
-        ==>
-            |res.value| == HeaderTypes.MESSAGE_ID_LEN_V2
-        {
-            var id;
-            if suite.messageVersion == 1 {
-                id :- Random.GenerateBytes(HeaderTypes.MESSAGE_ID_LEN_V1 as int32);
-            } else {
-                id :- Random.GenerateBytes(HeaderTypes.MESSAGE_ID_LEN_V2 as int32);
-            }
+      //= compliance/client-apis/encrypt.txt#2.8.1
+      //# Implementations of the AWS Encryption SDK MUST NOT encrypt using the
+      //# Non-Framed content type.
+      var contentType := HeaderTypes.ContentType.Framed;
 
-            return Success(id);
-        }
+      match suite.commitment {
+        case None => return HeaderTypes.HeaderBody.V1HeaderBody(
+                              messageType := HeaderTypes.MessageType.TYPE_CUSTOMER_AED,
+                              esdkSuiteId := esdkAlgorithmSuiteId,
+                              messageId := messageId,
+                              encryptionContext := encryptionContext,
+                              encryptedDataKeys := encryptedDataKeys,
+                              contentType := contentType,
+                              headerIvLength := suite.encrypt.ivLength as nat,
+                              frameLength := frameLength
+                            );
+        case HKDF => return HeaderTypes.HeaderBody.V2HeaderBody(
+                              esdkSuiteId := esdkAlgorithmSuiteId,
+                              messageId := messageId,
+                              encryptionContext := encryptionContext,
+                              encryptedDataKeys := encryptedDataKeys,
+                              contentType := contentType,
+                              frameLength := frameLength,
+                              suiteData := suiteData.value
+                            );
+      }
+    }
 
-        method BuildHeaderBody(
-            messageId: HeaderTypes.MessageId,
-            suite: Client.AlgorithmSuites.AlgorithmSuite,
-            encryptionContext: EncryptionContext.ESDKCanonicalEncryptionContext,
-            encryptedDataKeys: SerializableTypes.ESDKEncryptedDataKeys,
-            frameLength: uint32,
-            suiteData: Option<seq<uint8>>
-        ) returns (res: HeaderTypes.HeaderBody)
+    method BuildHeaderAuthTag(
+      suite: Client.AlgorithmSuites.AlgorithmSuite,
+      dataKey: seq<uint8>,
+      rawHeader: seq<uint8>
+    )
+      returns (res: Result<HeaderTypes.HeaderAuth, string>)
 
-        //= compliance/data-format/message-header.txt#2.5.2
-        //= type=implication
-        //# The length of the suite data field MUST be equal to
-        //# the Algorithm Suite Data Length (../framework/algorithm-
-        //# suites.md#algorithm-suite-data-length) value of the algorithm suite
-        //# (../framework/algorithm-suites.md) specified by the Algorithm Suite
-        //# ID (Section 2.5.1.5) field.
-        requires suite.commitment.HKDF? ==>
-            && suiteData.Some?
-            && |suiteData.value| == suite.commitment.outputKeyLength as int
+      ensures res.Success? ==> Header.HeaderAuth?(suite, res.value)
+    {
+      //= compliance/client-apis/encrypt.txt#2.6.2
+      //# The
+      //# value of this MUST be the output of the authenticated encryption
+      //# algorithm (../framework/algorithm-suites.md#encryption-algorithm)
+      //# specified by the algorithm suite (../framework/algorithm-suites.md),
+      //# with the following inputs:
+      var keyLength := suite.encrypt.keyLength as int;
+      :- Need(|dataKey| == keyLength, "Incorrect data key length");
 
-        // This ensures that our header is internally consistent with respect to
-        // commitment (e.g. creating the right header version for the given suite)
-        ensures Header.HeaderVersionSupportsCommitment?(suite, res)
+      var ivLength := suite.encrypt.ivLength as int;
+      //#*  The IV has a value of 0.
+      var iv: seq<uint8> := seq(ivLength, _ => 0);
 
-        // Correct construction of V2 headers
-        ensures
-            && suite.commitment.HKDF?
-        ==>
-            && var esdkAlgorithmSuiteId := SerializableTypes.GetESDKAlgorithmSuiteId(suite.id);
-            && res == HeaderTypes.HeaderBody.V2HeaderBody(
-                esdkSuiteId := esdkAlgorithmSuiteId,
-                messageId := messageId,
-                encryptionContext := encryptionContext,
-                encryptedDataKeys := encryptedDataKeys,
-                contentType := HeaderTypes.ContentType.Framed,
-                frameLength := frameLength,
-                suiteData := suiteData.value
-            )
+      var encryptionOutput :- AESEncryption.AESEncrypt(
+                                suite.encrypt,
+                                iv,
+                                //#*  The cipherkey is the derived data key
+                                dataKey,
+                                //#*  The plaintext is an empty byte array
+                                [],
+                                //#*  The AAD is the serialized message header body (../data-format/
+                                //#   message-header.md#header-body).
+                                rawHeader
+                              );
+      var headerAuth := HeaderTypes.HeaderAuth.AESMac(
+                          headerIv := iv,
+                          headerAuthTag := encryptionOutput.authTag
+                        );
+      return Success(headerAuth);
+    }
 
-        // Correct construction of V1 headers
-        ensures
-            && suite.commitment.None?
-        ==>
-            && var esdkAlgorithmSuiteId := SerializableTypes.GetESDKAlgorithmSuiteId(suite.id);
-            && res == HeaderTypes.HeaderBody.V1HeaderBody(
-                messageType := HeaderTypes.MessageType.TYPE_CUSTOMER_AED,
-                esdkSuiteId := esdkAlgorithmSuiteId,
-                messageId := messageId,
-                encryptionContext := encryptionContext,
-                encryptedDataKeys := encryptedDataKeys,
-                contentType := HeaderTypes.ContentType.Framed,
-                headerIvLength := suite.encrypt.ivLength as nat,
-                frameLength := frameLength
-            )
-        {
-            var esdkAlgorithmSuiteId := SerializableTypes.GetESDKAlgorithmSuiteId(suite.id);
+    // We restrict this method to the encrypt path so that we can assume the body is framed.
+    method BuildHeaderForEncrypt(
+      messageId: HeaderTypes.MessageId,
+      suite: Client.AlgorithmSuites.AlgorithmSuite,
+      encryptionContext: Crypto.EncryptionContext,
+      encryptedDataKeys: SerializableTypes.ESDKEncryptedDataKeys,
+      frameLength: uint32,
+      derivedDataKeys: KeyDerivation.ExpandedKeyMaterial
+    ) returns (res: Result<Header.HeaderInfo, string>)
 
-            //= compliance/client-apis/encrypt.txt#2.8.1
-            //# Implementations of the AWS Encryption SDK MUST NOT encrypt using the
-            //# Non-Framed content type.
-            var contentType := HeaderTypes.ContentType.Framed;
+      requires SerializableTypes.IsESDKEncryptionContext(encryptionContext)
 
-            match suite.commitment {
-                case None => return HeaderTypes.HeaderBody.V1HeaderBody(
-                    messageType := HeaderTypes.MessageType.TYPE_CUSTOMER_AED,
-                    esdkSuiteId := esdkAlgorithmSuiteId,
-                    messageId := messageId,
-                    encryptionContext := encryptionContext,
-                    encryptedDataKeys := encryptedDataKeys,
-                    contentType := contentType,
-                    headerIvLength := suite.encrypt.ivLength as nat,
-                    frameLength := frameLength
-                );
-                case HKDF => return HeaderTypes.HeaderBody.V2HeaderBody(
-                    esdkSuiteId := esdkAlgorithmSuiteId,
-                    messageId := messageId,
-                    encryptionContext := encryptionContext,
-                    encryptedDataKeys := encryptedDataKeys,
-                    contentType := contentType,
-                    frameLength := frameLength,
-                    suiteData := suiteData.value
-                );
-            }
-        }
+      requires suite.commitment.HKDF? ==>
+                 && derivedDataKeys.commitmentKey.Some?
+                 && |derivedDataKeys.commitmentKey.value| == suite.commitment.outputKeyLength as int
 
-        method BuildHeaderAuthTag(
-            suite: Client.AlgorithmSuites.AlgorithmSuite,
-            dataKey: seq<uint8>,
-            rawHeader: seq<uint8>
-        )
-            returns (res: Result<HeaderTypes.HeaderAuth, string>)
+      requires frameLength > 0
 
-            ensures res.Success? ==> Header.HeaderAuth?(suite, res.value)
-        {
-            //= compliance/client-apis/encrypt.txt#2.6.2
-            //# The
-            //# value of this MUST be the output of the authenticated encryption
-            //# algorithm (../framework/algorithm-suites.md#encryption-algorithm)
-            //# specified by the algorithm suite (../framework/algorithm-suites.md),
-            //# with the following inputs:
-            var keyLength := suite.encrypt.keyLength as int;
-            :- Need(|dataKey| == keyLength, "Incorrect data key length");
+      // Make sure the output correctly uses the values that were given as input
+      ensures res.Success? ==>
+                && res.value.suite == suite
+                && res.value.body.frameLength == frameLength
+                && res.value.encryptionContext == encryptionContext
 
-            var ivLength := suite.encrypt.ivLength as int;
-            //#*  The IV has a value of 0.
-            var iv: seq<uint8> := seq(ivLength, _ => 0);
+      ensures res.Success? ==> Header.IsHeader(res.value)
 
-            var encryptionOutput :- AESEncryption.AESEncrypt(
-                suite.encrypt,
-                iv,
-                //#*  The cipherkey is the derived data key
-                dataKey,
-                //#*  The plaintext is an empty byte array
-                [],
-                //#*  The AAD is the serialized message header body (../data-format/
-                //#   message-header.md#header-body).
-                rawHeader
-            );
-            var headerAuth := HeaderTypes.HeaderAuth.AESMac(
-                headerIv := iv,
-                headerAuthTag := encryptionOutput.authTag
-            );
-            return Success(headerAuth);
-        }
+      ensures res.Success? ==> res.value.body.contentType.Framed?
+    {
+      var canonicalEncryptionContext := EncryptionContext.GetCanonicalEncryptionContext(encryptionContext);
 
-        // We restrict this method to the encrypt path so that we can assume the body is framed.
-        method BuildHeaderForEncrypt(
-            messageId: HeaderTypes.MessageId,
-            suite: Client.AlgorithmSuites.AlgorithmSuite,
-            encryptionContext: Crypto.EncryptionContext,
-            encryptedDataKeys: SerializableTypes.ESDKEncryptedDataKeys,
-            frameLength: uint32,
-            derivedDataKeys: KeyDerivation.ExpandedKeyMaterial
-        ) returns (res: Result<Header.HeaderInfo, string>)
+      var body := BuildHeaderBody(
+                    messageId,
+                    suite,
+                    canonicalEncryptionContext,
+                    encryptedDataKeys,
+                    frameLength as uint32,
+                    derivedDataKeys.commitmentKey
+                  );
 
-        requires SerializableTypes.IsESDKEncryptionContext(encryptionContext)
+      //= compliance/client-apis/encrypt.txt#2.6.2
+      //# Before encrypting input plaintext, this operation MUST serialize the
+      //# message header body (../data-format/message-header.md).
+      var rawHeader := Header.WriteHeaderBody(body);
 
-        requires suite.commitment.HKDF? ==>
-            && derivedDataKeys.commitmentKey.Some?
-            && |derivedDataKeys.commitmentKey.value| == suite.commitment.outputKeyLength as int
+      //= compliance/client-apis/encrypt.txt#2.6.2
+      //# After serializing the message header body, this operation MUST
+      //# calculate an authentication tag (../data-format/message-
+      //# header.md#authentication-tag) over the message header body.
+      var headerAuth :- BuildHeaderAuthTag(suite, derivedDataKeys.dataKey, rawHeader);
 
-        requires frameLength > 0
+      var header := Header.HeaderInfo(
+                      body := body,
+                      rawHeader := rawHeader,
+                      encryptionContext := encryptionContext,
+                      suite := suite,
+                      headerAuth := headerAuth
+                    );
 
-        // Make sure the output correctly uses the values that were given as input
-        ensures res.Success? ==>
-            && res.value.suite == suite
-            && res.value.body.frameLength == frameLength
-            && res.value.encryptionContext == encryptionContext
+      return Success(header);
+    }
 
-        ensures res.Success? ==> Header.IsHeader(res.value)
+    // See Encrypt/EncryptInternal for an explanation of why we separate Decrypt and DecryptInternal.
+    method Decrypt(input: Esdk.DecryptInput) returns (res: Result<Esdk.DecryptOutput, Esdk.IAwsEncryptionSdkException>)
+    {
+      var decryptResult := DecryptInternal(input);
+      var withConvertedError := Esdk.AwsEncryptionSdkException.WrapResultString(decryptResult);
+      return withConvertedError;
+    }
 
-        ensures res.Success? ==> res.value.body.contentType.Framed?
-        {
-            var canonicalEncryptionContext := EncryptionContext.GetCanonicalEncryptionContext(encryptionContext);
+    method DecryptInternal(input: Esdk.DecryptInput)
+      returns (res: Result<Esdk.DecryptOutput, string>)
 
-            var body := BuildHeaderBody(
-                messageId,
-                suite,
-                canonicalEncryptionContext,
-                encryptedDataKeys,
-                frameLength as uint32,
-                derivedDataKeys.commitmentKey
-            );
+      //= compliance/client-apis/decrypt.txt#2.7
+      //= type=TODO
+      //# This operation MUST perform all the above steps unless otherwise
+      //# specified, and it MUST perform them in the above order.
 
-            //= compliance/client-apis/encrypt.txt#2.6.2
-            //# Before encrypting input plaintext, this operation MUST serialize the
-            //# message header body (../data-format/message-header.md).
-            var rawHeader := Header.WriteHeaderBody(body);
+      //= compliance/client-apis/decrypt.txt#2.7.2
+      //= type=implication
+      //# If the parsed algorithm suite ID (../data-format/message-
+      //# header.md#algorithm-suite-id) is not supported by the commitment
+      //# policy (client.md#commitment-policy) configured in the client
+      //# (client.md) decrypt MUST yield an error.
 
-            //= compliance/client-apis/encrypt.txt#2.6.2
-            //# After serializing the message header body, this operation MUST
-            //# calculate an authentication tag (../data-format/message-
-            //# header.md#authentication-tag) over the message header body.
-            var headerAuth :- BuildHeaderAuthTag(suite, derivedDataKeys.dataKey, rawHeader);
+      //= compliance/client-apis/client.txt#2.4.2.1
+      //= type=implication
+      //# *  decrypt (decrypt.md) MUST support all algorithm suites
+      //
+      //= compliance/client-apis/client.txt#2.4.2.2
+      //= type=implication
+      //# *  decrypt (decrypt.md) MUST support all algorithm suites
+      //
+      //= compliance/client-apis/client.txt#2.4.2.3
+      //= type=implication
+      //# *  decrypt (decrypt.md) MUST only support algorithm suites that have
+      //# a Key Commitment (../framework/algorithm-suites.md#algorithm-
+      //# suites-encryption-key-derivation-settings) value of True
 
-            var header := Header.HeaderInfo(
-                body := body,
-                rawHeader := rawHeader,
-                encryptionContext := encryptionContext,
-                suite := suite,
-                headerAuth := headerAuth
-            );
-
-            return Success(header);
-        }
-
-        // See Encrypt/EncryptInternal for an explanation of why we separate Decrypt and DecryptInternal.
-        method Decrypt(input: Esdk.DecryptInput) returns (res: Result<Esdk.DecryptOutput, Esdk.IAwsEncryptionSdkException>)
-        {
-            var decryptResult := DecryptInternal(input);
-            var withConvertedError := Esdk.AwsEncryptionSdkException.WrapResultString(decryptResult);
-            return withConvertedError;
-        }
-
-        method DecryptInternal(input: Esdk.DecryptInput)
-            returns (res: Result<Esdk.DecryptOutput, string>)
-
-        //= compliance/client-apis/decrypt.txt#2.7
-        //= type=TODO
-        //# This operation MUST perform all the above steps unless otherwise
-        //# specified, and it MUST perform them in the above order.
-
-        //= compliance/client-apis/decrypt.txt#2.7.2
-        //= type=implication
-        //# If the parsed algorithm suite ID (../data-format/message-
-        //# header.md#algorithm-suite-id) is not supported by the commitment
-        //# policy (client.md#commitment-policy) configured in the client
-        //# (client.md) decrypt MUST yield an error.
-
-        //= compliance/client-apis/client.txt#2.4.2.1
-        //= type=implication
-        //# *  decrypt (decrypt.md) MUST support all algorithm suites
-        //
-        //= compliance/client-apis/client.txt#2.4.2.2
-        //= type=implication
-        //# *  decrypt (decrypt.md) MUST support all algorithm suites
-        //
-        //= compliance/client-apis/client.txt#2.4.2.3
-        //= type=implication
-        //# *  decrypt (decrypt.md) MUST only support algorithm suites that have
-        //# a Key Commitment (../framework/algorithm-suites.md#algorithm-
-        //# suites-encryption-key-derivation-settings) value of True
-
-        //= compliance/client-apis/decrypt.txt#2.7.2
-        //= type=implication
-        //# If the
-        //# algorithm suite is not supported by the commitment policy
-        //# (client.md#commitment-policy) configured in the client (client.md)
-        //# decrypt MUST yield an error.
-        // TODO :: Consider removing from spec as this is redundent
-        ensures
+      //= compliance/client-apis/decrypt.txt#2.7.2
+      //= type=implication
+      //# If the
+      //# algorithm suite is not supported by the commitment policy
+      //# (client.md#commitment-policy) configured in the client (client.md)
+      //# decrypt MUST yield an error.
+      // TODO :: Consider removing from spec as this is redundent
+      ensures
         (
-            && var buffer := SerializeFunctions.ReadableBuffer(input.ciphertext, 0);
-            && var headerBody := Header.ReadHeaderBody(buffer, this.maxEncryptedDataKeys);
-            && headerBody.Success?
-            && var algorithmSuiteId := SerializableTypes.GetAlgorithmSuiteId(headerBody.value.data.esdkSuiteId);
-            && Client.SpecificationClient().ValidateCommitmentPolicyOnDecrypt(
-                algorithmSuiteId, this.commitmentPolicy
-            ).Failure?
+          && var buffer := SerializeFunctions.ReadableBuffer(input.ciphertext, 0);
+          && var headerBody := Header.ReadHeaderBody(buffer, this.maxEncryptedDataKeys);
+          && headerBody.Success?
+          && var algorithmSuiteId := SerializableTypes.GetAlgorithmSuiteId(headerBody.value.data.esdkSuiteId);
+          && Client.SpecificationClient().ValidateCommitmentPolicyOnDecrypt(
+               algorithmSuiteId, this.commitmentPolicy
+             ).Failure?
         )
         ==>
-            res.Failure?
+          res.Failure?
 
-        //= compliance/client-apis/decrypt.txt#2.6
-        //= type=implication
-        //# The client MUST return as output to this operation:
-        ensures res.Success?
-        ==>
-            && var buffer := SerializeFunctions.ReadableBuffer(input.ciphertext, 0);
-            && var headerBody := Header.ReadHeaderBody(buffer, this.maxEncryptedDataKeys);
-            && headerBody.Success?
-            // *  Algorithm Suite (Section 2.6.3)
-            && var algorithmSuiteId := SerializableTypes.GetAlgorithmSuiteId(headerBody.value.data.esdkSuiteId);
-            && res.value.algorithmSuiteId == algorithmSuiteId
-            // *  Encryption Context (Section 2.6.2)
-            && var ec := EncryptionContext.GetEncryptionContext(headerBody.value.data.encryptionContext);
-            && res.value.encryptionContext == ec
+      //= compliance/client-apis/decrypt.txt#2.6
+      //= type=implication
+      //# The client MUST return as output to this operation:
+      ensures res.Success?
+              ==>
+                && var buffer := SerializeFunctions.ReadableBuffer(input.ciphertext, 0);
+                && var headerBody := Header.ReadHeaderBody(buffer, this.maxEncryptedDataKeys);
+                && headerBody.Success?
+                   // *  Algorithm Suite (Section 2.6.3)
+                && var algorithmSuiteId := SerializableTypes.GetAlgorithmSuiteId(headerBody.value.data.esdkSuiteId);
+                && res.value.algorithmSuiteId == algorithmSuiteId
+                   // *  Encryption Context (Section 2.6.2)
+                && var ec := EncryptionContext.GetEncryptionContext(headerBody.value.data.encryptionContext);
+                && res.value.encryptionContext == ec
 
-        //= compliance/client-apis/decrypt.txt#2.5
-        //= type=implication
-        //# The client MUST require exactly one of the following types of inputs:
-        //#*  Cryptographic Materials Manager (CMM) (../framework/cmm-
-        //#   interface.md)
-        //#*  Keyring (../framework/keyring-interface.md)
-        ensures
+      //= compliance/client-apis/decrypt.txt#2.5
+      //= type=implication
+      //# The client MUST require exactly one of the following types of inputs:
+      //#*  Cryptographic Materials Manager (CMM) (../framework/cmm-
+      //#   interface.md)
+      //#*  Keyring (../framework/keyring-interface.md)
+      ensures
         (
           || (input.materialsManager.Some? && input.keyring.Some?)
           || (input.materialsManager.None? && input.keyring.None?)
@@ -828,356 +828,356 @@ module {:extern "Dafny.Aws.EncryptionSdk.AwsEncryptionSdk"} AwsEncryptionSdk {
         ==>
           res.Failure?
 
-        {
-            var cmm :- CreateCmmFromInput(input.materialsManager, input.keyring);
+    {
+      var cmm :- CreateCmmFromInput(input.materialsManager, input.keyring);
 
-            //= compliance/client-apis/decrypt.txt#2.7.1
-            //# Given encrypted message bytes, this operation MUST process those
-            //# bytes sequentially, deserializing those bytes according to the
-            //# message format (../data-format/message.md).
+      //= compliance/client-apis/decrypt.txt#2.7.1
+      //# Given encrypted message bytes, this operation MUST process those
+      //# bytes sequentially, deserializing those bytes according to the
+      //# message format (../data-format/message.md).
 
-            var buffer := SerializeFunctions.ReadableBuffer(input.ciphertext, 0);
+      var buffer := SerializeFunctions.ReadableBuffer(input.ciphertext, 0);
 
-            //= compliance/client-apis/decrypt.txt#2.5.1.1
-            //= type=TODO
-            //# To make diagnosing this mistake easier, implementations SHOULD detect
-            //# the first two bytes of the Base64 encoding of any supported message
-            //# versions (../data-format/message-header.md#version-1) and types
-            //# (../data-format/message-header.md#type) and fail with a more specific
-            //# error message.
+      //= compliance/client-apis/decrypt.txt#2.5.1.1
+      //= type=TODO
+      //# To make diagnosing this mistake easier, implementations SHOULD detect
+      //# the first two bytes of the Base64 encoding of any supported message
+      //# versions (../data-format/message-header.md#version-1) and types
+      //# (../data-format/message-header.md#type) and fail with a more specific
+      //# error message.
 
-            var headerBody :- Header
-                .ReadHeaderBody(buffer, this.maxEncryptedDataKeys)
-                .MapFailure(EncryptDecryptHelpers.MapSerializeFailure(": ReadHeaderBody"));
+      var headerBody :- Header
+                        .ReadHeaderBody(buffer, this.maxEncryptedDataKeys)
+                        .MapFailure(EncryptDecryptHelpers.MapSerializeFailure(": ReadHeaderBody"));
 
-            var rawHeader := headerBody.tail.bytes[buffer.start..headerBody.tail.start];
+      var rawHeader := headerBody.tail.bytes[buffer.start..headerBody.tail.start];
 
-            var algorithmSuiteId := SerializableTypes.GetAlgorithmSuiteId(headerBody.data.esdkSuiteId);
-            //= compliance/client-apis/decrypt.txt#2.7.2
-            //# If the
-            //# algorithm suite is not supported by the commitment policy
-            //# (client.md#commitment-policy) configured in the client (client.md)
-            //# decrypt MUST yield an error.
-            var _ :- Client.SpecificationClient().ValidateCommitmentPolicyOnDecrypt(
-                algorithmSuiteId, this.commitmentPolicy
-            );
+      var algorithmSuiteId := SerializableTypes.GetAlgorithmSuiteId(headerBody.data.esdkSuiteId);
+      //= compliance/client-apis/decrypt.txt#2.7.2
+      //# If the
+      //# algorithm suite is not supported by the commitment policy
+      //# (client.md#commitment-policy) configured in the client (client.md)
+      //# decrypt MUST yield an error.
+      var _ :- Client.SpecificationClient().ValidateCommitmentPolicyOnDecrypt(
+                 algorithmSuiteId, this.commitmentPolicy
+               );
 
-            //= compliance/client-apis/decrypt.txt#2.5.2
-            //# This CMM MUST obtain the decryption materials (../framework/
-            //# structures.md#decryption-materials) required for decryption.
+      //= compliance/client-apis/decrypt.txt#2.5.2
+      //# This CMM MUST obtain the decryption materials (../framework/
+      //# structures.md#decryption-materials) required for decryption.
 
-            //= compliance/client-apis/decrypt.txt#2.5.3
-            //# This default CMM MUST obtain the decryption materials required for
-            //# decryption.
-            // TODO :: Consider removing "Default CMM MUST obtain" from spec.
-            // It is redundent and hard to prove.
+      //= compliance/client-apis/decrypt.txt#2.5.3
+      //# This default CMM MUST obtain the decryption materials required for
+      //# decryption.
+      // TODO :: Consider removing "Default CMM MUST obtain" from spec.
+      // It is redundent and hard to prove.
 
-            //= compliance/client-apis/decrypt.txt#2.7.2
-            //# This operation MUST obtain this set of decryption materials
-            //# (../framework/structures.md#decryption-materials), by calling Decrypt
-            //# Materials (../framework/cmm-interface.md#decrypt-materials) on a CMM
-            //# (../framework/cmm-interface.md).
-            var decMat :- GetDecryptionMaterials(cmm, algorithmSuiteId, headerBody.data);
+      //= compliance/client-apis/decrypt.txt#2.7.2
+      //# This operation MUST obtain this set of decryption materials
+      //# (../framework/structures.md#decryption-materials), by calling Decrypt
+      //# Materials (../framework/cmm-interface.md#decrypt-materials) on a CMM
+      //# (../framework/cmm-interface.md).
+      var decMat :- GetDecryptionMaterials(cmm, algorithmSuiteId, headerBody.data);
 
-            var suite := Client
-                .SpecificationClient()
-                .GetSuite(decMat.algorithmSuiteId);
+      var suite := Client
+                   .SpecificationClient()
+                   .GetSuite(decMat.algorithmSuiteId);
 
-            //= compliance/client-apis/decrypt.txt#2.4.2
-            //# This operation MUST NOT release any unauthenticated plaintext or
-            //# unauthenticated associated data.
-            var headerAuth :- HeaderAuth
-                .ReadHeaderAuthTag(headerBody.tail, suite)
-                .MapFailure(EncryptDecryptHelpers.MapSerializeFailure(": ReadHeaderAuthTag"));
+      //= compliance/client-apis/decrypt.txt#2.4.2
+      //# This operation MUST NOT release any unauthenticated plaintext or
+      //# unauthenticated associated data.
+      var headerAuth :- HeaderAuth
+                        .ReadHeaderAuthTag(headerBody.tail, suite)
+                        .MapFailure(EncryptDecryptHelpers.MapSerializeFailure(": ReadHeaderAuthTag"));
 
-            var maybeDerivedDataKeys := KeyDerivation.DeriveKeys(
-                headerBody.data.messageId, decMat.plaintextDataKey.value, suite
-            );
-            :- Need(maybeDerivedDataKeys.Success?, "Failed to derive data keys");
-            var derivedDataKeys := maybeDerivedDataKeys.value;
+      var maybeDerivedDataKeys := KeyDerivation.DeriveKeys(
+                                    headerBody.data.messageId, decMat.plaintextDataKey.value, suite
+                                  );
+      :- Need(maybeDerivedDataKeys.Success?, "Failed to derive data keys");
+      var derivedDataKeys := maybeDerivedDataKeys.value;
 
-            :- Need(Header.HeaderVersionSupportsCommitment?(suite, headerBody.data), "Invalid commitment values found in header body");
-            if suite.commitment.HKDF? {
-              var _ :- ValidateSuiteData(suite, headerBody.data, derivedDataKeys.commitmentKey.value);
-            }
+      :- Need(Header.HeaderVersionSupportsCommitment?(suite, headerBody.data), "Invalid commitment values found in header body");
+      if suite.commitment.HKDF? {
+        var _ :- ValidateSuiteData(suite, headerBody.data, derivedDataKeys.commitmentKey.value);
+      }
 
-            //= compliance/client-apis/decrypt.txt#2.7.3
-            //# If this tag verification fails, this operation MUST immediately halt
-            //# and fail.
-            var _ :-
-              //= compliance/client-apis/decrypt.txt#2.7.3
-              //# Once a valid message header is deserialized and decryption materials
-              //# are available, this operation MUST validate the message header body
-              //# (../data-format/message-header.md#header-body) by using the
-              //# authenticated encryption algorithm (../framework/algorithm-
-              //# suites.md#encryption-algorithm) to decrypt with the following inputs:
-              AESEncryption.AESDecrypt(
-                suite.encrypt,
-                //#*  the cipherkey is the derived data key
-                derivedDataKeys.dataKey,
-                //#*  the ciphertext is an empty byte array
-                [],
-                //#*  the tag is the value serialized in the message header's
-                //#   authentication tag field (../data-format/message-
-                //#   header.md#authentication-tag)
-                headerAuth.data.headerAuthTag,
-                //#*  the IV is the value serialized in the message header's IV field
-                //#   (../data-format/message-header#iv).
-                headerAuth.data.headerIv,
-                //#*  the AAD is the serialized message header body (../data-format/
-                //#   message-header.md#header-body).
-                rawHeader
-            );
-            assert {:split_here} true;
+      //= compliance/client-apis/decrypt.txt#2.7.3
+      //# If this tag verification fails, this operation MUST immediately halt
+      //# and fail.
+      var _ :-
+        //= compliance/client-apis/decrypt.txt#2.7.3
+        //# Once a valid message header is deserialized and decryption materials
+        //# are available, this operation MUST validate the message header body
+        //# (../data-format/message-header.md#header-body) by using the
+        //# authenticated encryption algorithm (../framework/algorithm-
+        //# suites.md#encryption-algorithm) to decrypt with the following inputs:
+        AESEncryption.AESDecrypt(
+          suite.encrypt,
+          //#*  the cipherkey is the derived data key
+          derivedDataKeys.dataKey,
+          //#*  the ciphertext is an empty byte array
+          [],
+          //#*  the tag is the value serialized in the message header's
+          //#   authentication tag field (../data-format/message-
+          //#   header.md#authentication-tag)
+          headerAuth.data.headerAuthTag,
+          //#*  the IV is the value serialized in the message header's IV field
+          //#   (../data-format/message-header#iv).
+          headerAuth.data.headerIv,
+          //#*  the AAD is the serialized message header body (../data-format/
+          //#   message-header.md#header-body).
+          rawHeader
+        );
+      assert {:split_here} true;
 
-            var receivedEncryptionContext := EncryptionContext.GetEncryptionContext(
-                headerBody.data.encryptionContext
-            );
-            :- Need(
-                SerializableTypes.IsESDKEncryptionContext(receivedEncryptionContext),
-                "Received invalid encryption context"
-            );
+      var receivedEncryptionContext := EncryptionContext.GetEncryptionContext(
+                                         headerBody.data.encryptionContext
+                                       );
+      :- Need(
+           SerializableTypes.IsESDKEncryptionContext(receivedEncryptionContext),
+           "Received invalid encryption context"
+         );
 
-            var header := Header.HeaderInfo(
-                body := headerBody.data,
-                rawHeader := rawHeader,
-                encryptionContext := receivedEncryptionContext,
-                suite := suite,
-                headerAuth := headerAuth.data
-            );
+      var header := Header.HeaderInfo(
+                      body := headerBody.data,
+                      rawHeader := rawHeader,
+                      encryptionContext := receivedEncryptionContext,
+                      suite := suite,
+                      headerAuth := headerAuth.data
+                    );
 
-            // TODO: The below assertions were added to give hints to the verifier in order to speed
-            // up verification. They can almost certainly be refactored into something prettier.
-            :- Need(
-                SerializableTypes.GetESDKAlgorithmSuiteId(header.suite.id) == header.body.esdkSuiteId,
-                "Invalid header: algorithm suite mismatch"
-            );
+      // TODO: The below assertions were added to give hints to the verifier in order to speed
+      // up verification. They can almost certainly be refactored into something prettier.
+      :- Need(
+           SerializableTypes.GetESDKAlgorithmSuiteId(header.suite.id) == header.body.esdkSuiteId,
+           "Invalid header: algorithm suite mismatch"
+         );
 
-            assert {:split_here} true;
+      assert {:split_here} true;
 
-            assert Header.HeaderAuth?(suite, headerAuth.data);
-            assert Header.IsHeader(header);
+      assert Header.HeaderAuth?(suite, headerAuth.data);
+      assert Header.IsHeader(header);
 
-            var key := derivedDataKeys.dataKey;
-            var plaintext: seq<uint8>;
+      var key := derivedDataKeys.dataKey;
+      var plaintext: seq<uint8>;
 
-            var messageBodyTail: SerializeFunctions.ReadableBuffer;
+      var messageBodyTail: SerializeFunctions.ReadableBuffer;
 
-            //= compliance/client-apis/decrypt.txt#2.7.4
-            //# Once the message header is successfully parsed, the next sequential
-            //# bytes MUST be deserialized according to the message body spec
-            //# (../data-format/message-body.md).
+      //= compliance/client-apis/decrypt.txt#2.7.4
+      //# Once the message header is successfully parsed, the next sequential
+      //# bytes MUST be deserialized according to the message body spec
+      //# (../data-format/message-body.md).
 
-            //= compliance/client-apis/decrypt.txt#2.7.4
-            //# The content type (../data-format/message-header.md#content-type)
-            //# field parsed from the message header above determines whether these
-            //# bytes MUST be deserialized as framed data (../data-format/message-
-            //# body.md#framed-data) or un-framed data (../data-format/message-
-            //# body.md#un-framed-data).
-            match header.body.contentType {
-                case NonFramed =>
-                    //= compliance/client-apis/decrypt.txt#2.7.4
-                    //# If this decryption fails, this operation MUST immediately halt and
-                    //# fail.
-                    var decryptRes :- ReadAndDecryptNonFramedMessageBody(headerAuth.tail, header, key);
-                    plaintext := decryptRes.0;
-                    messageBodyTail := decryptRes.1;
+      //= compliance/client-apis/decrypt.txt#2.7.4
+      //# The content type (../data-format/message-header.md#content-type)
+      //# field parsed from the message header above determines whether these
+      //# bytes MUST be deserialized as framed data (../data-format/message-
+      //# body.md#framed-data) or un-framed data (../data-format/message-
+      //# body.md#un-framed-data).
+      match header.body.contentType {
+        case NonFramed =>
+          //= compliance/client-apis/decrypt.txt#2.7.4
+          //# If this decryption fails, this operation MUST immediately halt and
+          //# fail.
+          var decryptRes :- ReadAndDecryptNonFramedMessageBody(headerAuth.tail, header, key);
+          plaintext := decryptRes.0;
+          messageBodyTail := decryptRes.1;
 
-                case Framed =>
-                    //= compliance/client-apis/decrypt.txt#2.7.4
-                    //# If this decryption fails, this operation MUST immediately halt and
-                    //# fail.
-                    var decryptRes :- ReadAndDecryptFramedMessageBody(headerAuth.tail, header, key);
-                    plaintext := decryptRes.0;
-                    messageBodyTail := decryptRes.1;
-            }
+        case Framed =>
+          //= compliance/client-apis/decrypt.txt#2.7.4
+          //# If this decryption fails, this operation MUST immediately halt and
+          //# fail.
+          var decryptRes :- ReadAndDecryptFramedMessageBody(headerAuth.tail, header, key);
+          plaintext := decryptRes.0;
+          messageBodyTail := decryptRes.1;
+      }
 
-            assert {:split_here} true;
+      assert {:split_here} true;
 
-            //= compliance/client-apis/decrypt.txt#2.7.5
-            //# If this verification is not successful, this operation MUST
-            //# immediately halt and fail.
-            var signature :- EncryptDecryptHelpers.VerifySignature(
-                messageBodyTail,
-                messageBodyTail.bytes[buffer.start..messageBodyTail.start],
-                decMat
-            );
+      //= compliance/client-apis/decrypt.txt#2.7.5
+      //# If this verification is not successful, this operation MUST
+      //# immediately halt and fail.
+      var signature :- EncryptDecryptHelpers.VerifySignature(
+                         messageBodyTail,
+                         messageBodyTail.bytes[buffer.start..messageBodyTail.start],
+                         decMat
+                       );
 
-            :- Need(signature.start == |signature.bytes|, "Data after message footer.");
+      :- Need(signature.start == |signature.bytes|, "Data after message footer.");
 
-            //= compliance/client-apis/decrypt.txt#2.7.1
-            //# Until the header is verified (Section 2.7.3), this operation MUST NOT
-            //# release any parsed information from the header.
-            // Note that the header is verified above
+      //= compliance/client-apis/decrypt.txt#2.7.1
+      //# Until the header is verified (Section 2.7.3), this operation MUST NOT
+      //# release any parsed information from the header.
+      // Note that the header is verified above
 
-            //= compliance/client-apis/decrypt.txt#2.7.4
-            //# This operation MUST NOT release any unauthenticated plaintext.
+      //= compliance/client-apis/decrypt.txt#2.7.4
+      //# This operation MUST NOT release any unauthenticated plaintext.
 
-            //= compliance/client-apis/decrypt.txt#2.7
-            //# If the input encrypted message is not being streamed (streaming.md)
-            //# to this operation, all output MUST NOT be released until after these
-            //# steps complete successfully.
-            return Success(
-                Esdk.DecryptOutput(
-                    plaintext := plaintext,
-                    encryptionContext := header.encryptionContext,
-                    algorithmSuiteId := header.suite.id
-                )
-            );
-        }
-
-        method ReadAndDecryptFramedMessageBody(
-            buffer: SerializeFunctions.ReadableBuffer,
-            header: Frames.FramedHeader,
-            key: seq<uint8>
-        )
-            returns (res: Result<(seq<uint8>, SerializeFunctions.ReadableBuffer), string>)
-            requires buffer.start <= |buffer.bytes|
-            requires |key| == header.suite.encrypt.keyLength as int
-            ensures res.Success? ==>
-                var (plaintext, tail) := res.value;
-                && SerializeFunctions.CorrectlyReadRange(buffer, tail)
-        {
-            assert SerializeFunctions.CorrectlyReadRange(buffer, buffer);
-            var messageBody :- MessageBody.ReadFramedMessageBody(buffer, header, [], buffer)
-                .MapFailure(EncryptDecryptHelpers.MapSerializeFailure(": ReadFramedMessageBody"));
-
-            assert header == messageBody.data.finalFrame.header;
-            assert |key| == messageBody.data.finalFrame.header.suite.encrypt.keyLength as int;
-
-            var plaintext :- MessageBody.DecryptFramedMessageBody(messageBody.data, key);
-            var messageBodyTail := messageBody.tail;
-
-            return Success((plaintext, messageBodyTail));
-        }
-
-        method ReadAndDecryptNonFramedMessageBody(
-            buffer: SerializeFunctions.ReadableBuffer,
-            header: Frames.NonFramedHeader,
-            key: seq<uint8>
-        )
-            returns (res: Result<(seq<uint8>, SerializeFunctions.ReadableBuffer), string>)
-            requires buffer.start <= |buffer.bytes|
-            requires |key| == header.suite.encrypt.keyLength as int
-            ensures res.Success? ==>
-                var (plaintext, tail) := res.value;
-                && SerializeFunctions.CorrectlyReadRange(buffer, tail)
-        {
-            var messageBody :- MessageBody.ReadNonFramedMessageBody(buffer, header)
-                .MapFailure(EncryptDecryptHelpers.MapSerializeFailure(": ReadNonFramedMessageBody"));
-            var frame: Frames.Frame := messageBody.data;
-            assert frame.NonFramed?;
-
-            assert header == frame.header;
-            assert |key| == frame.header.suite.encrypt.keyLength as int;
-
-            var plaintext :- MessageBody.DecryptFrame(frame, key);
-            var messageBodyTail := messageBody.tail;
-            return Success((plaintext, messageBodyTail));
-        }
-
-        method GetDecryptionMaterials(
-            cmm: Crypto.ICryptographicMaterialsManager,
-            algorithmSuiteId: Crypto.AlgorithmSuiteId,
-            headerBody: HeaderTypes.HeaderBody
-        ) returns (res: Result<Crypto.DecryptionMaterials, string>)
-
-        ensures res.Success? ==> Client.Materials.DecryptionMaterialsWithPlaintextDataKey(res.value)
-
-        ensures res.Success? ==> SerializableTypes.IsESDKEncryptionContext(res.value.encryptionContext)
-        {
-            var encryptionContext := EncryptionContext.GetEncryptionContext(headerBody.encryptionContext);
-            //= compliance/client-apis/decrypt.txt#2.7.2
-            //# ./framework/cmm-
-            //# interface.md#decrypt-materials) operation MUST be constructed as
-            //# follows:
-            var decMatRequest := Crypto.DecryptMaterialsInput(
-                //#*  Algorithm Suite ID: This is the parsed algorithm suite ID
-                //#   (../data-format/message-header.md#algorithm-suite-id) from the
-                //#   message header.
-                algorithmSuiteId:=algorithmSuiteId,
-                commitmentPolicy:=this.commitmentPolicy,
-                //#*  Encrypted Data Keys: This is the parsed encrypted data keys
-                //#   (../data-format/message-header#encrypted-data-keys) from the
-                //#   message header.
-                encryptedDataKeys:=headerBody.encryptedDataKeys,
-                //#*  Encryption Context: This is the parsed encryption context
-                //#   (../data-format/message-header.md#aad) from the message header.
-                encryptionContext:=encryptionContext
-            );
-            var decMatResult := cmm.DecryptMaterials(decMatRequest);
-            var output :- match decMatResult {
-                case Success(value) => Success(value)
-                case Failure(exception) => Failure(exception.GetMessage())
-            };
-            var decMat := output.decryptionMaterials;
-
-            // Validate decryption materials
-            :- Need(
-                Client.Materials.DecryptionMaterialsWithPlaintextDataKey(decMat),
-                "CMM returned invalid DecryptMaterials"
-            );
-
-            :- Need(SerializableTypes.IsESDKEncryptionContext(decMat.encryptionContext), "CMM failed to return serializable encryption materials.");
-
-            return Success(decMat);
-        }
-
-        /*
-        * Ensures that an input encryption context does not contain any values
-        * which use the reserved prefix
-        */
-        method ValidateEncryptionContext(input: Crypto.EncryptionContext)
-            returns (res: Result<(), string>)
-        //= compliance/client-apis/encrypt.txt#2.4.2
-        //= type=implication
-        //# The prefix "aws-crypto-" is reserved for internal use by the AWS
-        //# Encryption SDK; see the the Default CMM spec (default-cmm.md) for one
-        //# such use.
-        //# If the input encryption context contains any entries with
-        //# a key beginning with this prefix, the encryption operation MUST fail.
-        ensures
-            (exists key: UTF8.ValidUTF8Bytes | key in input.Keys :: RESERVED_ENCRYPTION_CONTEXT <= key)
-        ==>
-            res.Failure?
-        {
-            var anyReservedPrefixUse := exists key: UTF8.ValidUTF8Bytes | key in input.Keys :: RESERVED_ENCRYPTION_CONTEXT <= key;
-            :- Need(!anyReservedPrefixUse, "Encryption context keys cannot contain reserved prefix 'aws-crypto-'");
-
-            return Success(());
-        }
-
-        method ValidateMaxEncryptedDataKeys(edks: SerializableTypes.ESDKEncryptedDataKeys)
-            returns (res: Result<(), string>)
-
-        ensures this.maxEncryptedDataKeys.None? ==> res.Success?
-
-        ensures
-            && this.maxEncryptedDataKeys.Some?
-            && |edks| > this.maxEncryptedDataKeys.value as int
-        ==>
-            res.Failure?
-        {
-            if
-                && this.maxEncryptedDataKeys.Some?
-                && |edks| > this.maxEncryptedDataKeys.value as int
-            {
-                return Failure("Encrypted data keys exceed maxEncryptedDataKeys");
-            } else {
-                return Success(());
-            }
-        }
-
+      //= compliance/client-apis/decrypt.txt#2.7
+      //# If the input encrypted message is not being streamed (streaming.md)
+      //# to this operation, all output MUST NOT be released until after these
+      //# steps complete successfully.
+      return Success(
+               Esdk.DecryptOutput(
+                 plaintext := plaintext,
+                 encryptionContext := header.encryptionContext,
+                 algorithmSuiteId := header.suite.id
+               )
+             );
     }
+
+    method ReadAndDecryptFramedMessageBody(
+      buffer: SerializeFunctions.ReadableBuffer,
+      header: Frames.FramedHeader,
+      key: seq<uint8>
+    )
+      returns (res: Result<(seq<uint8>, SerializeFunctions.ReadableBuffer), string>)
+      requires buffer.start <= |buffer.bytes|
+      requires |key| == header.suite.encrypt.keyLength as int
+      ensures res.Success? ==>
+                var (plaintext, tail) := res.value;
+                && SerializeFunctions.CorrectlyReadRange(buffer, tail)
+    {
+      assert SerializeFunctions.CorrectlyReadRange(buffer, buffer);
+      var messageBody :- MessageBody.ReadFramedMessageBody(buffer, header, [], buffer)
+                         .MapFailure(EncryptDecryptHelpers.MapSerializeFailure(": ReadFramedMessageBody"));
+
+      assert header == messageBody.data.finalFrame.header;
+      assert |key| == messageBody.data.finalFrame.header.suite.encrypt.keyLength as int;
+
+      var plaintext :- MessageBody.DecryptFramedMessageBody(messageBody.data, key);
+      var messageBodyTail := messageBody.tail;
+
+      return Success((plaintext, messageBodyTail));
+    }
+
+    method ReadAndDecryptNonFramedMessageBody(
+      buffer: SerializeFunctions.ReadableBuffer,
+      header: Frames.NonFramedHeader,
+      key: seq<uint8>
+    )
+      returns (res: Result<(seq<uint8>, SerializeFunctions.ReadableBuffer), string>)
+      requires buffer.start <= |buffer.bytes|
+      requires |key| == header.suite.encrypt.keyLength as int
+      ensures res.Success? ==>
+                var (plaintext, tail) := res.value;
+                && SerializeFunctions.CorrectlyReadRange(buffer, tail)
+    {
+      var messageBody :- MessageBody.ReadNonFramedMessageBody(buffer, header)
+                         .MapFailure(EncryptDecryptHelpers.MapSerializeFailure(": ReadNonFramedMessageBody"));
+      var frame: Frames.Frame := messageBody.data;
+      assert frame.NonFramed?;
+
+      assert header == frame.header;
+      assert |key| == frame.header.suite.encrypt.keyLength as int;
+
+      var plaintext :- MessageBody.DecryptFrame(frame, key);
+      var messageBodyTail := messageBody.tail;
+      return Success((plaintext, messageBodyTail));
+    }
+
+    method GetDecryptionMaterials(
+      cmm: Crypto.ICryptographicMaterialsManager,
+      algorithmSuiteId: Crypto.AlgorithmSuiteId,
+      headerBody: HeaderTypes.HeaderBody
+    ) returns (res: Result<Crypto.DecryptionMaterials, string>)
+
+      ensures res.Success? ==> Client.Materials.DecryptionMaterialsWithPlaintextDataKey(res.value)
+
+      ensures res.Success? ==> SerializableTypes.IsESDKEncryptionContext(res.value.encryptionContext)
+    {
+      var encryptionContext := EncryptionContext.GetEncryptionContext(headerBody.encryptionContext);
+      //= compliance/client-apis/decrypt.txt#2.7.2
+      //# ./framework/cmm-
+      //# interface.md#decrypt-materials) operation MUST be constructed as
+      //# follows:
+      var decMatRequest := Crypto.DecryptMaterialsInput(
+                             //#*  Algorithm Suite ID: This is the parsed algorithm suite ID
+                             //#   (../data-format/message-header.md#algorithm-suite-id) from the
+                             //#   message header.
+                             algorithmSuiteId:=algorithmSuiteId,
+                             commitmentPolicy:=this.commitmentPolicy,
+                             //#*  Encrypted Data Keys: This is the parsed encrypted data keys
+                             //#   (../data-format/message-header#encrypted-data-keys) from the
+                             //#   message header.
+                             encryptedDataKeys:=headerBody.encryptedDataKeys,
+                             //#*  Encryption Context: This is the parsed encryption context
+                             //#   (../data-format/message-header.md#aad) from the message header.
+                             encryptionContext:=encryptionContext
+                           );
+      var decMatResult := cmm.DecryptMaterials(decMatRequest);
+      var output :- match decMatResult {
+                      case Success(value) => Success(value)
+                      case Failure(exception) => Failure(exception.GetMessage())
+                    };
+      var decMat := output.decryptionMaterials;
+
+      // Validate decryption materials
+      :- Need(
+           Client.Materials.DecryptionMaterialsWithPlaintextDataKey(decMat),
+           "CMM returned invalid DecryptMaterials"
+         );
+
+      :- Need(SerializableTypes.IsESDKEncryptionContext(decMat.encryptionContext), "CMM failed to return serializable encryption materials.");
+
+      return Success(decMat);
+    }
+
     /*
-     * Ensures that the suite data contained in the header of a message matches
-     * the expected suite data
+     * Ensures that an input encryption context does not contain any values
+     * which use the reserved prefix
      */
-    method ValidateSuiteData(
-        suite: Client.AlgorithmSuites.AlgorithmSuite,
-        header: HeaderTypes.HeaderBody,
-        expectedSuiteData: seq<uint8>
-    ) returns (res: Result<(), string>)
+    method ValidateEncryptionContext(input: Crypto.EncryptionContext)
+      returns (res: Result<(), string>)
+      //= compliance/client-apis/encrypt.txt#2.4.2
+      //= type=implication
+      //# The prefix "aws-crypto-" is reserved for internal use by the AWS
+      //# Encryption SDK; see the the Default CMM spec (default-cmm.md) for one
+      //# such use.
+      //# If the input encryption context contains any entries with
+      //# a key beginning with this prefix, the encryption operation MUST fail.
+      ensures
+        (exists key: UTF8.ValidUTF8Bytes | key in input.Keys :: RESERVED_ENCRYPTION_CONTEXT <= key)
+        ==>
+          res.Failure?
+    {
+      var anyReservedPrefixUse := exists key: UTF8.ValidUTF8Bytes | key in input.Keys :: RESERVED_ENCRYPTION_CONTEXT <= key;
+      :- Need(!anyReservedPrefixUse, "Encryption context keys cannot contain reserved prefix 'aws-crypto-'");
+
+      return Success(());
+    }
+
+    method ValidateMaxEncryptedDataKeys(edks: SerializableTypes.ESDKEncryptedDataKeys)
+      returns (res: Result<(), string>)
+
+      ensures this.maxEncryptedDataKeys.None? ==> res.Success?
+
+      ensures
+        && this.maxEncryptedDataKeys.Some?
+        && |edks| > this.maxEncryptedDataKeys.value as int
+        ==>
+          res.Failure?
+    {
+      if
+        && this.maxEncryptedDataKeys.Some?
+        && |edks| > this.maxEncryptedDataKeys.value as int
+      {
+        return Failure("Encrypted data keys exceed maxEncryptedDataKeys");
+      } else {
+        return Success(());
+      }
+    }
+
+  }
+  /*
+   * Ensures that the suite data contained in the header of a message matches
+   * the expected suite data
+   */
+  method ValidateSuiteData(
+    suite: Client.AlgorithmSuites.AlgorithmSuite,
+    header: HeaderTypes.HeaderBody,
+    expectedSuiteData: seq<uint8>
+  ) returns (res: Result<(), string>)
 
     // Validating suite data is only relevant for suites with commitment
     requires suite.commitment.HKDF?
@@ -1196,17 +1196,17 @@ module {:extern "Dafny.Aws.EncryptionSdk.AwsEncryptionSdk"} AwsEncryptionSdk {
     // Failure cases
     ensures header.suiteData != expectedSuiteData ==> res.Failure?
     ensures |header.suiteData| != suite.commitment.outputKeyLength as int ==> res.Failure?
-    {
-      :- Need(
-        |header.suiteData| == suite.commitment.outputKeyLength as int,
-        "Commitment key is invalid"
-      );
+  {
+    :- Need(
+         |header.suiteData| == suite.commitment.outputKeyLength as int,
+         "Commitment key is invalid"
+       );
 
-      :- Need(
-        expectedSuiteData == header.suiteData,
-        "Commitment key does not match"
-      );
+    :- Need(
+         expectedSuiteData == header.suiteData,
+         "Commitment key does not match"
+       );
 
-      return Success(());
-    }
+    return Success(());
+  }
 }

--- a/src/SDK/AwsEncryptionSdk.dfy
+++ b/src/SDK/AwsEncryptionSdk.dfy
@@ -430,9 +430,9 @@ module {:extern "Dafny.Aws.EncryptionSdk.AwsEncryptionSdk"} AwsEncryptionSdk {
       //# encryption-materials) on a CMM (../framework/cmm-interface.md).
       var getEncMatResult := cmm.GetEncryptionMaterials(encMatRequest);
       var output :- match getEncMatResult {
-                      case Success(value) => Success(value)
-                      case Failure(exception) => Failure(exception.GetMessage())
-                    };
+        case Success(value) => Success(value)
+        case Failure(exception) => Failure(exception.GetMessage())
+      };
 
       var materials := output.encryptionMaterials;
 
@@ -1107,9 +1107,9 @@ module {:extern "Dafny.Aws.EncryptionSdk.AwsEncryptionSdk"} AwsEncryptionSdk {
       );
       var decMatResult := cmm.DecryptMaterials(decMatRequest);
       var output :- match decMatResult {
-                      case Success(value) => Success(value)
-                      case Failure(exception) => Failure(exception.GetMessage())
-                    };
+        case Success(value) => Success(value)
+        case Failure(exception) => Failure(exception.GetMessage())
+      };
       var decMat := output.decryptionMaterials;
 
       // Validate decryption materials

--- a/src/SDK/AwsEncryptionSdkFactory.dfy
+++ b/src/SDK/AwsEncryptionSdkFactory.dfy
@@ -22,12 +22,12 @@ module {:extern "Dafny.Aws.EncryptionSdk.AwsEncryptionSdkFactory"} AwsEncryption
 
       ensures res.Success?
     {
-        var emptyConfig := Esdk.AwsEncryptionSdkConfig(
-          commitmentPolicy := None(),
-          maxEncryptedDataKeys := None()
-        );
-        var esdk := new AwsEncryptionSdk.AwsEncryptionSdk(emptyConfig);
-        return Success(esdk);
+      var emptyConfig := Esdk.AwsEncryptionSdkConfig(
+                           commitmentPolicy := None(),
+                           maxEncryptedDataKeys := None()
+                         );
+      var esdk := new AwsEncryptionSdk.AwsEncryptionSdk(emptyConfig);
+      return Success(esdk);
     }
 
     method CreateAwsEncryptionSdk(input: Esdk.AwsEncryptionSdkConfig)
@@ -36,22 +36,22 @@ module {:extern "Dafny.Aws.EncryptionSdk.AwsEncryptionSdkFactory"} AwsEncryption
       ensures
         && input.maxEncryptedDataKeys.Some?
         && input.maxEncryptedDataKeys.value <= 0
-      ==>
-        res.Failure?
+        ==>
+          res.Failure?
 
       ensures
         || input.maxEncryptedDataKeys.None?
         || (input.maxEncryptedDataKeys.Some? && input.maxEncryptedDataKeys.value > 0)
-      ==>
-        res.Success?
+        ==>
+          res.Success?
     {
-        if input.maxEncryptedDataKeys.Some? && input.maxEncryptedDataKeys.value <= 0 {
-            var err := new Esdk.AwsEncryptionSdkException("maxEncryptedDataKeys must be non-negative");
-            return Failure(err);
-        }
+      if input.maxEncryptedDataKeys.Some? && input.maxEncryptedDataKeys.value <= 0 {
+        var err := new Esdk.AwsEncryptionSdkException("maxEncryptedDataKeys must be non-negative");
+        return Failure(err);
+      }
 
-        var esdk := new AwsEncryptionSdk.AwsEncryptionSdk(input);
-        return Success(esdk);
+      var esdk := new AwsEncryptionSdk.AwsEncryptionSdk(input);
+      return Success(esdk);
     }
   }
 }

--- a/src/SDK/AwsEncryptionSdkFactory.dfy
+++ b/src/SDK/AwsEncryptionSdkFactory.dfy
@@ -23,9 +23,9 @@ module {:extern "Dafny.Aws.EncryptionSdk.AwsEncryptionSdkFactory"} AwsEncryption
       ensures res.Success?
     {
       var emptyConfig := Esdk.AwsEncryptionSdkConfig(
-                           commitmentPolicy := None(),
-                           maxEncryptedDataKeys := None()
-                         );
+        commitmentPolicy := None(),
+        maxEncryptedDataKeys := None()
+      );
       var esdk := new AwsEncryptionSdk.AwsEncryptionSdk(emptyConfig);
       return Success(esdk);
     }

--- a/src/SDK/EncryptDecrypt.dfy
+++ b/src/SDK/EncryptDecrypt.dfy
@@ -25,10 +25,10 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
   import opened SerializeFunctions
   import HeaderAuth
 
-    //= compliance/client-apis/encrypt.txt#2.4.6
-    //= type=implication
-    //# This
-    //# value MUST default to 4096 bytes.
+  //= compliance/client-apis/encrypt.txt#2.4.6
+  //= type=implication
+  //# This
+  //# value MUST default to 4096 bytes.
   const DEFAULT_FRAME_LENGTH : int64 := 4096
 
   // Specification of Encrypt with signature
@@ -40,10 +40,10 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
     :(res: Result<seq<uint8>, string>)
     requires |signature| < UINT16_LIMIT
     ensures res.Success?
-    ==>
-      && var message := SerializeMessageWithoutSignature(framedMessage, suite);
-      && message.Success?
-      && res.value == message.value + WriteShortLengthSeq(signature)
+            ==>
+              && var message := SerializeMessageWithoutSignature(framedMessage, suite);
+              && message.Success?
+              && res.value == message.value + WriteShortLengthSeq(signature)
   {
     var serializedSignature := WriteShortLengthSeq(signature);
     var serializedMessage :- SerializeMessageWithoutSignature(framedMessage, suite);
@@ -95,75 +95,75 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
     //# Otherwise this operation MUST NOT perform this
     //# step.
     ensures decMat.verificationKey.None? ==> res.Success? && res.value == buffer
-    
+
     // This proof makes sure we return failure if we successfully call signature verification
     // and it returns false.
     // It is basically just reproducing the exact steps we take in the method body.
     ensures (
-      && var sigAlg := Client.SpecificationClient().GetSuite(decMat.algorithmSuiteId).signature;
-      && sigAlg.ECDSA?
-      && var ecdsaParams := sigAlg.curve;
-      && var signature := SerializeFunctions
-        .ReadShortLengthSeq(buffer)
-        .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
-      && signature.Success?
-      && var signatureVerifiedResult := Signature.Verify(ecdsaParams,
-        decMat.verificationKey.value,
-        msg,
-        signature.value.data
-      );
-      // The verification call succeeded and the value it returned was false
-      // (indicating invalid signature)
-      && signatureVerifiedResult.Success?
-      && !signatureVerifiedResult.value
-    )
-    ==>
-      res.Failure?
+              && var sigAlg := Client.SpecificationClient().GetSuite(decMat.algorithmSuiteId).signature;
+              && sigAlg.ECDSA?
+              && var ecdsaParams := sigAlg.curve;
+              && var signature := SerializeFunctions
+                                  .ReadShortLengthSeq(buffer)
+                                  .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
+              && signature.Success?
+              && var signatureVerifiedResult := Signature.Verify(ecdsaParams,
+                                                                 decMat.verificationKey.value,
+                                                                 msg,
+                                                                 signature.value.data
+                                                );
+              // The verification call succeeded and the value it returned was false
+              // (indicating invalid signature)
+              && signatureVerifiedResult.Success?
+              && !signatureVerifiedResult.value
+            )
+            ==>
+              res.Failure?
 
     // This proof makes sure we return failure if we fail to call signature verification.
     // It is basically just reproducing the exact steps we take in the method body.
     ensures (
-      && var sigAlg := Client.SpecificationClient().GetSuite(decMat.algorithmSuiteId).signature;
-      && sigAlg.ECDSA?
-      && var ecdsaParams := sigAlg.curve;
-      && var signature := SerializeFunctions
-        .ReadShortLengthSeq(buffer)
-        .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
-      && signature.Success?
-      && var signatureVerifiedResult := Signature.Verify(ecdsaParams,
-        decMat.verificationKey.value,
-        msg,
-        signature.value.data
-      );
-      // The verification call failed
-      && signatureVerifiedResult.Failure?
-    )
-    ==>
-      res.Failure?
+              && var sigAlg := Client.SpecificationClient().GetSuite(decMat.algorithmSuiteId).signature;
+              && sigAlg.ECDSA?
+              && var ecdsaParams := sigAlg.curve;
+              && var signature := SerializeFunctions
+                                  .ReadShortLengthSeq(buffer)
+                                  .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
+              && signature.Success?
+              && var signatureVerifiedResult := Signature.Verify(ecdsaParams,
+                                                                 decMat.verificationKey.value,
+                                                                 msg,
+                                                                 signature.value.data
+                                                );
+              // The verification call failed
+              && signatureVerifiedResult.Failure?
+            )
+            ==>
+              res.Failure?
 
 
     // This proof makes sure we return success if signature verification succeeds.
     // It is basically just reproducing the exact steps we take in the method body.
     ensures (
-      && var sigAlg := Client.SpecificationClient().GetSuite(decMat.algorithmSuiteId).signature;
-      && sigAlg.ECDSA?
-      && var ecdsaParams := sigAlg.curve;
-      && var signature := SerializeFunctions
-        .ReadShortLengthSeq(buffer)
-        .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
-      && signature.Success?
-      && var signatureVerifiedResult := Signature.Verify(ecdsaParams,
-        decMat.verificationKey.value,
-        msg,
-        signature.value.data
-      );
-      // The verification call succeeded and the value it returned was true
-      // (indicating valid signature)
-      && signatureVerifiedResult.Success?
-      && signatureVerifiedResult.value
-    )
-    ==>
-      res.Success?
+              && var sigAlg := Client.SpecificationClient().GetSuite(decMat.algorithmSuiteId).signature;
+              && sigAlg.ECDSA?
+              && var ecdsaParams := sigAlg.curve;
+              && var signature := SerializeFunctions
+                                  .ReadShortLengthSeq(buffer)
+                                  .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
+              && signature.Success?
+              && var signatureVerifiedResult := Signature.Verify(ecdsaParams,
+                                                                 decMat.verificationKey.value,
+                                                                 msg,
+                                                                 signature.value.data
+                                                );
+              // The verification call succeeded and the value it returned was true
+              // (indicating valid signature)
+              && signatureVerifiedResult.Success?
+              && signatureVerifiedResult.value
+            )
+            ==>
+              res.Success?
 
   {
     // If there is no verification key, that lets us conclude that the suite does not have a signature.
@@ -177,19 +177,19 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
     //# If the algorithm suite has a signature algorithm, this operation MUST
     //# verify the message footer using the specified signature algorithm.
 
-    
+
     //= compliance/client-apis/decrypt.txt#2.7
     //# ./framework/algorithm-
     //# suites.md#signature-algorithm), this operation MUST perform
     //# this step.
     var signature :- SerializeFunctions
-    
-      //= compliance/client-apis/decrypt.txt#2.7.5
-      //# After deserializing the body, this operation MUST deserialize the
-      //# next encrypted message bytes as the message footer (../data-format/
-      //# message-footer.md).
-      .ReadShortLengthSeq(buffer)
-      .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
+
+                     //= compliance/client-apis/decrypt.txt#2.7.5
+                     //# After deserializing the body, this operation MUST deserialize the
+                     //# next encrypted message bytes as the message footer (../data-format/
+                     //# message-footer.md).
+                     .ReadShortLengthSeq(buffer)
+                     .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
 
     var ecdsaParams := Client.SpecificationClient().GetSuite(decMat.algorithmSuiteId).signature.curve;
 
@@ -200,15 +200,15 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
     //# suites.md) in the decryption materials to verify the encrypted
     //# message, with the following inputs:
     var signatureVerifiedResult :- Signature.Verify(ecdsaParams,
-      //#*  The verification key is the verification key (../framework/
-      //#   structures.md#verification-key) in the decryption materials.
-      decMat.verificationKey.value,
-      //#*  The input to verify is the concatenation of the serialization of
-      //#   the message header (../data-format/message-header.md) and message
-      //#   body (../data-format/message-body.md).
-      msg,
-      signature.data
-    );
+                                                    //#*  The verification key is the verification key (../framework/
+                                                    //#   structures.md#verification-key) in the decryption materials.
+                                                    decMat.verificationKey.value,
+                                                    //#*  The input to verify is the concatenation of the serialization of
+                                                    //#   the message header (../data-format/message-header.md) and message
+                                                    //#   body (../data-format/message-body.md).
+                                                    msg,
+                                                    signature.data
+                                   );
 
     if (!signatureVerifiedResult) {
       return Failure("Invalid signature");
@@ -247,7 +247,7 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
 
   function method MapSerializeFailure(s: string): SerializeFunctions.ReadProblems -> string {
     (e: SerializeFunctions.ReadProblems) =>
-    match e
+      match e
       case Error(e) => e
       case MoreNeeded(_) => "Incomplete message" + s
   }

--- a/src/SDK/EncryptDecrypt.dfy
+++ b/src/SDK/EncryptDecrypt.dfy
@@ -105,13 +105,13 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
               && var ecdsaParams := sigAlg.curve;
               && var signature := SerializeFunctions
                                   .ReadShortLengthSeq(buffer)
-                                  .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
+              .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
               && signature.Success?
               && var signatureVerifiedResult := Signature.Verify(ecdsaParams,
                                                                  decMat.verificationKey.value,
                                                                  msg,
                                                                  signature.value.data
-                                                );
+                 );
               // The verification call succeeded and the value it returned was false
               // (indicating invalid signature)
               && signatureVerifiedResult.Success?
@@ -128,13 +128,13 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
               && var ecdsaParams := sigAlg.curve;
               && var signature := SerializeFunctions
                                   .ReadShortLengthSeq(buffer)
-                                  .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
+              .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
               && signature.Success?
               && var signatureVerifiedResult := Signature.Verify(ecdsaParams,
                                                                  decMat.verificationKey.value,
                                                                  msg,
                                                                  signature.value.data
-                                                );
+                 );
               // The verification call failed
               && signatureVerifiedResult.Failure?
             )
@@ -150,13 +150,13 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
               && var ecdsaParams := sigAlg.curve;
               && var signature := SerializeFunctions
                                   .ReadShortLengthSeq(buffer)
-                                  .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
+              .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
               && signature.Success?
               && var signatureVerifiedResult := Signature.Verify(ecdsaParams,
                                                                  decMat.verificationKey.value,
                                                                  msg,
                                                                  signature.value.data
-                                                );
+                 );
               // The verification call succeeded and the value it returned was true
               // (indicating valid signature)
               && signatureVerifiedResult.Success?
@@ -189,7 +189,7 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
                      //# next encrypted message bytes as the message footer (../data-format/
                      //# message-footer.md).
                      .ReadShortLengthSeq(buffer)
-                     .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
+    .MapFailure(MapSerializeFailure(": ReadShortLengthSeq"));
 
     var ecdsaParams := Client.SpecificationClient().GetSuite(decMat.algorithmSuiteId).signature.curve;
 
@@ -208,7 +208,7 @@ module {:extern "EncryptDecryptHelpers"} EncryptDecryptHelpers {
                                                     //#   body (../data-format/message-body.md).
                                                     msg,
                                                     signature.data
-                                   );
+    );
 
     if (!signatureVerifiedResult) {
       return Failure("Invalid signature");

--- a/src/SDK/KeyDerivation.dfy
+++ b/src/SDK/KeyDerivation.dfy
@@ -23,9 +23,9 @@ module {:extern "KeyDerivation"} KeyDerivation {
   // Convenience container to hold both a data key and an optional commitment key
   // to support algorithm suites that provide commitment and those that do not
   datatype ExpandedKeyMaterial = ExpandedKeyMaterial(
-                                   nameonly dataKey: seq<uint8>,
-                                   nameonly commitmentKey: Option<seq<uint8>>
-                                 )
+    nameonly dataKey: seq<uint8>,
+    nameonly commitmentKey: Option<seq<uint8>>
+  )
 
   /*
    * Derives a single data key from an input plaintext data key, using "v1"-style

--- a/src/SDK/KeyDerivation.dfy
+++ b/src/SDK/KeyDerivation.dfy
@@ -23,9 +23,9 @@ module {:extern "KeyDerivation"} KeyDerivation {
   // Convenience container to hold both a data key and an optional commitment key
   // to support algorithm suites that provide commitment and those that do not
   datatype ExpandedKeyMaterial = ExpandedKeyMaterial(
-    nameonly dataKey: seq<uint8>,
-    nameonly commitmentKey: Option<seq<uint8>>
-  )
+                                   nameonly dataKey: seq<uint8>,
+                                   nameonly commitmentKey: Option<seq<uint8>>
+                                 )
 
   /*
    * Derives a single data key from an input plaintext data key, using "v1"-style
@@ -133,8 +133,8 @@ module {:extern "KeyDerivation"} KeyDerivation {
     //# data key using the commit key derivation (../framework/algorithm-
     //# suites.md#algorithm-suites-commit-key-derivation-settings).
     ensures res.Success? ==>
-      && res.value.commitmentKey.Some?
-      && |res.value.commitmentKey.value| == suite.commitment.outputKeyLength as int
+              && res.value.commitmentKey.Some?
+              && |res.value.commitmentKey.value| == suite.commitment.outputKeyLength as int
 
     ensures res.Success? ==> |res.value.dataKey| == suite.encrypt.keyLength as int
 
@@ -181,20 +181,20 @@ module {:extern "KeyDerivation"} KeyDerivation {
     requires |plaintextKey| < INT32_MAX_LIMIT
 
     ensures res.Success? ==>
-      |res.value.dataKey| == suite.encrypt.keyLength as nat
+              |res.value.dataKey| == suite.encrypt.keyLength as nat
 
     ensures
       && res.Success?
       && suite.commitment.None?
-    ==>
-      res.value.commitmentKey.None?
+      ==>
+        res.value.commitmentKey.None?
 
     ensures
       && res.Success?
       && suite.commitment.HKDF?
-    ==>
-      && res.value.commitmentKey.Some?
-      && |res.value.commitmentKey.value| == suite.commitment.outputKeyLength as int
+      ==>
+        && res.value.commitmentKey.Some?
+        && |res.value.commitmentKey.value| == suite.commitment.outputKeyLength as int
   {
     var keys : ExpandedKeyMaterial;
     if (suite.messageVersion == 2) {

--- a/src/SDK/MessageBody.dfy
+++ b/src/SDK/MessageBody.dfy
@@ -275,11 +275,11 @@ module MessageBody {
       //# a regular frame (Section 2.7.1) using the consumable plaintext
       //# bytes.
       var regularFrame :- EncryptRegularFrame(
-                            key,
-                            header,
-                            plaintextFrame,
-                            sequenceNumber
-                          );
+        key,
+        header,
+        plaintextFrame,
+        sequenceNumber
+      );
 
       assert regularFrame.seqNum as nat == |regularFrames| + 1;
       LemmaAddingNextRegularFrame(regularFrames, regularFrame);
@@ -317,11 +317,11 @@ module MessageBody {
     //# Frame encrypted content length SHOULD be equal to the frame length
     //# but MAY be 0.
     var finalFrame :- EncryptFinalFrame(
-                        key,
-                        header,
-                        plaintext[n..],
-                        sequenceNumber
-                      );
+      key,
+      header,
+      plaintext[n..],
+      sequenceNumber
+    );
 
     assert MessageFramesAreForTheSameMessage(regularFrames + [finalFrame]);
 
@@ -370,50 +370,50 @@ module MessageBody {
     // *  The AAD is the serialized message body AAD (../data-format/
     //    message-body-aad.md), constructed as follows:
     var aad := BodyAAD(
-                 // -  The message ID (../data-format/message-body-aad.md#message-id)
-                 //    is the same as the message ID (../data-frame/message-
-                 //    header.md#message-id) serialized in the header of this message.
-                 header.body.messageId,
-                 AADRegularFrame,
-                 sequenceNumber,
-                 //= compliance/client-apis/encrypt.txt#2.7.1
-                 //# -  The content length (../data-format/message-body-aad.md#content-
-                 //# length) MUST have a value equal to the length of the plaintext
-                 //# being encrypted.
-                 |plaintext| as uint64
-               );
+      // -  The message ID (../data-format/message-body-aad.md#message-id)
+      //    is the same as the message ID (../data-frame/message-
+      //    header.md#message-id) serialized in the header of this message.
+      header.body.messageId,
+      AADRegularFrame,
+      sequenceNumber,
+      //= compliance/client-apis/encrypt.txt#2.7.1
+      //# -  The content length (../data-format/message-body-aad.md#content-
+      //# length) MUST have a value equal to the length of the plaintext
+      //# being encrypted.
+      |plaintext| as uint64
+    );
 
     var encryptionOutput :- AESEncryption.AESEncrypt(
-                              header.suite.encrypt,
-                              iv,
-                              key,
-                              plaintext,
-                              aad
-                            );
+      header.suite.encrypt,
+      iv,
+      key,
+      plaintext,
+      aad
+    );
 
     //= compliance/client-apis/encrypt.txt#2.7.1
     //# This operation MUST serialize a regular frame or final frame with the
     //# following specifics:
     var frame: Frames.RegularFrame := Frames.Frame.RegularFrame(
-                                        header,
-                                        //= compliance/client-apis/encrypt.txt#2.7.1
-                                        //# *  Sequence Number (../data-format/message-body.md#sequence-number):
-                                        //# MUST be the sequence number of this frame, as determined above.
-                                        sequenceNumber,
-                                        //= compliance/client-apis/encrypt.txt#2.7.1
-                                        //# *  IV (../data-format/message-body.md#iv): MUST be the IV used when
-                                        //# calculating the encrypted content above
-                                        iv,
-                                        //= compliance/client-apis/encrypt.txt#2.7.1
-                                        //# *  Encrypted Content (../data-format/message-body.md#encrypted-
-                                        //# content): MUST be the encrypted content calculated above.
-                                        encryptionOutput.cipherText,
-                                        //= compliance/client-apis/encrypt.txt#2.7.1
-                                        //# *  Authentication Tag (../data-format/message-body.md#authentication-
-                                        //# tag): MUST be the authentication tag output when calculating the
-                                        //# encrypted content above.
-                                        encryptionOutput.authTag
-                                      );
+      header,
+      //= compliance/client-apis/encrypt.txt#2.7.1
+      //# *  Sequence Number (../data-format/message-body.md#sequence-number):
+      //# MUST be the sequence number of this frame, as determined above.
+      sequenceNumber,
+      //= compliance/client-apis/encrypt.txt#2.7.1
+      //# *  IV (../data-format/message-body.md#iv): MUST be the IV used when
+      //# calculating the encrypted content above
+      iv,
+      //= compliance/client-apis/encrypt.txt#2.7.1
+      //# *  Encrypted Content (../data-format/message-body.md#encrypted-
+      //# content): MUST be the encrypted content calculated above.
+      encryptionOutput.cipherText,
+      //= compliance/client-apis/encrypt.txt#2.7.1
+      //# *  Authentication Tag (../data-format/message-body.md#authentication-
+      //# tag): MUST be the authentication tag output when calculating the
+      //# encrypted content above.
+      encryptionOutput.authTag
+    );
 
     return Success(frame);
   }
@@ -453,31 +453,31 @@ module MessageBody {
     var iv := IVSeq(header.suite, sequenceNumber);
 
     var aad := BodyAAD(
-                 header.body.messageId,
-                 AADFinalFrame,
-                 sequenceNumber,
-                 //= compliance/client-apis/encrypt.txt#2.7.1
-                 //# o  For a final frame this MUST be the length of the remaining
-                 //# plaintext bytes which have not yet been encrypted, whose
-                 //# length MUST be equal to or less than the frame length.
-                 |plaintext| as uint64
-               );
+      header.body.messageId,
+      AADFinalFrame,
+      sequenceNumber,
+      //= compliance/client-apis/encrypt.txt#2.7.1
+      //# o  For a final frame this MUST be the length of the remaining
+      //# plaintext bytes which have not yet been encrypted, whose
+      //# length MUST be equal to or less than the frame length.
+      |plaintext| as uint64
+    );
 
     var encryptionOutput :- AESEncryption.AESEncrypt(
-                              header.suite.encrypt,
-                              iv,
-                              key,
-                              plaintext,
-                              aad
-                            );
+      header.suite.encrypt,
+      iv,
+      key,
+      plaintext,
+      aad
+    );
 
     var finalFrame: Frames.FinalFrame := Frames.Frame.FinalFrame(
-                                           header,
-                                           sequenceNumber,
-                                           iv,
-                                           encryptionOutput.cipherText,
-                                           encryptionOutput.authTag
-                                         );
+      header,
+      sequenceNumber,
+      iv,
+      encryptionOutput.cipherText,
+      encryptionOutput.authTag
+    );
 
     return Success(finalFrame);
   }
@@ -834,18 +834,18 @@ module MessageBody {
       assert {:split_here} true;
       var finalFrame :- Frames.ReadFinalFrame(continuation, header);
       :- Need(
-           finalFrame.data.seqNum as nat == |regularFrames| + 1,
-           Error("Sequence number out of order.")
-         );
+        finalFrame.data.seqNum as nat == |regularFrames| + 1,
+        Error("Sequence number out of order.")
+      );
 
       assert {:split_here} true;
       assert MessageFramesAreMonotonic(regularFrames + [finalFrame.data]);
       assert MessageFramesAreForTheSameMessage(regularFrames + [finalFrame.data]);
 
       var body: FramedMessage := FramedMessageBody(
-                                   regularFrames := regularFrames,
-                                   finalFrame := finalFrame.data
-                                 );
+        regularFrames := regularFrames,
+        finalFrame := finalFrame.data
+      );
 
       assert {:split_here} true;
       assert CorrectlyRead(continuation, Success(finalFrame), Frames.WriteFinalFrame);

--- a/src/SDK/MessageBody.dfy
+++ b/src/SDK/MessageBody.dfy
@@ -103,8 +103,8 @@ module MessageBody {
   {
     exists plaintextSeg: seq<seq<uint8>>
     ::
-    && FramesEncryptPlaintextSegments(frames.regularFrames + [frames.finalFrame], plaintextSeg)
-    && SumPlaintextSegments(plaintextSeg) == plaintext
+      && FramesEncryptPlaintextSegments(frames.regularFrames + [frames.finalFrame], plaintextSeg)
+      && SumPlaintextSegments(plaintextSeg) == plaintext
   }
 
   predicate FramesEncryptPlaintextSegments(frames: seq<Frame>, plaintextSeg: seq<seq<uint8>>)
@@ -113,13 +113,13 @@ module MessageBody {
     if |frames| != |plaintextSeg| then
       false
     else
-      // No more regular frames, check the tail
-     if frames == [] then
-        true
-      else
-        // Drop the segments
-        && FramesEncryptPlaintextSegments(Seq.DropLast(frames), Seq.DropLast(plaintextSeg))
-        && AESEncryption.CiphertextGeneratedWithPlaintext(Seq.Last(frames).encContent, Seq.Last(plaintextSeg))
+    // No more regular frames, check the tail
+    if frames == [] then
+      true
+    else
+      // Drop the segments
+      && FramesEncryptPlaintextSegments(Seq.DropLast(frames), Seq.DropLast(plaintextSeg))
+      && AESEncryption.CiphertextGeneratedWithPlaintext(Seq.Last(frames).encContent, Seq.Last(plaintextSeg))
   }
 
   function SumPlaintextSegments(plaintextSeg: seq<seq<uint8>>): seq<uint8>
@@ -131,8 +131,8 @@ module MessageBody {
   }
 
   type MessageRegularFrames = regularFrames: seq<Frames.RegularFrame>
-  | IsMessageRegularFrames(regularFrames)
-  witness *
+    | IsMessageRegularFrames(regularFrames)
+    witness *
 
   predicate MessageFramesAreMonotonic(frames: seq<MessageFrame>){
     if |frames| == 0 then true
@@ -146,9 +146,9 @@ module MessageBody {
 
   predicate MessageFramesAreForTheSameMessage(frames: seq<MessageFrame>){
     forall i
-    // This excludes the First frame in the seq
-    // because all headers are definitionally equal for `[]` and `[frame]`.
-    | 0 < i < |frames|
+      // This excludes the First frame in the seq
+      // because all headers are definitionally equal for `[]` and `[frame]`.
+      | 0 < i < |frames|
     ::  Seq.First(frames).header == frames[i].header
   }
 
@@ -162,53 +162,53 @@ module MessageBody {
     //# *  The number of frames in a single message MUST be less than or
     //# equal to "2^32 - 1".
     && 0 <= |regularFrames| < ENDFRAME_SEQUENCE_NUMBER as nat
-    // The sequence number MUST be monotonic
-    //
-    //= compliance/data-format/message-body.txt#2.5.2.1.1
-    //= type=implication
-    //# Framed Data MUST start at Sequence Number 1.
-    //
-    //= compliance/data-format/message-body.txt#2.5.2.1.1
-    //= type=implication
-    //# Subsequent frames MUST be in order and MUST contain an increment of 1
-    //# from the previous frame.
+       // The sequence number MUST be monotonic
+       //
+       //= compliance/data-format/message-body.txt#2.5.2.1.1
+       //= type=implication
+       //# Framed Data MUST start at Sequence Number 1.
+       //
+       //= compliance/data-format/message-body.txt#2.5.2.1.1
+       //= type=implication
+       //# Subsequent frames MUST be in order and MUST contain an increment of 1
+       //# from the previous frame.
     && MessageFramesAreMonotonic(regularFrames)
-    // All frames MUST all be from the same messages i.e. the same header
+       // All frames MUST all be from the same messages i.e. the same header
     && MessageFramesAreForTheSameMessage(regularFrames)
   }
 
   type NonFramedMessage = Frames.NonFramed
 
   datatype FramedMessageBody = FramedMessageBody(
-    regularFrames: MessageRegularFrames,
-    //= compliance/data-format/message-body.txt#2.5.2.2
-    //= type=implication
-    //# Framed data MUST contain exactly one final frame.
-    finalFrame: Frames.FinalFrame
-  )
+                                 regularFrames: MessageRegularFrames,
+                                 //= compliance/data-format/message-body.txt#2.5.2.2
+                                 //= type=implication
+                                 //# Framed data MUST contain exactly one final frame.
+                                 finalFrame: Frames.FinalFrame
+                               )
 
   type FramedMessage = body: FramedMessageBody
-  |
-  //= compliance/data-format/message-body.txt#2.5.2.2.2
-  //= type=implication
-  //# The Final Frame Sequence number MUST be equal to the total number of
-  //# frames in the Framed Data.
-  && MessageFramesAreMonotonic(body.regularFrames + [body.finalFrame])
-  && MessageFramesAreForTheSameMessage(body.regularFrames + [body.finalFrame])
-  witness *
+    |
+      //= compliance/data-format/message-body.txt#2.5.2.2.2
+      //= type=implication
+      //# The Final Frame Sequence number MUST be equal to the total number of
+      //# frames in the Framed Data.
+      && MessageFramesAreMonotonic(body.regularFrames + [body.finalFrame])
+      && MessageFramesAreForTheSameMessage(body.regularFrames + [body.finalFrame])
+    witness *
 
   type MessageFrame = frame: Frames.Frame
-  |
-  || Frames.IsFinalFrame(frame)
-  || Frames.IsRegularFrame(frame)
-  witness *
+    |
+      || Frames.IsFinalFrame(frame)
+      || Frames.IsRegularFrame(frame)
+    witness *
 
   type Frame = frame: Frames.Frame
-  |
-  || Frames.IsFinalFrame(frame)
-  || Frames.IsRegularFrame(frame)
-  || Frames.IsNonFramed(frame)
-  witness *
+    |
+      || Frames.IsFinalFrame(frame)
+      || Frames.IsRegularFrame(frame)
+      || Frames.IsNonFramed(frame)
+    witness *
 
   lemma LemmaAddingNextRegularFrame(
     regularFrames: MessageRegularFrames,
@@ -230,12 +230,12 @@ module MessageBody {
     requires 0 < header.body.frameLength as nat < UINT32_LIMIT
     requires header.body.contentType.Framed?
     ensures match result
-      case Failure(e) => true
-      case Success(body) =>
-        && (forall frame: Frames.Frame
-          | frame in body.regularFrames
-          :: AESEncryption.EncryptedWithKey(frame.encContent, key))
-        && AESEncryption.EncryptedWithKey(body.finalFrame.encContent, key)
+            case Failure(e) => true
+            case Success(body) =>
+              && (forall frame: Frames.Frame
+                    | frame in body.regularFrames
+                  :: AESEncryption.EncryptedWithKey(frame.encContent, key))
+              && AESEncryption.EncryptedWithKey(body.finalFrame.encContent, key)
   {
     var n : int, sequenceNumber := 0, START_SEQUENCE_NUMBER;
     var regularFrames: MessageRegularFrames := [];
@@ -260,10 +260,10 @@ module MessageBody {
       invariant START_SEQUENCE_NUMBER <= sequenceNumber <= ENDFRAME_SEQUENCE_NUMBER
       invariant |regularFrames| == (sequenceNumber - START_SEQUENCE_NUMBER) as nat
       invariant forall frame: Frames.Frame
-      | frame in regularFrames
-      ::
-        && AESEncryption.EncryptedWithKey(frame.encContent, key)
-        && frame.header == header
+                  | frame in regularFrames
+                ::
+                  && AESEncryption.EncryptedWithKey(frame.encContent, key)
+                  && frame.header == header
     {
       :- Need(sequenceNumber < ENDFRAME_SEQUENCE_NUMBER, "too many frames");
       var plaintextFrame := plaintext[n..n + header.body.frameLength as nat];
@@ -275,11 +275,11 @@ module MessageBody {
       //# a regular frame (Section 2.7.1) using the consumable plaintext
       //# bytes.
       var regularFrame :- EncryptRegularFrame(
-        key,
-        header,
-        plaintextFrame,
-        sequenceNumber
-      );
+                            key,
+                            header,
+                            plaintextFrame,
+                            sequenceNumber
+                          );
 
       assert regularFrame.seqNum as nat == |regularFrames| + 1;
       LemmaAddingNextRegularFrame(regularFrames, regularFrame);
@@ -317,18 +317,18 @@ module MessageBody {
     //# Frame encrypted content length SHOULD be equal to the frame length
     //# but MAY be 0.
     var finalFrame :- EncryptFinalFrame(
-      key,
-      header,
-      plaintext[n..],
-      sequenceNumber
-    );
+                        key,
+                        header,
+                        plaintext[n..],
+                        sequenceNumber
+                      );
 
     assert MessageFramesAreForTheSameMessage(regularFrames + [finalFrame]);
 
     return Success(FramedMessageBody(
-      regularFrames := regularFrames,
-      finalFrame := finalFrame
-    ));
+                     regularFrames := regularFrames,
+                     finalFrame := finalFrame
+                   ));
   }
 
   method EncryptRegularFrame(
@@ -349,12 +349,12 @@ module MessageBody {
     //# MUST equal the frame length.
     requires |plaintext| == header.body.frameLength as nat && sequenceNumber != ENDFRAME_SEQUENCE_NUMBER
     ensures match res
-      case Failure(e) => true
-      case Success(frame) =>
-        && AESEncryption.CiphertextGeneratedWithPlaintext(frame.encContent, plaintext)
-        && AESEncryption.EncryptedWithKey(frame.encContent, key)
-        && frame.seqNum == sequenceNumber
-        && frame.header == header
+            case Failure(e) => true
+            case Success(frame) =>
+              && AESEncryption.CiphertextGeneratedWithPlaintext(frame.encContent, plaintext)
+              && AESEncryption.EncryptedWithKey(frame.encContent, key)
+              && frame.seqNum == sequenceNumber
+              && frame.header == header
   {
     //= compliance/client-apis/encrypt.txt#2.7.1
     //# To construct a regular or final frame that represents the next frame
@@ -370,50 +370,50 @@ module MessageBody {
     // *  The AAD is the serialized message body AAD (../data-format/
     //    message-body-aad.md), constructed as follows:
     var aad := BodyAAD(
-      // -  The message ID (../data-format/message-body-aad.md#message-id)
-      //    is the same as the message ID (../data-frame/message-
-      //    header.md#message-id) serialized in the header of this message.
-      header.body.messageId,
-      AADRegularFrame,
-      sequenceNumber,
-      //= compliance/client-apis/encrypt.txt#2.7.1
-      //# -  The content length (../data-format/message-body-aad.md#content-
-      //# length) MUST have a value equal to the length of the plaintext
-      //# being encrypted.
-      |plaintext| as uint64
-    );
+                 // -  The message ID (../data-format/message-body-aad.md#message-id)
+                 //    is the same as the message ID (../data-frame/message-
+                 //    header.md#message-id) serialized in the header of this message.
+                 header.body.messageId,
+                 AADRegularFrame,
+                 sequenceNumber,
+                 //= compliance/client-apis/encrypt.txt#2.7.1
+                 //# -  The content length (../data-format/message-body-aad.md#content-
+                 //# length) MUST have a value equal to the length of the plaintext
+                 //# being encrypted.
+                 |plaintext| as uint64
+               );
 
     var encryptionOutput :- AESEncryption.AESEncrypt(
-      header.suite.encrypt,
-      iv,
-      key,
-      plaintext,
-      aad
-    );
+                              header.suite.encrypt,
+                              iv,
+                              key,
+                              plaintext,
+                              aad
+                            );
 
     //= compliance/client-apis/encrypt.txt#2.7.1
     //# This operation MUST serialize a regular frame or final frame with the
     //# following specifics:
     var frame: Frames.RegularFrame := Frames.Frame.RegularFrame(
-      header,
-      //= compliance/client-apis/encrypt.txt#2.7.1
-      //# *  Sequence Number (../data-format/message-body.md#sequence-number):
-      //# MUST be the sequence number of this frame, as determined above.
-      sequenceNumber,
-      //= compliance/client-apis/encrypt.txt#2.7.1
-      //# *  IV (../data-format/message-body.md#iv): MUST be the IV used when
-      //# calculating the encrypted content above
-      iv,
-      //= compliance/client-apis/encrypt.txt#2.7.1
-      //# *  Encrypted Content (../data-format/message-body.md#encrypted-
-      //# content): MUST be the encrypted content calculated above.
-      encryptionOutput.cipherText,
-      //= compliance/client-apis/encrypt.txt#2.7.1
-      //# *  Authentication Tag (../data-format/message-body.md#authentication-
-      //# tag): MUST be the authentication tag output when calculating the
-      //# encrypted content above.
-      encryptionOutput.authTag
-    );
+                                        header,
+                                        //= compliance/client-apis/encrypt.txt#2.7.1
+                                        //# *  Sequence Number (../data-format/message-body.md#sequence-number):
+                                        //# MUST be the sequence number of this frame, as determined above.
+                                        sequenceNumber,
+                                        //= compliance/client-apis/encrypt.txt#2.7.1
+                                        //# *  IV (../data-format/message-body.md#iv): MUST be the IV used when
+                                        //# calculating the encrypted content above
+                                        iv,
+                                        //= compliance/client-apis/encrypt.txt#2.7.1
+                                        //# *  Encrypted Content (../data-format/message-body.md#encrypted-
+                                        //# content): MUST be the encrypted content calculated above.
+                                        encryptionOutput.cipherText,
+                                        //= compliance/client-apis/encrypt.txt#2.7.1
+                                        //# *  Authentication Tag (../data-format/message-body.md#authentication-
+                                        //# tag): MUST be the authentication tag output when calculating the
+                                        //# encrypted content above.
+                                        encryptionOutput.authTag
+                                      );
 
     return Success(frame);
   }
@@ -442,42 +442,42 @@ module MessageBody {
     //# Length (message-header.md#frame-length).
     requires |plaintext| <= header.body.frameLength as nat
     ensures match res
-      case Failure(e) => true
-      case Success(frame) =>
-        && AESEncryption.CiphertextGeneratedWithPlaintext(frame.encContent, plaintext)
-        && AESEncryption.EncryptedWithKey(frame.encContent, key)
-        && frame.seqNum == sequenceNumber
-        && frame.header == header
+            case Failure(e) => true
+            case Success(frame) =>
+              && AESEncryption.CiphertextGeneratedWithPlaintext(frame.encContent, plaintext)
+              && AESEncryption.EncryptedWithKey(frame.encContent, key)
+              && frame.seqNum == sequenceNumber
+              && frame.header == header
   {
 
     var iv := IVSeq(header.suite, sequenceNumber);
 
     var aad := BodyAAD(
-      header.body.messageId,
-      AADFinalFrame,
-      sequenceNumber,
-      //= compliance/client-apis/encrypt.txt#2.7.1
-      //# o  For a final frame this MUST be the length of the remaining
-      //# plaintext bytes which have not yet been encrypted, whose
-      //# length MUST be equal to or less than the frame length.
-      |plaintext| as uint64
-    );
+                 header.body.messageId,
+                 AADFinalFrame,
+                 sequenceNumber,
+                 //= compliance/client-apis/encrypt.txt#2.7.1
+                 //# o  For a final frame this MUST be the length of the remaining
+                 //# plaintext bytes which have not yet been encrypted, whose
+                 //# length MUST be equal to or less than the frame length.
+                 |plaintext| as uint64
+               );
 
     var encryptionOutput :- AESEncryption.AESEncrypt(
-      header.suite.encrypt,
-      iv,
-      key,
-      plaintext,
-      aad
-    );
+                              header.suite.encrypt,
+                              iv,
+                              key,
+                              plaintext,
+                              aad
+                            );
 
     var finalFrame: Frames.FinalFrame := Frames.Frame.FinalFrame(
-      header,
-      sequenceNumber,
-      iv,
-      encryptionOutput.cipherText,
-      encryptionOutput.authTag
-    );
+                                           header,
+                                           sequenceNumber,
+                                           iv,
+                                           encryptionOutput.cipherText,
+                                           encryptionOutput.authTag
+                                         );
 
     return Success(finalFrame);
   }
@@ -489,10 +489,10 @@ module MessageBody {
     returns (res: Result<seq<uint8>, string>)
     requires |key| == body.finalFrame.header.suite.encrypt.keyLength as int
     ensures match res
-      case Failure(_) => true
-      case Success(plaintext) => //Exists a sequence of frames which encrypts the plaintext and is serialized in the read section of the stream
-        && FramesEncryptPlaintext(body, plaintext)
-        && DecryptedWithKey(key, plaintext)
+            case Failure(_) => true
+            case Success(plaintext) => //Exists a sequence of frames which encrypts the plaintext and is serialized in the read section of the stream
+              && FramesEncryptPlaintext(body, plaintext)
+              && DecryptedWithKey(key, plaintext)
   {
     var plaintext := [];
     // var n: uint32 := 1;
@@ -537,15 +537,15 @@ module MessageBody {
     returns (res: Result<seq<uint8>, string>)
     requires |key| == frame.header.suite.encrypt.keyLength as int
     ensures match res
-      case Success(plaintextSegment) => ( // Decrypting the frame encoded in the stream is the returned ghost frame
-        && AESEncryption.CiphertextGeneratedWithPlaintext(frame.encContent, plaintextSegment)
-        && AESEncryption.DecryptedWithKey(key, plaintextSegment)
-        && (frame.RegularFrame? || frame.FinalFrame? ==> |plaintextSegment| < UINT32_LIMIT)
-      )
-      case Failure(_) => true
+            case Success(plaintextSegment) => ( // Decrypting the frame encoded in the stream is the returned ghost frame
+              && AESEncryption.CiphertextGeneratedWithPlaintext(frame.encContent, plaintextSegment)
+              && AESEncryption.DecryptedWithKey(key, plaintextSegment)
+              && (frame.RegularFrame? || frame.FinalFrame? ==> |plaintextSegment| < UINT32_LIMIT)
+            )
+            case Failure(_) => true
   {
     var aad := BodyAADByFrameType(frame);
-    
+
     //= compliance/client-apis/decrypt.txt#2.7.4
     //# If this decryption fails, this operation MUST immediately halt and
     //# fail.
@@ -596,76 +596,76 @@ module MessageBody {
     returns (aad: seq<uint8>)
   {
     var (sequenceNumber, bc, length) := match frame
-      case RegularFrame(header,seqNum,_,_,_) => (
-        //= compliance/data-format/message-body-aad.txt#2.4.3
-        //# For framed data (message-body.md#framed-data), the value of this
-        //# field MUST be the frame sequence number (message-body.md#sequence-
-        //# number).
-        seqNum,
+                                        case RegularFrame(header,seqNum,_,_,_) => (
+                                        //= compliance/data-format/message-body-aad.txt#2.4.3
+                                        //# For framed data (message-body.md#framed-data), the value of this
+                                        //# field MUST be the frame sequence number (message-body.md#sequence-
+                                        //# number).
+                                        seqNum,
 
-        //= compliance/data-format/message-body-aad.txt#2.4.2
-        //# *  The regular frames (message-body.md#regular-frame) in framed data
-        //# (message-body.md#framed-data) MUST use the value
-        //# "AWSKMSEncryptionClient Frame".
-        AADRegularFrame,
+                                        //= compliance/data-format/message-body-aad.txt#2.4.2
+                                        //# *  The regular frames (message-body.md#regular-frame) in framed data
+                                        //# (message-body.md#framed-data) MUST use the value
+                                        //# "AWSKMSEncryptionClient Frame".
+                                        AADRegularFrame,
 
-        //= compliance/data-format/message-body-aad.txt#2.4.4
-        //# *  For framed data (message-body.md#framed-data), this value MUST
-        //# equal the length, in bytes, of the plaintext being encrypted in
-        //# this frame.
+                                        //= compliance/data-format/message-body-aad.txt#2.4.4
+                                        //# *  For framed data (message-body.md#framed-data), this value MUST
+                                        //# equal the length, in bytes, of the plaintext being encrypted in
+                                        //# this frame.
 
-        //= compliance/data-format/message-body-aad.txt#2.4.4
-        //# -  For regular frames (message-body.md#regular-frame), this value
-        //# MUST equal the value of the frame length (message-
-        //# header.md#frame-length) field in the message header.
-        header.body.frameLength as uint64
-      )
-      case FinalFrame(_,seqNum,_, encContent,_) => (
-        //= compliance/data-format/message-body-aad.txt#2.4.3
-        //# For framed data (message-body.md#framed-data), the value of this
-        //# field MUST be the frame sequence number (message-body.md#sequence-
-        //# number).
-        seqNum,
+                                        //= compliance/data-format/message-body-aad.txt#2.4.4
+                                        //# -  For regular frames (message-body.md#regular-frame), this value
+                                        //# MUST equal the value of the frame length (message-
+                                        //# header.md#frame-length) field in the message header.
+                                        header.body.frameLength as uint64
+                                        )
+                                        case FinalFrame(_,seqNum,_, encContent,_) => (
+                                        //= compliance/data-format/message-body-aad.txt#2.4.3
+                                        //# For framed data (message-body.md#framed-data), the value of this
+                                        //# field MUST be the frame sequence number (message-body.md#sequence-
+                                        //# number).
+                                        seqNum,
 
-        //= compliance/data-format/message-body-aad.txt#2.4.2
-        //# *  The final frame (message-body.md#final-frame) in framed data
-        //# (message-body.md#framed-data) MUST use the value
-        //# "AWSKMSEncryptionClient Final Frame".
-        AADFinalFrame,
+                                        //= compliance/data-format/message-body-aad.txt#2.4.2
+                                        //# *  The final frame (message-body.md#final-frame) in framed data
+                                        //# (message-body.md#framed-data) MUST use the value
+                                        //# "AWSKMSEncryptionClient Final Frame".
+                                        AADFinalFrame,
 
-        //= compliance/data-format/message-body-aad.txt#2.4.4
-        //# *  For framed data (message-body.md#framed-data), this value MUST
-        //# equal the length, in bytes, of the plaintext being encrypted in
-        //# this frame.
+                                        //= compliance/data-format/message-body-aad.txt#2.4.4
+                                        //# *  For framed data (message-body.md#framed-data), this value MUST
+                                        //# equal the length, in bytes, of the plaintext being encrypted in
+                                        //# this frame.
 
-        //= compliance/data-format/message-body-aad.txt#2.4.4
-        //# -  For the final frame (message-body.md#final-frame), this value
-        //# MUST be greater than or equal to 0 and less than or equal to
-        //# the value of the frame length (message-header.md#frame-length)
-        //# field in the message header.
-        |encContent| as uint64
-      )
-      case NonFramed(_,_,encContent,_) => (
-        //= compliance/client-apis/decrypt.txt#2.7.4
-        //# If this is un-framed data,
-        //# this value MUST be 1.
+                                        //= compliance/data-format/message-body-aad.txt#2.4.4
+                                        //# -  For the final frame (message-body.md#final-frame), this value
+                                        //# MUST be greater than or equal to 0 and less than or equal to
+                                        //# the value of the frame length (message-header.md#frame-length)
+                                        //# field in the message header.
+                                        |encContent| as uint64
+                                        )
+                                        case NonFramed(_,_,encContent,_) => (
+                                        //= compliance/client-apis/decrypt.txt#2.7.4
+                                        //# If this is un-framed data,
+                                        //# this value MUST be 1.
 
-        //= compliance/data-format/message-body-aad.txt#2.4.3
-        //# For non-framed data (message-body.md#non-framed-data), the
-        //# value of this field MUST be "1".
-        NONFRAMED_SEQUENCE_NUMBER,
-        
-        //= compliance/data-format/message-body-aad.txt#2.4.2
-        //# *  Non-framed data (message-body.md#non-framed-data) MUST use the
-        //# value "AWSKMSEncryptionClient Single Block".
-        AADSingleBlock,
+                                        //= compliance/data-format/message-body-aad.txt#2.4.3
+                                        //# For non-framed data (message-body.md#non-framed-data), the
+                                        //# value of this field MUST be "1".
+                                        NONFRAMED_SEQUENCE_NUMBER,
 
-        //= compliance/data-format/message-body-aad.txt#2.4.4
-        //# *  For non-framed data (message-body.md#non-framed-data), this value
-        //# MUST equal the length, in bytes, of the plaintext data provided to
-        //# the algorithm for encryption.
-        |encContent| as uint64
-      );
+                                        //= compliance/data-format/message-body-aad.txt#2.4.2
+                                        //# *  Non-framed data (message-body.md#non-framed-data) MUST use the
+                                        //# value "AWSKMSEncryptionClient Single Block".
+                                        AADSingleBlock,
+
+                                        //= compliance/data-format/message-body-aad.txt#2.4.4
+                                        //# *  For non-framed data (message-body.md#non-framed-data), this value
+                                        //# MUST equal the length, in bytes, of the plaintext data provided to
+                                        //# the algorithm for encryption.
+                                        |encContent| as uint64
+                                        );
 
     aad := BodyAAD(frame.header.body.messageId, bc, sequenceNumber, length);
   }
@@ -692,28 +692,28 @@ module MessageBody {
       + contentAAD.value
       //# -  The sequence number (../data-format/message-body-
       //#    aad.md#sequence-number) is the sequence number deserialized
-      //#    from the frame being decrypted. 
+      //#    from the frame being decrypted.
       + UInt32ToSeq(sequenceNumber)
       //= compliance/client-apis/decrypt.txt#2.7.4
       //# -  The content length (../data-format/message-body-aad.md#content-
       //# length) MUST have a value equal to the length of the plaintext
       //# that was encrypted.
       + UInt64ToSeq(length)
-    ;
+      ;
   }
 
   predicate DecryptedWithKey(key: seq<uint8>, plaintext: seq<uint8>)
   {
     if AESEncryption.DecryptedWithKey(key, plaintext) then true else
-      exists plaintextSeg | SumPlaintextSegments(plaintextSeg) == plaintext ::
-        DecryptedSegmentsWithKey(key, plaintextSeg)
+    exists plaintextSeg | SumPlaintextSegments(plaintextSeg) == plaintext ::
+      DecryptedSegmentsWithKey(key, plaintextSeg)
   }
 
   predicate DecryptedSegmentsWithKey(key: seq<uint8>, plaintextSeg: seq<seq<uint8>>)
   {
     if plaintextSeg == [] then true else
-      && DecryptedSegmentsWithKey(key, plaintextSeg[..|plaintextSeg| - 1])
-      && AESEncryption.DecryptedWithKey(key, plaintextSeg[|plaintextSeg| - 1])
+    && DecryptedSegmentsWithKey(key, plaintextSeg[..|plaintextSeg| - 1])
+    && AESEncryption.DecryptedWithKey(key, plaintextSeg[|plaintextSeg| - 1])
   }
 
   function method WriteFramedMessageBody(
@@ -725,7 +725,7 @@ module MessageBody {
     //# The final frame
     //# MUST be the last frame.
     ensures ret == WriteMessageRegularFrames(body.regularFrames)
-      + Frames.WriteFinalFrame(body.finalFrame)
+                   + Frames.WriteFinalFrame(body.finalFrame)
   {
     WriteMessageRegularFrames(body.regularFrames) + Frames.WriteFinalFrame(body.finalFrame)
   }
@@ -735,10 +735,10 @@ module MessageBody {
   )
     :(ret: seq<uint8>)
     ensures if |frames| == 0 then
-      ret == []
-    else
-      ret == WriteMessageRegularFrames(Seq.DropLast(frames))
-      + Frames.WriteRegularFrame(Seq.Last(frames))
+              ret == []
+            else
+              ret == WriteMessageRegularFrames(Seq.DropLast(frames))
+              + Frames.WriteRegularFrame(Seq.Last(frames))
   {
     if |frames| == 0 then []
     else
@@ -754,15 +754,15 @@ module MessageBody {
   )
     :(res: ReadCorrect<FramedMessage>)
     requires forall frame: Frames.Frame
-    | frame in regularFrames
-    :: frame.header == header
+               | frame in regularFrames
+             :: frame.header == header
     requires CorrectlyReadRange(buffer, continuation)
     requires CorrectlyRead(buffer, Success(SuccessfulRead(regularFrames, continuation)), WriteMessageRegularFrames)
     decreases ENDFRAME_SEQUENCE_NUMBER as nat - |regularFrames|
     ensures CorrectlyRead(buffer, res, WriteFramedMessageBody)
     ensures res.Success?
-    ==>
-      && res.value.data.finalFrame.header == header
+            ==>
+              && res.value.data.finalFrame.header == header
   {
     var sequenceNumber :- ReadUInt32(continuation);
 
@@ -773,7 +773,7 @@ module MessageBody {
     //# (../data-format/message-body.md#final-frame) or regular frame
     //# (../fata-format/message-body/md#regular-frame).
     if (sequenceNumber.data != ENDFRAME_SEQUENCE_NUMBER) then
-    
+
       assert {:split_here} true;
 
       //= compliance/client-apis/decrypt.txt#2.7.4
@@ -830,22 +830,22 @@ module MessageBody {
       //# number-end) and the following bytes according to the final frame spec
       //# (../data-format/message-body.md#final-frame).
       assert sequenceNumber.data == ENDFRAME_SEQUENCE_NUMBER;
-      
+
       assert {:split_here} true;
       var finalFrame :- Frames.ReadFinalFrame(continuation, header);
       :- Need(
-        finalFrame.data.seqNum as nat == |regularFrames| + 1,
-        Error("Sequence number out of order.")
-      );
+           finalFrame.data.seqNum as nat == |regularFrames| + 1,
+           Error("Sequence number out of order.")
+         );
 
       assert {:split_here} true;
       assert MessageFramesAreMonotonic(regularFrames + [finalFrame.data]);
       assert MessageFramesAreForTheSameMessage(regularFrames + [finalFrame.data]);
 
       var body: FramedMessage := FramedMessageBody(
-        regularFrames := regularFrames,
-        finalFrame := finalFrame.data
-      );
+                                   regularFrames := regularFrames,
+                                   finalFrame := finalFrame.data
+                                 );
 
       assert {:split_here} true;
       assert CorrectlyRead(continuation, Success(finalFrame), Frames.WriteFinalFrame);
@@ -873,8 +873,8 @@ module MessageBody {
     :(res: ReadCorrect<NonFramedMessage>)
     ensures CorrectlyRead(buffer, res, WriteNonFramedMessageBody)
     ensures res.Success?
-    ==>
-      && res.value.data.header == header
+            ==>
+              && res.value.data.header == header
   {
     var block :- Frames.ReadNonFrame(buffer, header);
     Success(SuccessfulRead(block.data, block.tail))

--- a/src/SDK/MessageBody.dfy
+++ b/src/SDK/MessageBody.dfy
@@ -180,12 +180,12 @@ module MessageBody {
   type NonFramedMessage = Frames.NonFramed
 
   datatype FramedMessageBody = FramedMessageBody(
-                                 regularFrames: MessageRegularFrames,
-                                 //= compliance/data-format/message-body.txt#2.5.2.2
-                                 //= type=implication
-                                 //# Framed data MUST contain exactly one final frame.
-                                 finalFrame: Frames.FinalFrame
-                               )
+    regularFrames: MessageRegularFrames,
+    //= compliance/data-format/message-body.txt#2.5.2.2
+    //= type=implication
+    //# Framed data MUST contain exactly one final frame.
+    finalFrame: Frames.FinalFrame
+  )
 
   type FramedMessage = body: FramedMessageBody
     |

--- a/src/SDK/MessageBody.dfy
+++ b/src/SDK/MessageBody.dfy
@@ -596,76 +596,76 @@ module MessageBody {
     returns (aad: seq<uint8>)
   {
     var (sequenceNumber, bc, length) := match frame
-                                        case RegularFrame(header,seqNum,_,_,_) => (
-                                        //= compliance/data-format/message-body-aad.txt#2.4.3
-                                        //# For framed data (message-body.md#framed-data), the value of this
-                                        //# field MUST be the frame sequence number (message-body.md#sequence-
-                                        //# number).
-                                        seqNum,
+      case RegularFrame(header,seqNum,_,_,_) => (
+      //= compliance/data-format/message-body-aad.txt#2.4.3
+      //# For framed data (message-body.md#framed-data), the value of this
+      //# field MUST be the frame sequence number (message-body.md#sequence-
+      //# number).
+      seqNum,
 
-                                        //= compliance/data-format/message-body-aad.txt#2.4.2
-                                        //# *  The regular frames (message-body.md#regular-frame) in framed data
-                                        //# (message-body.md#framed-data) MUST use the value
-                                        //# "AWSKMSEncryptionClient Frame".
-                                        AADRegularFrame,
+      //= compliance/data-format/message-body-aad.txt#2.4.2
+      //# *  The regular frames (message-body.md#regular-frame) in framed data
+      //# (message-body.md#framed-data) MUST use the value
+      //# "AWSKMSEncryptionClient Frame".
+      AADRegularFrame,
 
-                                        //= compliance/data-format/message-body-aad.txt#2.4.4
-                                        //# *  For framed data (message-body.md#framed-data), this value MUST
-                                        //# equal the length, in bytes, of the plaintext being encrypted in
-                                        //# this frame.
+      //= compliance/data-format/message-body-aad.txt#2.4.4
+      //# *  For framed data (message-body.md#framed-data), this value MUST
+      //# equal the length, in bytes, of the plaintext being encrypted in
+      //# this frame.
 
-                                        //= compliance/data-format/message-body-aad.txt#2.4.4
-                                        //# -  For regular frames (message-body.md#regular-frame), this value
-                                        //# MUST equal the value of the frame length (message-
-                                        //# header.md#frame-length) field in the message header.
-                                        header.body.frameLength as uint64
-                                        )
-                                        case FinalFrame(_,seqNum,_, encContent,_) => (
-                                        //= compliance/data-format/message-body-aad.txt#2.4.3
-                                        //# For framed data (message-body.md#framed-data), the value of this
-                                        //# field MUST be the frame sequence number (message-body.md#sequence-
-                                        //# number).
-                                        seqNum,
+      //= compliance/data-format/message-body-aad.txt#2.4.4
+      //# -  For regular frames (message-body.md#regular-frame), this value
+      //# MUST equal the value of the frame length (message-
+      //# header.md#frame-length) field in the message header.
+      header.body.frameLength as uint64
+      )
+      case FinalFrame(_,seqNum,_, encContent,_) => (
+      //= compliance/data-format/message-body-aad.txt#2.4.3
+      //# For framed data (message-body.md#framed-data), the value of this
+      //# field MUST be the frame sequence number (message-body.md#sequence-
+      //# number).
+      seqNum,
 
-                                        //= compliance/data-format/message-body-aad.txt#2.4.2
-                                        //# *  The final frame (message-body.md#final-frame) in framed data
-                                        //# (message-body.md#framed-data) MUST use the value
-                                        //# "AWSKMSEncryptionClient Final Frame".
-                                        AADFinalFrame,
+      //= compliance/data-format/message-body-aad.txt#2.4.2
+      //# *  The final frame (message-body.md#final-frame) in framed data
+      //# (message-body.md#framed-data) MUST use the value
+      //# "AWSKMSEncryptionClient Final Frame".
+      AADFinalFrame,
 
-                                        //= compliance/data-format/message-body-aad.txt#2.4.4
-                                        //# *  For framed data (message-body.md#framed-data), this value MUST
-                                        //# equal the length, in bytes, of the plaintext being encrypted in
-                                        //# this frame.
+      //= compliance/data-format/message-body-aad.txt#2.4.4
+      //# *  For framed data (message-body.md#framed-data), this value MUST
+      //# equal the length, in bytes, of the plaintext being encrypted in
+      //# this frame.
 
-                                        //= compliance/data-format/message-body-aad.txt#2.4.4
-                                        //# -  For the final frame (message-body.md#final-frame), this value
-                                        //# MUST be greater than or equal to 0 and less than or equal to
-                                        //# the value of the frame length (message-header.md#frame-length)
-                                        //# field in the message header.
-                                        |encContent| as uint64
-                                        )
-                                        case NonFramed(_,_,encContent,_) => (
-                                        //= compliance/client-apis/decrypt.txt#2.7.4
-                                        //# If this is un-framed data,
-                                        //# this value MUST be 1.
+      //= compliance/data-format/message-body-aad.txt#2.4.4
+      //# -  For the final frame (message-body.md#final-frame), this value
+      //# MUST be greater than or equal to 0 and less than or equal to
+      //# the value of the frame length (message-header.md#frame-length)
+      //# field in the message header.
+      |encContent| as uint64
+      )
+      case NonFramed(_,_,encContent,_) => (
+      //= compliance/client-apis/decrypt.txt#2.7.4
+      //# If this is un-framed data,
+      //# this value MUST be 1.
 
-                                        //= compliance/data-format/message-body-aad.txt#2.4.3
-                                        //# For non-framed data (message-body.md#non-framed-data), the
-                                        //# value of this field MUST be "1".
-                                        NONFRAMED_SEQUENCE_NUMBER,
+      //= compliance/data-format/message-body-aad.txt#2.4.3
+      //# For non-framed data (message-body.md#non-framed-data), the
+      //# value of this field MUST be "1".
+      NONFRAMED_SEQUENCE_NUMBER,
 
-                                        //= compliance/data-format/message-body-aad.txt#2.4.2
-                                        //# *  Non-framed data (message-body.md#non-framed-data) MUST use the
-                                        //# value "AWSKMSEncryptionClient Single Block".
-                                        AADSingleBlock,
+      //= compliance/data-format/message-body-aad.txt#2.4.2
+      //# *  Non-framed data (message-body.md#non-framed-data) MUST use the
+      //# value "AWSKMSEncryptionClient Single Block".
+      AADSingleBlock,
 
-                                        //= compliance/data-format/message-body-aad.txt#2.4.4
-                                        //# *  For non-framed data (message-body.md#non-framed-data), this value
-                                        //# MUST equal the length, in bytes, of the plaintext data provided to
-                                        //# the algorithm for encryption.
-                                        |encContent| as uint64
-                                        );
+      //= compliance/data-format/message-body-aad.txt#2.4.4
+      //# *  For non-framed data (message-body.md#non-framed-data), this value
+      //# MUST equal the length, in bytes, of the plaintext data provided to
+      //# the algorithm for encryption.
+      |encContent| as uint64
+      );
 
     aad := BodyAAD(frame.header.body.messageId, bc, sequenceNumber, length);
   }

--- a/src/SDK/Serialize/EncryptedDataKeys.dfy
+++ b/src/SDK/Serialize/EncryptedDataKeys.dfy
@@ -60,9 +60,9 @@ module EncryptedDataKeys {
     var SuccessfulRead(providerInfo, providerInfoPos) :- ReadShortLengthSeq(providerIdPos);
     var SuccessfulRead(cipherText, tail) :- ReadShortLengthSeq(providerInfoPos);
     var edk: ESDKEncryptedDataKey := Crypto.EncryptedDataKey(
-                                       keyProviderId := providerId,
-                                       keyProviderInfo := providerInfo,
-                                       ciphertext := cipherText);
+      keyProviderId := providerId,
+      keyProviderInfo := providerInfo,
+      ciphertext := cipherText);
 
     Success(SuccessfulRead(edk, tail))
   }
@@ -235,10 +235,10 @@ module EncryptedDataKeys {
       // are valid WriteEncryptedDataKey bytes,
       // we can prove that this part is complete
       var edk := ReadEncryptedDataKeyIsComplete(
-                   data[|accumulator|],
-                   WriteEncryptedDataKey(data[|accumulator|]),
-                   nextEdkStart
-                 );
+        data[|accumulator|],
+        WriteEncryptedDataKey(data[|accumulator|]),
+        nextEdkStart
+      );
 
       assert edk.data == data[|accumulator|];
 
@@ -247,11 +247,11 @@ module EncryptedDataKeys {
       // Along the way, we prove ReadEncryptedDataKeyIsComplete
       // for each encrypted data key "along the way".
       var edks := ReadEncryptedDataKeysIsComplete(
-                    data,
-                    nextAccumulator,
-                    bytes,
-                    buffer
-                  );
+        data,
+        nextAccumulator,
+        bytes,
+        buffer
+      );
 
       assert edks.data == data;
       assert edks.tail.start == buffer.start + |WriteEncryptedDataKeys(data)|;
@@ -283,10 +283,10 @@ module EncryptedDataKeys {
     assert bytes[|WriteUint16(|data| as uint16)|..] == WriteEncryptedDataKeys(data);
 
     var count := ReadUInt16IsComplete(
-                   |data| as uint16,
-                   WriteUint16(|data| as uint16),
-                   buffer
-                 );
+      |data| as uint16,
+      WriteUint16(|data| as uint16),
+      buffer
+    );
     assert count.data == |data| as uint16;
 
     var edks := ReadEncryptedDataKeysIsComplete(data, [], WriteEncryptedDataKeys(data), count.tail);

--- a/src/SDK/Serialize/EncryptedDataKeys.dfy
+++ b/src/SDK/Serialize/EncryptedDataKeys.dfy
@@ -60,9 +60,9 @@ module EncryptedDataKeys {
     var SuccessfulRead(providerInfo, providerInfoPos) :- ReadShortLengthSeq(providerIdPos);
     var SuccessfulRead(cipherText, tail) :- ReadShortLengthSeq(providerInfoPos);
     var edk: ESDKEncryptedDataKey := Crypto.EncryptedDataKey(
-        keyProviderId := providerId,
-        keyProviderInfo := providerInfo,
-        ciphertext := cipherText);
+                                       keyProviderId := providerId,
+                                       keyProviderInfo := providerInfo,
+                                       ciphertext := cipherText);
 
     Success(SuccessfulRead(edk, tail))
   }
@@ -133,9 +133,9 @@ module EncryptedDataKeys {
       && Success(ret) == ReadEncryptedDataKey(buffer)
   {
     assert bytes
-    == WriteShortLengthSeq(data.keyProviderId)
-    + WriteShortLengthSeq(data.keyProviderInfo)
-    + WriteShortLengthSeq(data.ciphertext);
+        == WriteShortLengthSeq(data.keyProviderId)
+           + WriteShortLengthSeq(data.keyProviderInfo)
+           + WriteShortLengthSeq(data.ciphertext);
 
     assert WriteShortLengthSeq(data.keyProviderId) <= bytes;
     assert WriteShortLengthSeq(data.keyProviderInfo) <= bytes[|WriteShortLengthSeq(data.keyProviderId)|..];
@@ -235,10 +235,10 @@ module EncryptedDataKeys {
       // are valid WriteEncryptedDataKey bytes,
       // we can prove that this part is complete
       var edk := ReadEncryptedDataKeyIsComplete(
-        data[|accumulator|],
-        WriteEncryptedDataKey(data[|accumulator|]),
-        nextEdkStart
-      );
+                   data[|accumulator|],
+                   WriteEncryptedDataKey(data[|accumulator|]),
+                   nextEdkStart
+                 );
 
       assert edk.data == data[|accumulator|];
 
@@ -247,11 +247,11 @@ module EncryptedDataKeys {
       // Along the way, we prove ReadEncryptedDataKeyIsComplete
       // for each encrypted data key "along the way".
       var edks := ReadEncryptedDataKeysIsComplete(
-        data,
-        nextAccumulator,
-        bytes,
-        buffer
-      );
+                    data,
+                    nextAccumulator,
+                    bytes,
+                    buffer
+                  );
 
       assert edks.data == data;
       assert edks.tail.start == buffer.start + |WriteEncryptedDataKeys(data)|;
@@ -273,20 +273,20 @@ module EncryptedDataKeys {
       && buffer.start <= |buffer.bytes|
       && bytes <= buffer.bytes[buffer.start..]
     ensures ret.Success?
-    ==>
-      && ret.value.data == data
-      && ret.value.tail.start == buffer.start + |bytes|
-      && Success(ret.value) == ReadEncryptedDataKeysSection(buffer, maxEdks)
+            ==>
+              && ret.value.data == data
+              && ret.value.tail.start == buffer.start + |bytes|
+              && Success(ret.value) == ReadEncryptedDataKeysSection(buffer, maxEdks)
   {
     reveal ReadEncryptedDataKeysSection();
     assert bytes == WriteUint16(|data| as uint16) + WriteEncryptedDataKeys(data);
     assert bytes[|WriteUint16(|data| as uint16)|..] == WriteEncryptedDataKeys(data);
 
     var count := ReadUInt16IsComplete(
-      |data| as uint16,
-      WriteUint16(|data| as uint16),
-      buffer
-    );
+                   |data| as uint16,
+                   WriteUint16(|data| as uint16),
+                   buffer
+                 );
     assert count.data == |data| as uint16;
 
     var edks := ReadEncryptedDataKeysIsComplete(data, [], WriteEncryptedDataKeys(data), count.tail);

--- a/src/SDK/Serialize/EncryptionContext.dfy
+++ b/src/SDK/Serialize/EncryptionContext.dfy
@@ -621,10 +621,10 @@ module EncryptionContext {
       // are valid WriteAADPair bytes,
       // we can prove that this part is complete
       var pair := ReadAADPairIsComplete(
-                    data[|accumulator|],
-                    WriteAADPair(data[|accumulator|]),
-                    nextPair
-                  );
+        data[|accumulator|],
+        WriteAADPair(data[|accumulator|]),
+        nextPair
+      );
 
       assert pair.data == data[|accumulator|];
       reveal KeysToSet();
@@ -651,12 +651,12 @@ module EncryptionContext {
       // Along the way, we prove ReadAADPairIsComplete
       // for each encryption context pair "along the way".
       var pairs := ReadAADPairsIsComplete(
-                     data,
-                     accumulator + [pair.data],
-                     keys + KeysToSet([pair.data]),
-                     bytes,
-                     buffer
-                   );
+        data,
+        accumulator + [pair.data],
+        keys + KeysToSet([pair.data]),
+        bytes,
+        buffer
+      );
 
       assert pairs.data == data;
 
@@ -688,20 +688,20 @@ module EncryptionContext {
     assert bytes[|WriteUint16(|data| as uint16)|..] == WriteAADPairs(data);
 
     var count := ReadUInt16IsComplete(
-                   |data| as uint16,
-                   WriteUint16(|data| as uint16),
-                   buffer
-                 );
+      |data| as uint16,
+      WriteUint16(|data| as uint16),
+      buffer
+    );
     assert count.data as nat == |data|;
     var accumulator:ESDKCanonicalEncryptionContext := [];
 
     var pairs := ReadAADPairsIsComplete(
-                   data,
-                   accumulator,
-                   KeysToSet(accumulator),
-                   WriteAADPairs(data),
-                   count.tail
-                 );
+      data,
+      accumulator,
+      KeysToSet(accumulator),
+      WriteAADPairs(data),
+      count.tail
+    );
     assert pairs.data == data;
 
     return ReadAAD(buffer).value;
@@ -736,19 +736,19 @@ module EncryptionContext {
       assert 0 < |data|;
 
       var length := ReadUInt16IsComplete(
-                      |WriteAAD(data)| as uint16,
-                      WriteUint16(|WriteAAD(data)| as uint16),
-                      buffer
-                    );
+        |WriteAAD(data)| as uint16,
+        WriteUint16(|WriteAAD(data)| as uint16),
+        buffer
+      );
       assert length.data == |WriteAAD(data)| as uint16;
       assert length.tail.start + length.data as nat <= |length.tail.bytes|;
       assert !IsExpandedAADSection(buffer);
 
       var aad := ReadAADIsComplete(
-                   data,
-                   WriteAAD(data),
-                   length.tail
-                 );
+        data,
+        WriteAAD(data),
+        length.tail
+      );
       assert aad.data == data;
 
       return ReadAADSection(buffer).value;

--- a/src/SDK/Serialize/EncryptionContext.dfy
+++ b/src/SDK/Serialize/EncryptionContext.dfy
@@ -27,30 +27,30 @@ module EncryptionContext {
   // For reading and writing, we use the arbitrary given order,
   // and separate the ordering problem from serialization.
   type ESDKEncryptionContextPair = p: Pair<UTF8.ValidUTF8Bytes, UTF8.ValidUTF8Bytes>
-  |
-    && HasUint16Len(p.key) && ValidUTF8Seq(p.key)
-    && HasUint16Len(p.value) && ValidUTF8Seq(p.value)
-  witness *
+    |
+      && HasUint16Len(p.key) && ValidUTF8Seq(p.key)
+      && HasUint16Len(p.value) && ValidUTF8Seq(p.value)
+    witness *
 
   type ESDKCanonicalEncryptionContext = pairs: seq<ESDKEncryptionContextPair>
-  | ESDKCanonicalEncryptionContext?(pairs)
-  witness *
+    | ESDKCanonicalEncryptionContext?(pairs)
+    witness *
 
   predicate ESDKCanonicalEncryptionContext?(pairs: seq<ESDKEncryptionContextPair>) {
     && HasUint16Len(pairs)
     && LinearLength(pairs) < ESDK_CANONICAL_ENCRYPTION_CONTEXT_MAX_LENGTH
-    //= compliance/data-format/message-header.txt#2.5.1.7.2.2
-    //= type=implication
-    //# This sequence MUST NOT contain duplicate entries.
+       //= compliance/data-format/message-header.txt#2.5.1.7.2.2
+       //= type=implication
+       //# This sequence MUST NOT contain duplicate entries.
     && KeysAreUnique(pairs)
   }
 
   predicate KeysAreUnique<K, V>(pairs: Linear<K, V>)
   {
     (forall i, j
-    // This satisfies every cardinality AND i != j
-    :: 0 <= i < j < |pairs|
-    ==> pairs[i].key != pairs[j].key)
+       // This satisfies every cardinality AND i != j
+     :: 0 <= i < j < |pairs|
+        ==> pairs[i].key != pairs[j].key)
   }
 
   function method GetCanonicalEncryptionContext(
@@ -72,7 +72,7 @@ module EncryptionContext {
     assert ESDKCanonicalEncryptionContext?(canonicalEncryptionContext);
     assert KeysAreUnique(canonicalEncryptionContext);
     map i
-    | 0 <= i < |canonicalEncryptionContext|
+      | 0 <= i < |canonicalEncryptionContext|
     :: canonicalEncryptionContext[i].key := canonicalEncryptionContext[i].value
   }
 
@@ -154,28 +154,28 @@ module EncryptionContext {
     (ret: seq<uint8>)
     ensures
       if |ec| == 0 then
-      // These all deal with |ec| == 0
+        // These all deal with |ec| == 0
 
-      //= compliance/data-format/message-header.txt#2.5.1.7.1
-      //= type=implication
-      //# When the encryption context (../framework/structures.md#encryption-
-      //# context) is empty, the value of this field MUST be 0.
+        //= compliance/data-format/message-header.txt#2.5.1.7.1
+        //= type=implication
+        //# When the encryption context (../framework/structures.md#encryption-
+        //# context) is empty, the value of this field MUST be 0.
 
-      //= compliance/data-format/message-header.txt#2.5.1.7.2
-      //= type=implication
-      //# When the encryption
-      //# context (../framework/structures.md#encryption-context) is empty,
-      //# this field MUST NOT be included in the Section 2.5.1.7.
+        //= compliance/data-format/message-header.txt#2.5.1.7.2
+        //= type=implication
+        //# When the encryption
+        //# context (../framework/structures.md#encryption-context) is empty,
+        //# this field MUST NOT be included in the Section 2.5.1.7.
 
-      ret == WriteUint16(|ec| as uint16)
-    else
-      //= compliance/data-format/message-header.txt#2.5.1.7.2.1
-      //= type=implication
-      //# The value of this field MUST be greater
-      //# than 0.
-      && var aad := WriteAAD(ec);
-      && ret == WriteUint16(|aad| as uint16) + aad
-    {
+        ret == WriteUint16(|ec| as uint16)
+      else
+        //= compliance/data-format/message-header.txt#2.5.1.7.2.1
+        //= type=implication
+        //# The value of this field MUST be greater
+        //# than 0.
+        && var aad := WriteAAD(ec);
+        && ret == WriteUint16(|aad| as uint16) + aad
+  {
     if |ec| == 0 then WriteUint16(0)
     else
       var aad := WriteAAD(ec);
@@ -216,13 +216,13 @@ module EncryptionContext {
   ):
     (ret: seq<uint8>)
     ensures |ec| == 0
-    ==>
-      && LinearLength(ec) == |ret|
-      && ret == []
+            ==>
+              && LinearLength(ec) == |ret|
+              && ret == []
     ensures |ec| != 0
-    ==>
-      && LinearLength(Seq.DropLast(ec)) + PairLength(Seq.Last(ec)) == |ret|
-      && WriteAADPairs(Seq.DropLast(ec)) + WriteAADPair(Seq.Last(ec)) == ret
+            ==>
+              && LinearLength(Seq.DropLast(ec)) + PairLength(Seq.Last(ec)) == |ret|
+              && WriteAADPairs(Seq.DropLast(ec)) + WriteAADPair(Seq.Last(ec)) == ret
     ensures |ret| < ESDK_CANONICAL_ENCRYPTION_CONTEXT_MAX_LENGTH
   {
     if |ec| == 0 then []
@@ -334,9 +334,9 @@ module EncryptionContext {
   ):
     (res: ReadCorrect<ESDKCanonicalEncryptionContext>)
     ensures if IsExpandedAADSection(buffer) then
-      CorrectlyRead(buffer, res, WriteExpandedAADSection)
-    else 
-      CorrectlyRead(buffer, res, WriteAADSection)
+              CorrectlyRead(buffer, res, WriteExpandedAADSection)
+            else
+              CorrectlyRead(buffer, res, WriteAADSection)
   {
     var length :- ReadUInt16(buffer);
     if length.data == 0 then
@@ -359,7 +359,7 @@ module EncryptionContext {
         assert WriteExpandedAADSection(empty) == ReadRange((buffer, verifyCount.tail));
 
         Success(SuccessfulRead(empty, verifyCount.tail))
-      else 
+      else
         // This count MUST be greater than 0,
         // because the length of the AAD is greater than 2.
         :- Need(0 < verifyCount.data, Error("Encryption Context byte length exceeds pairs count."));
@@ -401,11 +401,11 @@ module EncryptionContext {
   ):
     (ret: seq<uint8>)
     ensures if |ec| == 0 then
-      ret == [0, 2, 0, 0]
-    else
-      && var aad := WriteAAD(ec);
-      && ret == UInt16ToSeq(|aad| as uint16) + aad
-    {
+              ret == [0, 2, 0, 0]
+            else
+              && var aad := WriteAAD(ec);
+              && ret == UInt16ToSeq(|aad| as uint16) + aad
+  {
     var aad := WriteAAD(ec);
     UInt16ToSeq(|aad| as uint16) + aad
   }
@@ -458,16 +458,16 @@ module EncryptionContext {
     data: ESDKCanonicalEncryptionContext
   )
     ensures forall accumulator
-    | accumulator <= data
-    ::
-      && ESDKCanonicalEncryptionContext?(accumulator)
-      && ESDKCanonicalEncryptionContext?(data[|accumulator|..])
+              | accumulator <= data
+            ::
+              && ESDKCanonicalEncryptionContext?(accumulator)
+              && ESDKCanonicalEncryptionContext?(data[|accumulator|..])
   {
     forall accumulator
-    | accumulator <= data
-    ensures
-      && ESDKCanonicalEncryptionContext?(accumulator)
-      && ESDKCanonicalEncryptionContext?(data[|accumulator|..])
+      | accumulator <= data
+      ensures
+        && ESDKCanonicalEncryptionContext?(accumulator)
+        && ESDKCanonicalEncryptionContext?(data[|accumulator|..])
     {
       assert |accumulator| <= |data|;
       assert |data[|accumulator|..]| <= |data|;
@@ -606,12 +606,12 @@ module EncryptionContext {
     // building up to the terminal case (see the inductive call below)
     if data == accumulator {
       return ReadAADPairs(
-        buffer,
-        accumulator,
-        keys,
-        |data| as uint16,
-        buffer.( start := buffer.start + |WriteAADPairs(data)| ))
-      .value;
+               buffer,
+               accumulator,
+               keys,
+               |data| as uint16,
+               buffer.( start := buffer.start + |WriteAADPairs(data)| ))
+             .value;
     } else {
 
       var nextPair := NextPairIsComplete(data, accumulator, bytes, buffer);
@@ -621,10 +621,10 @@ module EncryptionContext {
       // are valid WriteAADPair bytes,
       // we can prove that this part is complete
       var pair := ReadAADPairIsComplete(
-        data[|accumulator|],
-        WriteAADPair(data[|accumulator|]),
-        nextPair
-      );
+                    data[|accumulator|],
+                    WriteAADPair(data[|accumulator|]),
+                    nextPair
+                  );
 
       assert pair.data == data[|accumulator|];
       reveal KeysToSet();
@@ -651,12 +651,12 @@ module EncryptionContext {
       // Along the way, we prove ReadAADPairIsComplete
       // for each encryption context pair "along the way".
       var pairs := ReadAADPairsIsComplete(
-        data,
-        accumulator + [pair.data],
-        keys + KeysToSet([pair.data]),
-        bytes,
-        buffer
-      );
+                     data,
+                     accumulator + [pair.data],
+                     keys + KeysToSet([pair.data]),
+                     bytes,
+                     buffer
+                   );
 
       assert pairs.data == data;
 
@@ -688,20 +688,20 @@ module EncryptionContext {
     assert bytes[|WriteUint16(|data| as uint16)|..] == WriteAADPairs(data);
 
     var count := ReadUInt16IsComplete(
-      |data| as uint16,
-      WriteUint16(|data| as uint16),
-      buffer
-    );
+                   |data| as uint16,
+                   WriteUint16(|data| as uint16),
+                   buffer
+                 );
     assert count.data as nat == |data|;
     var accumulator:ESDKCanonicalEncryptionContext := [];
 
     var pairs := ReadAADPairsIsComplete(
-      data,
-      accumulator,
-      KeysToSet(accumulator),
-      WriteAADPairs(data),
-      count.tail
-    );
+                   data,
+                   accumulator,
+                   KeysToSet(accumulator),
+                   WriteAADPairs(data),
+                   count.tail
+                 );
     assert pairs.data == data;
 
     return ReadAAD(buffer).value;
@@ -736,19 +736,19 @@ module EncryptionContext {
       assert 0 < |data|;
 
       var length := ReadUInt16IsComplete(
-        |WriteAAD(data)| as uint16,
-        WriteUint16(|WriteAAD(data)| as uint16),
-        buffer
-      );
+                      |WriteAAD(data)| as uint16,
+                      WriteUint16(|WriteAAD(data)| as uint16),
+                      buffer
+                    );
       assert length.data == |WriteAAD(data)| as uint16;
       assert length.tail.start + length.data as nat <= |length.tail.bytes|;
       assert !IsExpandedAADSection(buffer);
 
       var aad := ReadAADIsComplete(
-        data,
-        WriteAAD(data),
-        length.tail
-      );
+                   data,
+                   WriteAAD(data),
+                   length.tail
+                 );
       assert aad.data == data;
 
       return ReadAADSection(buffer).value;

--- a/src/SDK/Serialize/Frames.dfy
+++ b/src/SDK/Serialize/Frames.dfy
@@ -166,12 +166,12 @@ module Frames {
     var authTag :- Read(encContent.tail, header.suite.encrypt.tagLength as nat);
 
     var regularFrame: RegularFrame := Frame.RegularFrame(
-                                        header,
-                                        sequenceNumber.data,
-                                        iv.data,
-                                        encContent.data,
-                                        authTag.data
-                                      );
+      header,
+      sequenceNumber.data,
+      iv.data,
+      encContent.data,
+      authTag.data
+    );
 
     assert {:split_here} true;
     assert WriteRegularFrame(regularFrame) <= buffer.bytes[buffer.start..];
@@ -243,12 +243,12 @@ module Frames {
 
     var authTag :- Read(encContent.tail, header.suite.encrypt.tagLength as nat);
     var finalFrame: FinalFrame := Frame.FinalFrame(
-                                    header,
-                                    sequenceNumber.data,
-                                    iv.data,
-                                    encContent.data,
-                                    authTag.data
-                                  );
+      header,
+      sequenceNumber.data,
+      iv.data,
+      encContent.data,
+      authTag.data
+    );
 
     assert WriteUint32(finalFrameSignal.data)
       + (WriteUint32(finalFrame.seqNum)
@@ -276,11 +276,11 @@ module Frames {
     var authTag :- Read(encContent.tail, header.suite.encrypt.tagLength as nat);
 
     var nonFramed: NonFramed := Frame.NonFramed(
-                                  header,
-                                  iv.data,
-                                  encContent.data,
-                                  authTag.data
-                                );
+      header,
+      iv.data,
+      encContent.data,
+      authTag.data
+    );
 
     assert {:split_here} true;
     assert WriteNonFramed(nonFramed) <= buffer.bytes[buffer.start..];

--- a/src/SDK/Serialize/Header.dfy
+++ b/src/SDK/Serialize/Header.dfy
@@ -128,15 +128,15 @@ module Header {
     var version :- SharedHeaderFunctions.ReadMessageFormatVersion(buffer);
 
     var (body, tail) :- match version.data {
-                          case V1 =>
-                            var b :- V1HeaderBody.ReadV1HeaderBody(buffer, maxEdks);
-                            var body: HeaderTypes.HeaderBody := b.data;
-                            Success((body, b.tail))
-                          case V2 =>
-                            var b :- V2HeaderBody.ReadV2HeaderBody(buffer, maxEdks);
-                            var body: HeaderTypes.HeaderBody := b.data;
-                            Success((body, b.tail))
-                        };
+      case V1 =>
+        var b :- V1HeaderBody.ReadV1HeaderBody(buffer, maxEdks);
+        var body: HeaderTypes.HeaderBody := b.data;
+        Success((body, b.tail))
+      case V2 =>
+        var b :- V2HeaderBody.ReadV2HeaderBody(buffer, maxEdks);
+        var body: HeaderTypes.HeaderBody := b.data;
+        Success((body, b.tail))
+    };
 
     :- Need(body.contentType.Framed? <==> body.frameLength > 0,
             Error("Frame length must be positive if content is framed"));

--- a/src/SDK/Serialize/Header.dfy
+++ b/src/SDK/Serialize/Header.dfy
@@ -35,12 +35,12 @@ module Header {
   import opened SerializeFunctions
 
   datatype HeaderInfo = HeaderInfo(
-                          nameonly body: HeaderTypes.HeaderBody,
-                          nameonly rawHeader: seq<uint8>,
-                          nameonly encryptionContext: ESDKEncryptionContext,
-                          nameonly suite: Client.AlgorithmSuites.AlgorithmSuite,
-                          nameonly headerAuth: HeaderTypes.HeaderAuth
-                        )
+    nameonly body: HeaderTypes.HeaderBody,
+    nameonly rawHeader: seq<uint8>,
+    nameonly encryptionContext: ESDKEncryptionContext,
+    nameonly suite: Client.AlgorithmSuites.AlgorithmSuite,
+    nameonly headerAuth: HeaderTypes.HeaderAuth
+  )
 
   predicate IsHeader(h: HeaderInfo)
   {

--- a/src/SDK/Serialize/HeaderAuth.dfy
+++ b/src/SDK/Serialize/HeaderAuth.dfy
@@ -100,9 +100,9 @@ module HeaderAuth {
     var headerAuthTag :- Read(headerIv.tail, suite.encrypt.tagLength as nat);
 
     var auth: AESMac := HeaderTypes.HeaderAuth.AESMac(
-                          headerIv := headerIv.data,
-                          headerAuthTag := headerAuthTag.data
-                        );
+      headerIv := headerIv.data,
+      headerAuthTag := headerAuthTag.data
+    );
 
     Success(SuccessfulRead(auth, headerAuthTag.tail))
   }
@@ -123,9 +123,9 @@ module HeaderAuth {
     var headerAuthTag :- Read(buffer, suite.encrypt.tagLength as nat);
 
     var auth: AESMac := HeaderTypes.HeaderAuth.AESMac(
-                          headerIv := headerIv,
-                          headerAuthTag := headerAuthTag.data
-                        );
+      headerIv := headerIv,
+      headerAuthTag := headerAuthTag.data
+    );
 
     Success(SuccessfulRead(auth, headerAuthTag.tail))
   }

--- a/src/SDK/Serialize/HeaderAuth.dfy
+++ b/src/SDK/Serialize/HeaderAuth.dfy
@@ -26,8 +26,8 @@ module HeaderAuth {
   import opened SerializeFunctions
 
   type AESMac = a: HeaderTypes.HeaderAuth
-  | a.AESMac?
-  witness *
+    | a.AESMac?
+    witness *
 
   function method WriteHeaderAuthTagV2(
     headerAuth: AESMac
@@ -69,7 +69,7 @@ module HeaderAuth {
     //= compliance/client-apis/encrypt.txt#2.6.2
     //# *  Authentication Tag (../data-format/message-
     //# header.md#authentication-tag): MUST have the value of the
-    //# authentication tag calculated above.  
+    //# authentication tag calculated above.
     + Write(headerAuth.headerAuthTag)
   }
 
@@ -80,9 +80,9 @@ module HeaderAuth {
     :(ret: Result<seq<uint8>, string>)
   {
     match suite.messageVersion
-      case 1 => Success(WriteHeaderAuthTagV1(headerAuth))
-      case 2 => Success(WriteHeaderAuthTagV2(headerAuth))
-      case _ => Failure("Unexpected message version")
+    case 1 => Success(WriteHeaderAuthTagV1(headerAuth))
+    case 2 => Success(WriteHeaderAuthTagV2(headerAuth))
+    case _ => Failure("Unexpected message version")
   }
 
   function method ReadHeaderAuthTagV1(
@@ -92,17 +92,17 @@ module HeaderAuth {
     :(res: ReadCorrect<AESMac>)
     ensures CorrectlyRead(buffer, res, WriteHeaderAuthTagV1)
     ensures res.Success?
-    ==>
-      && |res.value.data.headerIv| == suite.encrypt.ivLength as nat
-      && |res.value.data.headerAuthTag| == suite.encrypt.tagLength as nat
+            ==>
+              && |res.value.data.headerIv| == suite.encrypt.ivLength as nat
+              && |res.value.data.headerAuthTag| == suite.encrypt.tagLength as nat
   {
     var headerIv :- Read(buffer, suite.encrypt.ivLength as nat);
     var headerAuthTag :- Read(headerIv.tail, suite.encrypt.tagLength as nat);
 
     var auth: AESMac := HeaderTypes.HeaderAuth.AESMac(
-      headerIv := headerIv.data,
-      headerAuthTag := headerAuthTag.data
-    );
+                          headerIv := headerIv.data,
+                          headerAuthTag := headerAuthTag.data
+                        );
 
     Success(SuccessfulRead(auth, headerAuthTag.tail))
   }
@@ -114,18 +114,18 @@ module HeaderAuth {
     :(res: ReadCorrect<AESMac>)
     ensures CorrectlyRead(buffer, res, WriteHeaderAuthTagV2)
     ensures res.Success?
-    ==>
-      && |res.value.data.headerIv| == suite.encrypt.ivLength as nat
-      && |res.value.data.headerAuthTag| == suite.encrypt.tagLength as nat
+            ==>
+              && |res.value.data.headerIv| == suite.encrypt.ivLength as nat
+              && |res.value.data.headerAuthTag| == suite.encrypt.tagLength as nat
   {
     // TODO: probably this hardcoded iv of all 0s will go into alg suite
     var headerIv := seq(suite.encrypt.ivLength as int, _ => 0);
     var headerAuthTag :- Read(buffer, suite.encrypt.tagLength as nat);
 
     var auth: AESMac := HeaderTypes.HeaderAuth.AESMac(
-      headerIv := headerIv,
-      headerAuthTag := headerAuthTag.data
-    );
+                          headerIv := headerIv,
+                          headerAuthTag := headerAuthTag.data
+                        );
 
     Success(SuccessfulRead(auth, headerAuthTag.tail))
   }
@@ -139,13 +139,13 @@ module HeaderAuth {
     ensures suite.messageVersion == 1 ==> CorrectlyRead(buffer, res, WriteHeaderAuthTagV1)
     ensures suite.messageVersion == 2 ==> CorrectlyRead(buffer, res, WriteHeaderAuthTagV2)
     ensures res.Success?
-    ==>
-      && |res.value.data.headerIv| == suite.encrypt.ivLength as nat
-      && |res.value.data.headerAuthTag| == suite.encrypt.tagLength as nat
+            ==>
+              && |res.value.data.headerIv| == suite.encrypt.ivLength as nat
+              && |res.value.data.headerAuthTag| == suite.encrypt.tagLength as nat
   {
     match suite.messageVersion
-      case 1 => ReadHeaderAuthTagV1(buffer, suite)
-      case 2 => ReadHeaderAuthTagV2(buffer, suite)
-      case _ => Failure(Error("Unexpected message version"))
+    case 1 => ReadHeaderAuthTagV1(buffer, suite)
+    case 2 => ReadHeaderAuthTagV2(buffer, suite)
+    case _ => Failure(Error("Unexpected message version"))
   }
 }

--- a/src/SDK/Serialize/HeaderTypes.dfy
+++ b/src/SDK/Serialize/HeaderTypes.dfy
@@ -86,9 +86,9 @@ module HeaderTypes {
 
   datatype HeaderAuth =
     | AESMac(
-        nameonly headerIv: seq<uint8>,
-        nameonly headerAuthTag: seq<uint8>
-      )
+    nameonly headerIv: seq<uint8>,
+    nameonly headerAuthTag: seq<uint8>
+  )
 
   datatype MessageType =
     | TYPE_CUSTOMER_AED

--- a/src/SDK/Serialize/HeaderTypes.dfy
+++ b/src/SDK/Serialize/HeaderTypes.dfy
@@ -21,13 +21,13 @@ module HeaderTypes {
   import opened SerializeFunctions
 
   datatype MessageFormatVersion =
-  | V1
-  | V2
-    {
+    | V1
+    | V2
+  {
     function method Serialize(): (bytes: seq<uint8>) {
       match this
-        case V1 => [0x01]
-        case V2 => [0x02]
+      case V1 => [0x01]
+      case V2 => [0x02]
     }
 
     lemma LemmaSerializeCorrectValue()
@@ -36,16 +36,16 @@ module HeaderTypes {
       //# The version (hex) of this field
       //# MUST be a value that exists in the following table:
       ensures match this
-        //= compliance/data-format/message-header.txt#2.5.1.1
-        //= type=implication
-        //# The value of the "Version" field MUST be "01" in the
-        //# Version 1.0 header body.
-        case V1 => this.Serialize() == [0x01]
-        //= compliance/data-format/message-header.txt#2.5.1.2
-        //= type=implication
-        //# The value of the "Version" field MUST be "02" in the
-        //# Version 2.0 header body.
-        case V2 => this.Serialize() == [0x02]
+              //= compliance/data-format/message-header.txt#2.5.1.1
+              //= type=implication
+              //# The value of the "Version" field MUST be "01" in the
+              //# Version 1.0 header body.
+              case V1 => this.Serialize() == [0x01]
+              //= compliance/data-format/message-header.txt#2.5.1.2
+              //= type=implication
+              //# The value of the "Version" field MUST be "02" in the
+              //# Version 2.0 header body.
+              case V2 => this.Serialize() == [0x02]
     {}
 
     static function method Get(
@@ -65,34 +65,34 @@ module HeaderTypes {
 
   datatype HeaderBody =
     | V1HeaderBody(
-      nameonly messageType: MessageType,
-      nameonly esdkSuiteId: ESDKAlgorithmSuiteId,
-      nameonly messageId: MessageId,
-      nameonly encryptionContext: EncryptionContext.ESDKCanonicalEncryptionContext,
-      nameonly encryptedDataKeys: ESDKEncryptedDataKeys,
-      nameonly contentType: ContentType,
-      nameonly headerIvLength: nat,
-      nameonly frameLength: uint32
-    )
+        nameonly messageType: MessageType,
+        nameonly esdkSuiteId: ESDKAlgorithmSuiteId,
+        nameonly messageId: MessageId,
+        nameonly encryptionContext: EncryptionContext.ESDKCanonicalEncryptionContext,
+        nameonly encryptedDataKeys: ESDKEncryptedDataKeys,
+        nameonly contentType: ContentType,
+        nameonly headerIvLength: nat,
+        nameonly frameLength: uint32
+      )
     | V2HeaderBody(
-      nameonly esdkSuiteId: ESDKAlgorithmSuiteId,
-      nameonly messageId: MessageId,
-      nameonly encryptionContext: EncryptionContext.ESDKCanonicalEncryptionContext,
-      nameonly encryptedDataKeys: ESDKEncryptedDataKeys,
-      nameonly contentType: ContentType,
-      nameonly frameLength: uint32,
-      nameonly suiteData: seq<uint8>
-    )
+        nameonly esdkSuiteId: ESDKAlgorithmSuiteId,
+        nameonly messageId: MessageId,
+        nameonly encryptionContext: EncryptionContext.ESDKCanonicalEncryptionContext,
+        nameonly encryptedDataKeys: ESDKEncryptedDataKeys,
+        nameonly contentType: ContentType,
+        nameonly frameLength: uint32,
+        nameonly suiteData: seq<uint8>
+      )
 
   datatype HeaderAuth =
-  | AESMac(
-    nameonly headerIv: seq<uint8>,
-    nameonly headerAuthTag: seq<uint8>
-  )
+    | AESMac(
+        nameonly headerIv: seq<uint8>,
+        nameonly headerAuthTag: seq<uint8>
+      )
 
   datatype MessageType =
-  | TYPE_CUSTOMER_AED
-    {
+    | TYPE_CUSTOMER_AED
+  {
     function method Serialize(): (val: uint8) {
       match this
       case TYPE_CUSTOMER_AED => 0x80
@@ -121,8 +121,8 @@ module HeaderTypes {
   }
 
   datatype ContentType =
-  | NonFramed
-  | Framed
+    | NonFramed
+    | Framed
   {
     function method Serialize(): (val: uint8) {
       match this
@@ -158,7 +158,7 @@ module HeaderTypes {
   const MESSAGE_ID_LEN_V1 := 16
   const MESSAGE_ID_LEN_V2 := 32
   type MessageId = x: seq<uint8> |
-    || |x| == MESSAGE_ID_LEN_V1
-    || |x| == MESSAGE_ID_LEN_V2
-  witness *
+      || |x| == MESSAGE_ID_LEN_V1
+      || |x| == MESSAGE_ID_LEN_V2
+    witness *
 }

--- a/src/SDK/Serialize/SerializableTypes.dfy
+++ b/src/SDK/Serialize/SerializableTypes.dfy
@@ -39,15 +39,15 @@ module SerializableTypes {
     && |ec| < UINT16_LIMIT
     && Length(ec) < ESDK_CANONICAL_ENCRYPTION_CONTEXT_MAX_LENGTH
     && forall element
-    | element in (multiset(ec.Keys) + multiset(ec.Values))
-    ::
-      && HasUint16Len(element)
-      && ValidUTF8Seq(element)
+         | element in (multiset(ec.Keys) + multiset(ec.Values))
+       ::
+         && HasUint16Len(element)
+         && ValidUTF8Seq(element)
   }
 
   type ESDKEncryptionContext = ec: Crypto.EncryptionContext
-  | IsESDKEncryptionContext(ec)
-  witness *
+    | IsESDKEncryptionContext(ec)
+    witness *
 
   const VALID_IDS: set<uint16> := {0x0578, 0x0478, 0x0378, 0x0346, 0x0214, 0x0178, 0x0146, 0x0114, 0x0078, 0x0046, 0x0014};
 
@@ -59,17 +59,17 @@ module SerializableTypes {
   type ESDKAlgorithmSuiteId = id: uint16 | id in VALID_IDS witness *
 
   const SupportedAlgorithmSuites: map<Crypto.AlgorithmSuiteId, ESDKAlgorithmSuiteId> := map[
-    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF := 0x0014,
-    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF := 0x0046,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF := 0x0078,
-    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256 := 0x0114,
-    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256 := 0x0146,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256 := 0x0178,
-    Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256 := 0x0214,
-    Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 := 0x0346,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 := 0x0378,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY := 0x0478,
-    Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384 := 0x0578
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_NO_KDF := 0x0014,
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_NO_KDF := 0x0046,
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_NO_KDF := 0x0078,
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256 := 0x0114,
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA256 := 0x0146,
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256 := 0x0178,
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256 := 0x0214,
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 := 0x0346,
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384 := 0x0378,
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY := 0x0478,
+                                                                                          Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384 := 0x0578
   ]
 
   function method GetESDKAlgorithmSuiteId(
@@ -88,7 +88,7 @@ module SerializableTypes {
     (res: Crypto.AlgorithmSuiteId)
   {
     var suiteId
-    :|
+      :|
       && suiteId in SupportedAlgorithmSuites
       && SupportedAlgorithmSuites[suiteId] == esdkId;
     suiteId
@@ -120,8 +120,8 @@ module SerializableTypes {
       && ret == LinearLength(pairs)
   {
     if |encryptionContext| == 0 then 0 else
-      var pairs := GetCanonicalLinearPairs(encryptionContext);
-      LinearLength(pairs)
+    var pairs := GetCanonicalLinearPairs(encryptionContext);
+    LinearLength(pairs)
   }
 
   // Defining and reasoning about order with maps
@@ -137,16 +137,16 @@ module SerializableTypes {
     //# These entries MUST have entries sorted, by key, in ascending order
     //# according to the UTF-8 encoded binary value.
     var keys: seq<UTF8.ValidUTF8Bytes> := Sets.ComputeSetToOrderedSequence2<uint8>(
-      encryptionContext.Keys,
-      UInt.UInt8Less
-    );
+                                            encryptionContext.Keys,
+                                            UInt.UInt8Less
+                                          );
     seq(
-      |keys|,
-      i
-        requires 0 <= i < |keys|
-      => Pair(
-        keys[i],
-        encryptionContext[keys[i]]))
+    |keys|,
+    i
+    requires 0 <= i < |keys|
+    => Pair(
+         keys[i],
+         encryptionContext[keys[i]]))
   }
 
   function method {:tailrecursion} LinearLength(
@@ -154,9 +154,9 @@ module SerializableTypes {
   ):
     (ret: nat)
     ensures |pairs| == 0
-    ==> ret == 0
+            ==> ret == 0
     ensures |pairs| != 0
-    ==> ret == LinearLength(Seq.DropLast(pairs)) + PairLength(Seq.Last(pairs))
+            ==> ret == LinearLength(Seq.DropLast(pairs)) + PairLength(Seq.Last(pairs))
   {
     if |pairs| == 0 then 0
     else

--- a/src/SDK/Serialize/SerializableTypes.dfy
+++ b/src/SDK/Serialize/SerializableTypes.dfy
@@ -137,9 +137,9 @@ module SerializableTypes {
     //# These entries MUST have entries sorted, by key, in ascending order
     //# according to the UTF-8 encoded binary value.
     var keys: seq<UTF8.ValidUTF8Bytes> := Sets.ComputeSetToOrderedSequence2<uint8>(
-                                            encryptionContext.Keys,
-                                            UInt.UInt8Less
-                                          );
+      encryptionContext.Keys,
+      UInt.UInt8Less
+    );
     seq(
     |keys|,
     i

--- a/src/SDK/Serialize/SerializableTypes.dfy
+++ b/src/SDK/Serialize/SerializableTypes.dfy
@@ -145,8 +145,8 @@ module SerializableTypes {
     i
     requires 0 <= i < |keys|
     => Pair(
-         keys[i],
-         encryptionContext[keys[i]]))
+      keys[i],
+      encryptionContext[keys[i]]))
   }
 
   function method {:tailrecursion} LinearLength(

--- a/src/SDK/Serialize/SerializeFunctions.dfy
+++ b/src/SDK/Serialize/SerializeFunctions.dfy
@@ -30,17 +30,17 @@ module SerializeFunctions {
   // and the position to start reading withing these bytes.
   // This data structure represents this information.
   datatype ReadableBuffer = ReadableBuffer(
-                              bytes: seq<uint8>,
-                              start: nat
-                            )
+    bytes: seq<uint8>,
+    start: nat
+  )
 
   // This holds the data from a successful read.
   // The `data` is the read type,
   // and the `tail` is the remaining data left to be read.
   datatype SuccessfulRead<T> = SuccessfulRead(
-                                 data: T,
-                                 tail: ReadableBuffer
-                               )
+    data: T,
+    tail: ReadableBuffer
+  )
 
   type ReadResult<T, E> = Result<SuccessfulRead<T>, E>
   type ReadCorrect<T> = ReadResult<T, ReadProblems>

--- a/src/SDK/Serialize/V1HeaderBody.dfy
+++ b/src/SDK/Serialize/V1HeaderBody.dfy
@@ -145,22 +145,22 @@ module V1HeaderBody {
     var reservedBytes :- ReadV1ReservedBytes(contentType.tail);
 
     var headerIvLength :- ReadV1HeaderIvLength(
-                            reservedBytes.tail,
-                            suite
-                          );
+      reservedBytes.tail,
+      suite
+    );
 
     var frameLength :- ReadUInt32(headerIvLength.tail);
 
     var body:V1HeaderBody := HeaderTypes.V1HeaderBody(
-                               messageType := messageType.data,
-                               esdkSuiteId := esdkSuiteId.data,
-                               messageId := messageId.data,
-                               encryptionContext := encryptionContext.data,
-                               encryptedDataKeys := encryptedDataKeys.data,
-                               contentType := contentType.data,
-                               headerIvLength := headerIvLength.data as nat,
-                               frameLength := frameLength.data
-                             );
+      messageType := messageType.data,
+      esdkSuiteId := esdkSuiteId.data,
+      messageId := messageId.data,
+      encryptionContext := encryptionContext.data,
+      encryptedDataKeys := encryptedDataKeys.data,
+      contentType := contentType.data,
+      headerIvLength := headerIvLength.data as nat,
+      frameLength := frameLength.data
+    );
 
     assert if IsV1ExpandedAADSection(buffer) then
         WriteV1ExpandedAADSectionHeaderBody(body) <= buffer.bytes[buffer.start..]

--- a/src/SDK/Serialize/V1HeaderBody.dfy
+++ b/src/SDK/Serialize/V1HeaderBody.dfy
@@ -28,8 +28,8 @@ module V1HeaderBody {
   import opened SerializeFunctions
 
   type V1HeaderBody = h: HeaderTypes.HeaderBody
-  | h.V1HeaderBody?
-  witness *
+    | h.V1HeaderBody?
+    witness *
 
   //= compliance/data-format/message-header.txt#2.5.2.1
   //= type=implication
@@ -37,8 +37,8 @@ module V1HeaderBody {
   //# 00 00 00".
   const RESERVED_BYTES: seq<uint8> := [0x00, 0x00, 0x00, 0x00];
   type ReservedBytes = s: seq<uint8>
-  | s == RESERVED_BYTES
-  witness RESERVED_BYTES
+    | s == RESERVED_BYTES
+    witness RESERVED_BYTES
 
   function method WriteV1HeaderBody(
     body: V1HeaderBody
@@ -71,50 +71,50 @@ module V1HeaderBody {
     //# corresponding to Customer Authenticated Encrypted Data (../data-
     //# format/message-header.md#supported-types)
     + (WriteV1MessageType(body.messageType)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  Algorithm Suite ID (../data-format/message-header.md#algorithm-
-    //# suite-id): MUST correspond to the algorithm suite (../framework/
-    //# algorithm-suites.md) used in this behavior
-    + (WriteESDKSuiteId(body.esdkSuiteId)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  Message ID (../data-format/message-header.md#message-id): The
-    //# process used to generate this identifier MUST use a good source of
-    //# randomness to make the chance of duplicate identifiers negligible.
-    + (WriteMessageId(body.messageId)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  AAD (../data-format/message-header.md#aad): MUST be the
-    //# serialization of the encryption context (../framework/
-    //# structures.md#encryption-context) in the encryption materials
-    //# (../framework/structures.md#encryption-materials)
-    + (WriteAADSection(body.encryptionContext)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  Encrypted Data Keys (../data-format/message-header.md#encrypted-
-    //# data-key-entries): MUST be the serialization of the encrypted data
-    //# keys (../framework/structures.md#encrypted-data-keys) in the
-    //# encryption materials (../framework/structures.md#encryption-
-    //# materials)
-    + (WriteEncryptedDataKeysSection(body.encryptedDataKeys)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  Content Type (../data-format/message-header.md#content-type): MUST
-    //# be 02 (../data-format/message-header.md#supported-content-types)
-    + (WriteContentType(body.contentType)
-    + (WriteV1ReservedBytes(RESERVED_BYTES)
-    //= compliance/data-format/message-header.txt#2.5.2.2
-    //# This value MUST be
-    //# equal to the IV length (../framework/algorithm-suites.md#iv-length)
-    //# value of the algorithm suite (../framework/algorithm-suites.md)
-    //# specified by the Algorithm Suite ID (Section 2.5.1.5) field.
-    //
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  IV Length (../data-format/message-header.md#iv-length): MUST match
-    //# the IV length (../framework/algorithm-suites.md#iv-length)
-    //# specified by the algorithm suite (../framework/algorithm-
-    //# suites.md)
-    + (WriteV1HeaderIvLength(suite.encrypt.ivLength)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  Frame Length (../data-format/message-header.md#frame-length): MUST
-    //# be the value of the frame size determined above.
-    + (WriteUint32(body.frameLength))))))))))
+       //= compliance/client-apis/encrypt.txt#2.6.2
+       //# *  Algorithm Suite ID (../data-format/message-header.md#algorithm-
+       //# suite-id): MUST correspond to the algorithm suite (../framework/
+       //# algorithm-suites.md) used in this behavior
+       + (WriteESDKSuiteId(body.esdkSuiteId)
+          //= compliance/client-apis/encrypt.txt#2.6.2
+          //# *  Message ID (../data-format/message-header.md#message-id): The
+          //# process used to generate this identifier MUST use a good source of
+          //# randomness to make the chance of duplicate identifiers negligible.
+          + (WriteMessageId(body.messageId)
+             //= compliance/client-apis/encrypt.txt#2.6.2
+             //# *  AAD (../data-format/message-header.md#aad): MUST be the
+             //# serialization of the encryption context (../framework/
+             //# structures.md#encryption-context) in the encryption materials
+             //# (../framework/structures.md#encryption-materials)
+             + (WriteAADSection(body.encryptionContext)
+                //= compliance/client-apis/encrypt.txt#2.6.2
+                //# *  Encrypted Data Keys (../data-format/message-header.md#encrypted-
+                //# data-key-entries): MUST be the serialization of the encrypted data
+                //# keys (../framework/structures.md#encrypted-data-keys) in the
+                //# encryption materials (../framework/structures.md#encryption-
+                //# materials)
+                + (WriteEncryptedDataKeysSection(body.encryptedDataKeys)
+                   //= compliance/client-apis/encrypt.txt#2.6.2
+                   //# *  Content Type (../data-format/message-header.md#content-type): MUST
+                   //# be 02 (../data-format/message-header.md#supported-content-types)
+                   + (WriteContentType(body.contentType)
+                      + (WriteV1ReservedBytes(RESERVED_BYTES)
+                         //= compliance/data-format/message-header.txt#2.5.2.2
+                         //# This value MUST be
+                         //# equal to the IV length (../framework/algorithm-suites.md#iv-length)
+                         //# value of the algorithm suite (../framework/algorithm-suites.md)
+                         //# specified by the Algorithm Suite ID (Section 2.5.1.5) field.
+                         //
+                         //= compliance/client-apis/encrypt.txt#2.6.2
+                         //# *  IV Length (../data-format/message-header.md#iv-length): MUST match
+                         //# the IV length (../framework/algorithm-suites.md#iv-length)
+                         //# specified by the algorithm suite (../framework/algorithm-
+                         //# suites.md)
+                         + (WriteV1HeaderIvLength(suite.encrypt.ivLength)
+                            //= compliance/client-apis/encrypt.txt#2.6.2
+                            //# *  Frame Length (../data-format/message-header.md#frame-length): MUST
+                            //# be the value of the frame size determined above.
+                            + (WriteUint32(body.frameLength))))))))))
   }
 
   function method {:vcs_split_on_every_assert} ReadV1HeaderBody(
@@ -145,27 +145,27 @@ module V1HeaderBody {
     var reservedBytes :- ReadV1ReservedBytes(contentType.tail);
 
     var headerIvLength :- ReadV1HeaderIvLength(
-      reservedBytes.tail,
-      suite
-    );
+                            reservedBytes.tail,
+                            suite
+                          );
 
     var frameLength :- ReadUInt32(headerIvLength.tail);
 
     var body:V1HeaderBody := HeaderTypes.V1HeaderBody(
-      messageType := messageType.data,
-      esdkSuiteId := esdkSuiteId.data,
-      messageId := messageId.data,
-      encryptionContext := encryptionContext.data,
-      encryptedDataKeys := encryptedDataKeys.data,
-      contentType := contentType.data,
-      headerIvLength := headerIvLength.data as nat,
-      frameLength := frameLength.data
-    );
+                               messageType := messageType.data,
+                               esdkSuiteId := esdkSuiteId.data,
+                               messageId := messageId.data,
+                               encryptionContext := encryptionContext.data,
+                               encryptedDataKeys := encryptedDataKeys.data,
+                               contentType := contentType.data,
+                               headerIvLength := headerIvLength.data as nat,
+                               frameLength := frameLength.data
+                             );
 
     assert if IsV1ExpandedAADSection(buffer) then
-      WriteV1ExpandedAADSectionHeaderBody(body) <= buffer.bytes[buffer.start..]
-    else
-      WriteV1HeaderBody(body) <= buffer.bytes[buffer.start..];
+        WriteV1ExpandedAADSectionHeaderBody(body) <= buffer.bytes[buffer.start..]
+      else
+        WriteV1HeaderBody(body) <= buffer.bytes[buffer.start..];
 
     Success(SuccessfulRead(body, frameLength.tail))
   }
@@ -266,16 +266,16 @@ module V1HeaderBody {
     // with associativity of concatenation
     // (knowing that (a + b) + c == a + (b + c) ).
     // So manually adding the () helps make it clear.
-      WriteMessageFormatVersion(HeaderTypes.MessageFormatVersion.V1)
+    WriteMessageFormatVersion(HeaderTypes.MessageFormatVersion.V1)
     + (WriteV1MessageType(body.messageType)
-    + (WriteESDKSuiteId(body.esdkSuiteId)
-    + (WriteMessageId(body.messageId)
-    + (WriteExpandedAADSection(body.encryptionContext)
-    + (WriteEncryptedDataKeysSection(body.encryptedDataKeys)
-    + (WriteContentType(body.contentType)
-    + (WriteV1ReservedBytes(RESERVED_BYTES)
-    + (WriteV1HeaderIvLength(suite.encrypt.ivLength)
-    + (WriteUint32(body.frameLength))))))))))
+       + (WriteESDKSuiteId(body.esdkSuiteId)
+          + (WriteMessageId(body.messageId)
+             + (WriteExpandedAADSection(body.encryptionContext)
+                + (WriteEncryptedDataKeysSection(body.encryptedDataKeys)
+                   + (WriteContentType(body.contentType)
+                      + (WriteV1ReservedBytes(RESERVED_BYTES)
+                         + (WriteV1HeaderIvLength(suite.encrypt.ivLength)
+                            + (WriteUint32(body.frameLength))))))))))
   }
 
 }

--- a/src/SDK/Serialize/V2HeaderBody.dfy
+++ b/src/SDK/Serialize/V2HeaderBody.dfy
@@ -28,8 +28,8 @@ module V2HeaderBody {
   import opened SerializeFunctions
 
   type V2HeaderBody = h: HeaderTypes.HeaderBody
-  | h.V2HeaderBody?
-  witness *
+    | h.V2HeaderBody?
+    witness *
 
   function method WriteV2HeaderBody(
     body: V2HeaderBody
@@ -59,39 +59,39 @@ module V2HeaderBody {
     //# suite-id): MUST correspond to the algorithm suite (../framework/
     //# algorithm-suites.md) used in this behavior
     + (WriteESDKSuiteId(body.esdkSuiteId)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  Message ID (../data-format/message-header.md#message-id): The
-    //# process used to generate this identifier MUST use a good source of
-    //# randomness to make the chance of duplicate identifiers negligible.
-    + (WriteMessageId(body.messageId)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  AAD (../data-format/message-header.md#aad): MUST be the
-    //# serialization of the encryption context (../framework/
-    //# structures.md#encryption-context) in the encryption materials
-    //# (../framework/structures.md#encryption-materials)
-    + (WriteAADSection(body.encryptionContext)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  Encrypted Data Keys (../data-format/message-header.md#encrypted-
-    //# data-key-entries): MUST be the serialization of the encrypted data
-    //# keys (../framework/structures.md#encrypted-data-keys) in the
-    //# encryption materials (../framework/structures.md#encryption-
-    //# materials)
-    + (WriteEncryptedDataKeysSection(body.encryptedDataKeys)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  Content Type (../data-format/message-header.md#content-type): MUST
-    //# be 02 (../data-format/message-header.md#supported-content-types)
-    + (WriteContentType(body.contentType)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  Frame Length (../data-format/message-header.md#frame-length): MUST
-    //# be the value of the frame size determined above.
-    + (WriteUint32(body.frameLength)
-    //= compliance/client-apis/encrypt.txt#2.6.2
-    //# *  Algorithm Suite Data (../data-format/message-header.md#algorithm-
-    //# suite-data): MUST be the value of the commit key (../framework/
-    //# algorithm-suites.md#commit-key) derived according to the algorithm
-    //# suites commit key derivation settings (../framework/algorithm-
-    //# suites.md#algorithm-suites-commit-key-derivation-settings).
-    + (Write(body.suiteData))))))))
+       //= compliance/client-apis/encrypt.txt#2.6.2
+       //# *  Message ID (../data-format/message-header.md#message-id): The
+       //# process used to generate this identifier MUST use a good source of
+       //# randomness to make the chance of duplicate identifiers negligible.
+       + (WriteMessageId(body.messageId)
+          //= compliance/client-apis/encrypt.txt#2.6.2
+          //# *  AAD (../data-format/message-header.md#aad): MUST be the
+          //# serialization of the encryption context (../framework/
+          //# structures.md#encryption-context) in the encryption materials
+          //# (../framework/structures.md#encryption-materials)
+          + (WriteAADSection(body.encryptionContext)
+             //= compliance/client-apis/encrypt.txt#2.6.2
+             //# *  Encrypted Data Keys (../data-format/message-header.md#encrypted-
+             //# data-key-entries): MUST be the serialization of the encrypted data
+             //# keys (../framework/structures.md#encrypted-data-keys) in the
+             //# encryption materials (../framework/structures.md#encryption-
+             //# materials)
+             + (WriteEncryptedDataKeysSection(body.encryptedDataKeys)
+                //= compliance/client-apis/encrypt.txt#2.6.2
+                //# *  Content Type (../data-format/message-header.md#content-type): MUST
+                //# be 02 (../data-format/message-header.md#supported-content-types)
+                + (WriteContentType(body.contentType)
+                   //= compliance/client-apis/encrypt.txt#2.6.2
+                   //# *  Frame Length (../data-format/message-header.md#frame-length): MUST
+                   //# be the value of the frame size determined above.
+                   + (WriteUint32(body.frameLength)
+                      //= compliance/client-apis/encrypt.txt#2.6.2
+                      //# *  Algorithm Suite Data (../data-format/message-header.md#algorithm-
+                      //# suite-data): MUST be the value of the commit key (../framework/
+                      //# algorithm-suites.md#commit-key) derived according to the algorithm
+                      //# suites commit key derivation settings (../framework/algorithm-
+                      //# suites.md#algorithm-suites-commit-key-derivation-settings).
+                      + (Write(body.suiteData))))))))
   }
 
   function method {:vcs_split_on_every_assert} ReadV2HeaderBody(
@@ -123,14 +123,14 @@ module V2HeaderBody {
     assert |suiteData.data| == suite.commitment.outputKeyLength as nat;
 
     var body:V2HeaderBody := HeaderTypes.V2HeaderBody(
-      esdkSuiteId := esdkSuiteId.data,
-      messageId := messageId.data,
-      encryptionContext := encryptionContext.data,
-      encryptedDataKeys := encryptedDataKeys.data,
-      contentType := contentType.data,
-      frameLength := frameLength.data,
-      suiteData := suiteData.data
-    );
+                               esdkSuiteId := esdkSuiteId.data,
+                               messageId := messageId.data,
+                               encryptionContext := encryptionContext.data,
+                               encryptedDataKeys := encryptedDataKeys.data,
+                               contentType := contentType.data,
+                               frameLength := frameLength.data,
+                               suiteData := suiteData.data
+                             );
 
     assert version.tail.start - buffer.start == 1;
     assert esdkSuiteId.tail.start - version.tail.start == 2;
@@ -138,30 +138,30 @@ module V2HeaderBody {
     assert messageId.tail.start == buffer.start + headerBytesToAADStart;
 
     assert if IsExpandedAADSection(messageId.tail) then
-      IsV2ExpandedAADSection(buffer)
-    else
-      !IsV2ExpandedAADSection(buffer);
+        IsV2ExpandedAADSection(buffer)
+      else
+        !IsV2ExpandedAADSection(buffer);
 
     assert WriteMessageFormatVersion(version.data)
       + WriteESDKSuiteId(body.esdkSuiteId)
       + WriteMessageId(body.messageId)
-      <= buffer.bytes[buffer.start..];
+        <= buffer.bytes[buffer.start..];
 
     assert if IsV2ExpandedAADSection(buffer) then
-      WriteExpandedAADSection(body.encryptionContext) <= buffer.bytes[messageId.tail.start..]
-    else
-      WriteAADSection(body.encryptionContext) <= buffer.bytes[messageId.tail.start..];
+        WriteExpandedAADSection(body.encryptionContext) <= buffer.bytes[messageId.tail.start..]
+      else
+        WriteAADSection(body.encryptionContext) <= buffer.bytes[messageId.tail.start..];
 
     assert WriteEncryptedDataKeysSection(body.encryptedDataKeys)
       + WriteContentType(body.contentType)
       + WriteUint32(body.frameLength)
       + Write(body.suiteData)
-      <= buffer.bytes[encryptionContext.tail.start..];
+        <= buffer.bytes[encryptionContext.tail.start..];
 
     assert if IsV2ExpandedAADSection(buffer) then
-      WriteV2ExpandedAADSectionHeader(body) <= buffer.bytes[buffer.start..]
-    else
-      WriteV2HeaderBody(body) <= buffer.bytes[buffer.start..];
+        WriteV2ExpandedAADSectionHeader(body) <= buffer.bytes[buffer.start..]
+      else
+        WriteV2HeaderBody(body) <= buffer.bytes[buffer.start..];
 
     Success(SuccessfulRead(body, suiteData.tail))
   }
@@ -199,13 +199,13 @@ module V2HeaderBody {
     // with associativity of concatenation
     // (knowing that (a + b) + c == a + (b + c) ).
     // So manually adding the () helps make it clear.
-      WriteMessageFormatVersion(HeaderTypes.MessageFormatVersion.V2)
+    WriteMessageFormatVersion(HeaderTypes.MessageFormatVersion.V2)
     + (WriteESDKSuiteId(body.esdkSuiteId)
-    + (WriteMessageId(body.messageId)
-    + (WriteExpandedAADSection(body.encryptionContext)
-    + (WriteEncryptedDataKeysSection(body.encryptedDataKeys)
-    + (WriteContentType(body.contentType)
-    + (WriteUint32(body.frameLength)
-    + (Write(body.suiteData))))))))
+       + (WriteMessageId(body.messageId)
+          + (WriteExpandedAADSection(body.encryptionContext)
+             + (WriteEncryptedDataKeysSection(body.encryptedDataKeys)
+                + (WriteContentType(body.contentType)
+                   + (WriteUint32(body.frameLength)
+                      + (Write(body.suiteData))))))))
   }
 }

--- a/src/SDK/Serialize/V2HeaderBody.dfy
+++ b/src/SDK/Serialize/V2HeaderBody.dfy
@@ -123,14 +123,14 @@ module V2HeaderBody {
     assert |suiteData.data| == suite.commitment.outputKeyLength as nat;
 
     var body:V2HeaderBody := HeaderTypes.V2HeaderBody(
-                               esdkSuiteId := esdkSuiteId.data,
-                               messageId := messageId.data,
-                               encryptionContext := encryptionContext.data,
-                               encryptedDataKeys := encryptedDataKeys.data,
-                               contentType := contentType.data,
-                               frameLength := frameLength.data,
-                               suiteData := suiteData.data
-                             );
+      esdkSuiteId := esdkSuiteId.data,
+      messageId := messageId.data,
+      encryptionContext := encryptionContext.data,
+      encryptedDataKeys := encryptedDataKeys.data,
+      contentType := contentType.data,
+      frameLength := frameLength.data,
+      suiteData := suiteData.data
+    );
 
     assert version.tail.start - buffer.start == 1;
     assert esdkSuiteId.tail.start - version.tail.start == 2;

--- a/src/StandardLibrary/Actions.dfy
+++ b/src/StandardLibrary/Actions.dfy
@@ -54,16 +54,16 @@ module Actions {
     ensures
       forall i ::
         && 0 <= i < |s|
-      ==>
-        action.Ensures(s[i], res[i])
+        ==>
+          action.Ensures(s[i], res[i])
   {
     var rs := [];
     for i := 0 to |s|
       invariant |s[..i]| == |rs|
       invariant forall j ::
-        && 0 <= j < i
-      ==>
-        action.Ensures(s[j], rs[j])
+          && 0 <= j < i
+          ==>
+            action.Ensures(s[j], rs[j])
     {
       var r := action.Invoke(s[i]);
       rs := rs + [r];
@@ -82,23 +82,23 @@ module Actions {
     returns (res: Result<seq<R>, E>)
     ensures
       res.Success?
-    ==>
-      |s| == |res.value|
+      ==>
+        |s| == |res.value|
     ensures
       res.Success?
-    ==>
+      ==>
         (forall i ::
-          && 0 <= i < |s|
-        ==>
-          action.Ensures(s[i], Success(res.value[i])))
+           && 0 <= i < |s|
+           ==>
+             action.Ensures(s[i], Success(res.value[i])))
   {
     var rs := [];
     for i := 0 to |s|
       invariant |s[..i]| == |rs|
       invariant forall j ::
-        && 0 <= j < i
-      ==>
-        action.Ensures(s[j], Success(rs[j]))
+          && 0 <= j < i
+          ==>
+            action.Ensures(s[j], Success(rs[j]))
     {
       var r :- action.Invoke(s[i]);
       rs := rs + [r];
@@ -119,19 +119,19 @@ module Actions {
     returns (res: seq<R>)
     ensures
       forall i :: i in s
-      ==>
-        && exists fm :: action.Ensures(i, fm)
-        && forall k | k in fm :: k in res
+                  ==>
+                    && exists fm :: action.Ensures(i, fm)
+                                    && forall k | k in fm :: k in res
   {
     ghost var parts := [];
     var rs := [];
     for i := 0 to |s|
       invariant |s[..i]| == |parts|
       invariant forall j ::
-        && 0 <= j < i
-      ==>
-        && action.Ensures(s[j], parts[j])
-        && forall b | b in parts[j] :: b in rs
+          && 0 <= j < i
+          ==>
+            && action.Ensures(s[j], parts[j])
+            && forall b | b in parts[j] :: b in rs
     {
       var r := action.Invoke(s[i]);
       rs := rs + r;
@@ -154,24 +154,24 @@ module Actions {
     returns (res: Result<seq<R>, E>, ghost parts: seq<seq<R>>)
     ensures
       res.Success?
-    ==>
-      && |s| == |parts|
-      && res.value == Flatten(parts)
-      && (forall i :: 0 <= i < |s|
       ==>
-        && action.Ensures(s[i], Success(parts[i]))
-        && multiset(parts[i]) <= multiset(res.value)
-      )
+        && |s| == |parts|
+        && res.value == Flatten(parts)
+        && (forall i :: 0 <= i < |s|
+                        ==>
+                          && action.Ensures(s[i], Success(parts[i]))
+                          && multiset(parts[i]) <= multiset(res.value)
+           )
   {
     parts := [];
     var rs := [];
     for i := 0 to |s|
       invariant |s[..i]| == |parts|
       invariant forall j ::
-        && 0 <= j < i
-      ==>
-        && action.Ensures(s[j], Success(parts[j]))
-        && multiset(parts[j]) <= multiset(rs)
+          && 0 <= j < i
+          ==>
+            && action.Ensures(s[j], Success(parts[j]))
+            && multiset(parts[j]) <= multiset(rs)
       invariant Flatten(parts) == rs
     {
       var r :- action.Invoke(s[i]);
@@ -196,18 +196,18 @@ module Actions {
     ensures
       forall j ::
         j in res
-      ==>
-        && j in s
-        && action.Ensures(j, true)
+        ==>
+          && j in s
+          && action.Ensures(j, true)
   {
     var rs := [];
     for i := 0 to |s|
       invariant |s[..i]| >= |rs|
       invariant forall j ::
-        j in rs
-      ==>
-        && j in s
-        && action.Ensures(j, true)
+          j in rs
+          ==>
+            && j in s
+            && action.Ensures(j, true)
     {
       var r := action.Invoke(s[i]);
       if r {
@@ -227,22 +227,22 @@ module Actions {
     returns (res: Result<seq<A>, E>)
     ensures
       res.Success?
-    ==>
-      && |s| >= |res.value|
-      && forall j ::
-        j in res.value
       ==>
-        && j in s
-        && action.Ensures(j, Success(true))
+        && |s| >= |res.value|
+        && forall j ::
+             j in res.value
+             ==>
+               && j in s
+               && action.Ensures(j, Success(true))
   {
     var rs := [];
     for i := 0 to |s|
       invariant |s[..i]| >= |rs|
       invariant forall j ::
-        j in rs
-      ==>
-        && j in s
-        && action.Ensures(j, Success(true))
+          j in rs
+          ==>
+            && j in s
+            && action.Ensures(j, Success(true))
     {
       var r :- action.Invoke(s[i]);
       if r {
@@ -266,8 +266,8 @@ module Actions {
     returns (res: Result<B, seq<E>>)
     ensures
       res.Success?
-    ==>
-      exists a | a in s :: action.Ensures(a, Success(res.value))
+      ==>
+        exists a | a in s :: action.Ensures(a, Success(res.value))
   {
     var errors := [];
     for i := 0 to |s| {

--- a/src/StandardLibrary/Base64.dfy
+++ b/src/StandardLibrary/Base64.dfy
@@ -345,31 +345,31 @@ module Base64 {
     // All Base64 strings are unpadded until the final block of 4 elements, where a padded seq could exist
     var finalBlockStart := |s| - 4;
     (|s| % 4 == 0) &&
-      (IsUnpaddedBase64String(s) ||
-      (IsUnpaddedBase64String(s[..finalBlockStart]) && (Is1Padding(s[finalBlockStart..]) || Is2Padding(s[finalBlockStart..]))))
+    (IsUnpaddedBase64String(s) ||
+     (IsUnpaddedBase64String(s[..finalBlockStart]) && (Is1Padding(s[finalBlockStart..]) || Is2Padding(s[finalBlockStart..]))))
   }
 
   function method DecodeValid(s: seq<char>): (b: seq<uint8>)
     requires IsBase64String(s)
   {
     if s == [] then [] else
-      var finalBlockStart := |s| - 4;
-      var prefix, suffix := s[..finalBlockStart], s[finalBlockStart..];
-      if Is1Padding(suffix) then
-        DecodeUnpadded(prefix) + Decode1Padding(suffix)
-      else if Is2Padding(suffix) then
-        DecodeUnpadded(prefix) + Decode2Padding(suffix)
-      else
-        DecodeUnpadded(s)
+    var finalBlockStart := |s| - 4;
+    var prefix, suffix := s[..finalBlockStart], s[finalBlockStart..];
+    if Is1Padding(suffix) then
+      DecodeUnpadded(prefix) + Decode1Padding(suffix)
+    else if Is2Padding(suffix) then
+      DecodeUnpadded(prefix) + Decode2Padding(suffix)
+    else
+      DecodeUnpadded(s)
   }
 
   lemma AboutDecodeValid(s: seq<char>, b: seq<uint8>)
     requires IsBase64String(s) && b == DecodeValid(s)
     ensures 4 <= |s| ==> var finalBlockStart := |s| - 4;
-      var prefix, suffix := s[..finalBlockStart], s[finalBlockStart..];
-      && (Is1Padding(suffix) ==> |b| % 3 == 2)
-      && (Is2Padding(suffix) ==> |b| % 3 == 1)
-      && (!Is1Padding(suffix) && !Is2Padding(suffix) ==> |b| % 3 == 0)
+                         var prefix, suffix := s[..finalBlockStart], s[finalBlockStart..];
+                         && (Is1Padding(suffix) ==> |b| % 3 == 2)
+                         && (Is2Padding(suffix) ==> |b| % 3 == 1)
+                         && (!Is1Padding(suffix) && !Is2Padding(suffix) ==> |b| % 3 == 0)
   {
     if 4 <= |s| {
       var finalBlockStart := |s| - 4;
@@ -446,8 +446,8 @@ module Base64 {
 
   lemma EncodeLengthExact(b: seq<uint8>)
     ensures var s := Encode(b);
-      && (|b| % 3 == 0 ==> |s| == |b| / 3 * 4)
-      && (|b| % 3 != 0 ==> |s| == |b| / 3 * 4 + 4)
+            && (|b| % 3 == 0 ==> |s| == |b| / 3 * 4)
+            && (|b| % 3 != 0 ==> |s| == |b| / 3 * 4 + 4)
   {
     var s := Encode(b);
     if |b| % 3 == 0 {
@@ -491,7 +491,7 @@ module Base64 {
 
   lemma EncodeLengthBound(b: seq<uint8>)
     ensures var s := Encode(b);
-      |s| <= |b| / 3 * 4 + 4
+            |s| <= |b| / 3 * 4 + 4
   {
     EncodeLengthExact(b);
   }

--- a/src/StandardLibrary/StandardLibrary.dfy
+++ b/src/StandardLibrary/StandardLibrary.dfy
@@ -69,7 +69,7 @@ module StandardLibrary {
     requires elemIndex == |s| || s[elemIndex] == c
     ensures FindIndexMatching(s, c, start) == if elemIndex == |s| then None else Some(elemIndex)
     decreases elemIndex - start
-    {}
+  {}
 
   function method FindIndexMatching<T(==)>(s: seq<T>, c: T, i: nat): (index: Option<nat>)
     requires i <= |s|
@@ -179,17 +179,17 @@ module StandardLibrary {
     && (lengthOfCommonPrefix == |a| || (lengthOfCommonPrefix < |b| && less(a[lengthOfCommonPrefix], b[lengthOfCommonPrefix])))
   }
 
-   /*
-    * In order for the lexicographic ordering above to have the expected properties, the
-    * relation "less" must be trichotomous and transitive.
-    *
-    * For an ordering `less` to be _trichotomous_ means that for any two `x` and `y`,
-    * EXACTLY one of the following three conditions holds:
-    *   - less(x, y)
-    *   - x == y
-    *   - less(y, x)
-    * Note that being trichotomous implies being irreflexive.
-    */
+  /*
+   * In order for the lexicographic ordering above to have the expected properties, the
+   * relation "less" must be trichotomous and transitive.
+   *
+   * For an ordering `less` to be _trichotomous_ means that for any two `x` and `y`,
+   * EXACTLY one of the following three conditions holds:
+   *   - less(x, y)
+   *   - x == y
+   *   - less(y, x)
+   * Note that being trichotomous implies being irreflexive.
+   */
 
   predicate Trichotomous<T(!new)>(less: (T, T) -> bool) {
     (forall x, y :: less(x, y) || x == y || less(y, x)) &&  // at least one of the three

--- a/src/StandardLibrary/String.dfy
+++ b/src/StandardLibrary/String.dfy
@@ -3,9 +3,9 @@
 
 module StandardLibrary.String {
   export provides Int2String, Base10Int2String
-    
+
   const Base10: seq<char> := ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-  
+
   function method Int2Digits(n: int, base: int): (digits: seq<int>)
     requires base > 1
     requires n >= 0

--- a/src/StandardLibrary/UInt.dfy
+++ b/src/StandardLibrary/UInt.dfy
@@ -106,8 +106,8 @@ module StandardLibrary.UInt {
   function method UInt64ToSeq(x: uint64): (ret: seq<uint8>)
     ensures |ret| == 8
     ensures 0x100_0000_0000_0000 * ret[0] as uint64 + 0x1_0000_0000_0000 * ret[1] as uint64 +
-      0x100_0000_0000 * ret[2] as uint64 + 0x1_0000_0000 * ret[3] as uint64 + 0x100_0000 * ret[4] as uint64 +
-      0x1_0000 * ret[5] as uint64 + 0x100 * ret[6] as uint64 + ret[7] as uint64 == x
+            0x100_0000_0000 * ret[2] as uint64 + 0x1_0000_0000 * ret[3] as uint64 + 0x100_0000 * ret[4] as uint64 +
+            0x1_0000 * ret[5] as uint64 + 0x100 * ret[6] as uint64 + ret[7] as uint64 == x
   {
     var b0 := (x / 0x100_0000_0000_0000) as uint8;
     var x0 := x - (b0 as uint64 * 0x100_0000_0000_0000);
@@ -151,85 +151,85 @@ module StandardLibrary.UInt {
   lemma UInt64SeqSerialize(x: uint64, s: seq<uint8>)
     requires |s| == 8
     requires 0x100_0000_0000_0000 * s[0] as uint64
-      + 0x1_0000_0000_0000 * s[1] as uint64
-      + 0x100_0000_0000 * s[2] as uint64
-      + 0x1_0000_0000 * s[3] as uint64
-      + 0x100_0000 * s[4] as uint64
-      + 0x1_0000 * s[5] as uint64
-      + 0x100 * s[6] as uint64
-      + s[7] as uint64 == x
+             + 0x1_0000_0000_0000 * s[1] as uint64
+             + 0x100_0000_0000 * s[2] as uint64
+             + 0x1_0000_0000 * s[3] as uint64
+             + 0x100_0000 * s[4] as uint64
+             + 0x1_0000 * s[5] as uint64
+             + 0x100 * s[6] as uint64
+             + s[7] as uint64 == x
     ensures UInt64ToSeq(x) == s
   {
     calc {
       UInt64ToSeq(x);
     ==
       UInt64ToSeq(s[0] as uint64 * 0x100_0000_0000_0000
-      + s[1] as uint64 * 0x1_0000_0000_0000
-      + s[2] as uint64 * 0x100_0000_0000
-      + s[3] as uint64 * 0x1_0000_0000
-      + s[4] as uint64 * 0x100_0000
-      + s[5] as uint64 * 0x1_0000
-      + s[6] as uint64 * 0x100
-      + s[7] as uint64);
+                  + s[1] as uint64 * 0x1_0000_0000_0000
+                  + s[2] as uint64 * 0x100_0000_0000
+                  + s[3] as uint64 * 0x1_0000_0000
+                  + s[4] as uint64 * 0x100_0000
+                  + s[5] as uint64 * 0x1_0000
+                  + s[6] as uint64 * 0x100
+                  + s[7] as uint64);
     ==
       var b0 := ((s[0] as uint64 * 0x100_0000_0000_0000
-        + s[1] as uint64 * 0x1_0000_0000_0000
-        + s[2] as uint64 * 0x100_0000_0000
-        + s[3] as uint64 * 0x1_0000_0000
-        + s[4] as uint64 * 0x100_0000
-        + s[5] as uint64 * 0x1_0000
-        + s[6] as uint64 * 0x100
-        + s[7] as uint64) / 0x100_0000_0000_0000) as uint8;
+                  + s[1] as uint64 * 0x1_0000_0000_0000
+                  + s[2] as uint64 * 0x100_0000_0000
+                  + s[3] as uint64 * 0x1_0000_0000
+                  + s[4] as uint64 * 0x100_0000
+                  + s[5] as uint64 * 0x1_0000
+                  + s[6] as uint64 * 0x100
+                  + s[7] as uint64) / 0x100_0000_0000_0000) as uint8;
       assert b0 == s[0];
       var x0 := (s[0] as uint64 * 0x100_0000_0000_0000
-        + s[1] as uint64 * 0x1_0000_0000_0000
-        + s[2] as uint64 * 0x100_0000_0000
-        + s[3] as uint64 * 0x1_0000_0000
-        + s[4] as uint64 * 0x100_0000
-        + s[5] as uint64 * 0x1_0000
-        + s[6] as uint64 * 0x100
-        + s[7] as uint64) - (b0 as uint64 * 0x100_0000_0000_0000);
+                 + s[1] as uint64 * 0x1_0000_0000_0000
+                 + s[2] as uint64 * 0x100_0000_0000
+                 + s[3] as uint64 * 0x1_0000_0000
+                 + s[4] as uint64 * 0x100_0000
+                 + s[5] as uint64 * 0x1_0000
+                 + s[6] as uint64 * 0x100
+                 + s[7] as uint64) - (b0 as uint64 * 0x100_0000_0000_0000);
       assert x0 == (s[1] as uint64 * 0x1_0000_0000_0000
-        + s[2] as uint64 * 0x100_0000_0000
-        + s[3] as uint64 * 0x1_0000_0000
-        + s[4] as uint64 * 0x100_0000
-        + s[5] as uint64 * 0x1_0000
-        + s[6] as uint64 * 0x100
-        + s[7] as uint64);
+                    + s[2] as uint64 * 0x100_0000_0000
+                    + s[3] as uint64 * 0x1_0000_0000
+                    + s[4] as uint64 * 0x100_0000
+                    + s[5] as uint64 * 0x1_0000
+                    + s[6] as uint64 * 0x100
+                    + s[7] as uint64);
 
       var b1 := (x0 / 0x1_0000_0000_0000) as uint8;
       assert b1 == s[1];
       var x1 := x0 - (b1 as uint64 * 0x1_0000_0000_0000);
       assert x1 == (s[2] as uint64 * 0x100_0000_0000
-        + s[3] as uint64 * 0x1_0000_0000
-        + s[4] as uint64 * 0x100_0000
-        + s[5] as uint64 * 0x1_0000
-        + s[6] as uint64 * 0x100
-        + s[7] as uint64);
+                    + s[3] as uint64 * 0x1_0000_0000
+                    + s[4] as uint64 * 0x100_0000
+                    + s[5] as uint64 * 0x1_0000
+                    + s[6] as uint64 * 0x100
+                    + s[7] as uint64);
 
       var b2 := (x1 / 0x100_0000_0000) as uint8;
       assert b2 == s[2];
       var x2 := x1 - (b2 as uint64 * 0x100_0000_0000);
       assert x2 == (s[3] as uint64 * 0x1_0000_0000
-        + s[4] as uint64 * 0x100_0000
-        + s[5] as uint64 * 0x1_0000
-        + s[6] as uint64 * 0x100
-        + s[7] as uint64);
+                    + s[4] as uint64 * 0x100_0000
+                    + s[5] as uint64 * 0x1_0000
+                    + s[6] as uint64 * 0x100
+                    + s[7] as uint64);
 
       var b3 := (x2 / 0x1_0000_0000) as uint8;
       assert b3 == s[3];
       var x3 := x2 - (b3 as uint64 * 0x1_0000_0000);
       assert x3 == (s[4] as uint64 * 0x100_0000
-        + s[5] as uint64 * 0x1_0000
-        + s[6] as uint64 * 0x100
-        + s[7] as uint64);
+                    + s[5] as uint64 * 0x1_0000
+                    + s[6] as uint64 * 0x100
+                    + s[7] as uint64);
 
       var b4 := (x3 / 0x100_0000) as uint8;
       assert b4 == s[4];
       var x4 := x3 - (b4 as uint64 * 0x100_0000);
       assert x4 == (s[5] as uint64 * 0x1_0000
-        + s[6] as uint64 * 0x100
-        + s[7] as uint64);
+                    + s[6] as uint64 * 0x100
+                    + s[7] as uint64);
 
       var b5 := (x4 / 0x1_0000) as uint8;
       assert b5 == s[5];
@@ -295,8 +295,8 @@ module StandardLibrary.UInt {
     requires n < UINT32_LIMIT
     requires 4 <= |s|
     requires var suffixStartIndex := |s| - 4;
-      (s[suffixStartIndex..] == UInt32ToSeq(n as uint32)) &&
-      (forall i :: 0 <= i < suffixStartIndex ==> s[i] == 0)
+             (s[suffixStartIndex..] == UInt32ToSeq(n as uint32)) &&
+             (forall i :: 0 <= i < suffixStartIndex ==> s[i] == 0)
     ensures SeqToNat(s) == n
   {
     if |s| == 4 {
@@ -304,22 +304,22 @@ module StandardLibrary.UInt {
         SeqToNat(s);
       ==
         SeqToNat(s[..3])
-          * 0x100 + s[3] as nat;
+        * 0x100 + s[3] as nat;
       ==  { assert s[..3][..2] == s[..2] && s[..3][2] == s[2]; }
         (SeqToNat(s[..2])
-          * 0x100 + s[2] as nat)
-          * 0x100 + s[3] as nat;
+         * 0x100 + s[2] as nat)
+        * 0x100 + s[3] as nat;
       ==  { assert s[..2][..1] == s[..1] && s[..2][1] == s[1]; }
         ((SeqToNat(s[..1])
           * 0x100 + s[1] as nat)
-          * 0x100 + s[2] as nat)
-          * 0x100 + s[3] as nat;
+         * 0x100 + s[2] as nat)
+        * 0x100 + s[3] as nat;
       ==  { assert s[..1][..0] == s[..0] && s[..1][0] == s[0]; }
         (((SeqToNat(s[..0])
-          * 0x100 + s[0] as nat)
+           * 0x100 + s[0] as nat)
           * 0x100 + s[1] as nat)
-          * 0x100 + s[2] as nat)
-          * 0x100 + s[3] as nat;
+         * 0x100 + s[2] as nat)
+        * 0x100 + s[3] as nat;
       ==
         n;
       }

--- a/src/Util/Streams.dfy
+++ b/src/Util/Streams.dfy
@@ -145,8 +145,8 @@ module Streams {
       ensures Valid()
       ensures res.Failure? ==> unchanged(reader)
       ensures res.Success? ==>
-        && reader.pos == old(reader.pos) + 4
-        && UInt32ToSeq(res.value) == reader.data[old(reader.pos)..reader.pos]
+                && reader.pos == old(reader.pos) + 4
+                && UInt32ToSeq(res.value) == reader.data[old(reader.pos)..reader.pos]
     {
       var bytes :- reader.ReadExact(4);
       assert |bytes| == 4;

--- a/src/Util/UTF8.dfy
+++ b/src/Util/UTF8.dfy
@@ -51,9 +51,9 @@ module {:extern "UTF8"} UTF8 {
   {
     // Based on syntax detailed on https://tools.ietf.org/html/rfc3629#section-4
     ((s[0] == 0xE0) && (0xA0 <= s[1] <= 0xBF) && (0x80 <= s[2] <= 0xBF))
-      || ((0xE1 <= s[0] <= 0xEC) && (0x80 <= s[1] <= 0xBF) && (0x80 <= s[2] <= 0xBF))
-      || ((s[0] == 0xED) && (0x80 <= s[1] <= 0x9F) && (0x80 <= s[2] <= 0xBF))
-      || ((0xEE <= s[0] <= 0xEF) && (0x80 <= s[1] <= 0xBF) && (0x80 <= s[2] <= 0xBF))
+    || ((0xE1 <= s[0] <= 0xEC) && (0x80 <= s[1] <= 0xBF) && (0x80 <= s[2] <= 0xBF))
+    || ((s[0] == 0xED) && (0x80 <= s[1] <= 0x9F) && (0x80 <= s[2] <= 0xBF))
+    || ((0xEE <= s[0] <= 0xEF) && (0x80 <= s[1] <= 0xBF) && (0x80 <= s[2] <= 0xBF))
   }
 
   predicate method Uses4Bytes(s: seq<uint8>)
@@ -61,8 +61,8 @@ module {:extern "UTF8"} UTF8 {
   {
     // Based on syntax detailed on https://tools.ietf.org/html/rfc3629#section-4
     ((s[0] == 0xF0) && (0x90 <= s[1] <= 0xBF) && (0x80 <= s[2] <= 0xBF) && (0x80 <= s[3] <= 0xBF))
-      || ((0xF1 <= s[0] <= 0xF3) && (0x80 <= s[1] <= 0xBF) && (0x80 <= s[2] <= 0xBF) && (0x80 <= s[3] <= 0xBF))
-      || ((s[0] == 0xF4) && (0x80 <= s[1] <= 0x8F) && (0x80 <= s[2] <= 0xBF) && (0x80 <= s[3] <= 0xBF))
+    || ((0xF1 <= s[0] <= 0xF3) && (0x80 <= s[1] <= 0xBF) && (0x80 <= s[2] <= 0xBF) && (0x80 <= s[3] <= 0xBF))
+    || ((s[0] == 0xF4) && (0x80 <= s[1] <= 0x8F) && (0x80 <= s[2] <= 0xBF) && (0x80 <= s[3] <= 0xBF))
   }
 
   predicate method {:tailrecursion} ValidUTF8Range(a: seq<uint8>, lo: nat, hi: nat)

--- a/test/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeryring/TestAwsKmsEncryptedDataKeyFilter.dfy
+++ b/test/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeryring/TestAwsKmsEncryptedDataKeyFilter.dfy
@@ -12,12 +12,12 @@ include "../../../../Util/TestUtils.dfy"
 module TestAwsKmsEncryptedDataKeyFilter {
   import Aws.Crypto
   import MaterialProviders.AwsKmsDiscoveryKeyring
-  import opened TestUtils    
+  import opened TestUtils
   import opened UInt = StandardLibrary.UInt
   import opened Wrappers
   import opened Actions
-  import UTF8  
-  
+  import UTF8
+
   //= compliance/framework/aws-kms/aws-kms-discovery-keyring.txt#2.8
   //= type=test
   //# *  The provider info MUST be a valid AWS KMS ARN (aws-kms-key-
@@ -27,8 +27,8 @@ module TestAwsKmsEncryptedDataKeyFilter {
   {
     var discoveryFilter := GetDiscoveryFilter();
     var edkFilter := new AwsKmsDiscoveryKeyring.AwsKmsEncryptedDataKeyFilter(
-      Option.Some(discoveryFilter)
-    );
+          Option.Some(discoveryFilter)
+        );
     var badEdk := GetNonKeyEncryptedDataKey();
     var filterResult := Actions.FilterWithResult(edkFilter, [badEdk]);
     match filterResult {
@@ -48,25 +48,25 @@ module TestAwsKmsEncryptedDataKeyFilter {
   {
     var matchingEdk := GenerateMockEncryptedDataKey("aws-kms", SHARED_TEST_KEY_ARN);
     var mismatchEdkPartition := GenerateMockEncryptedDataKey(
-      "aws-kms",
-      "arn:aws-cn:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
-    );
+                                  "aws-kms",
+                                  "arn:aws-cn:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
+                                );
     var mismatchEdkAccount := GenerateMockEncryptedDataKey(
-      "aws-kms",
-      "arn:aws:kms:us-west-2:827585335069:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
-    );
+                                "aws-kms",
+                                "arn:aws:kms:us-west-2:827585335069:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
+                              );
     var mismatchEdkProviderId := GenerateMockEncryptedDataKey(
-      "aws",
-      SHARED_TEST_KEY_ARN
-    );
+                                   "aws",
+                                   SHARED_TEST_KEY_ARN
+                                 );
     var discoveryFilter := GetDiscoveryFilter();
     var edkFilter := new AwsKmsDiscoveryKeyring.AwsKmsEncryptedDataKeyFilter(
-      Option.Some(discoveryFilter)
-    );
+          Option.Some(discoveryFilter)
+        );
     var filterResult := Actions.FilterWithResult(
-      edkFilter,
-      [matchingEdk, mismatchEdkPartition, mismatchEdkAccount, mismatchEdkProviderId]
-    );
+                          edkFilter,
+                          [matchingEdk, mismatchEdkPartition, mismatchEdkAccount, mismatchEdkProviderId]
+                        );
     expect filterResult.Success?;
     expect |filterResult.value| == 1;
     expect filterResult.value[0] == matchingEdk;
@@ -75,22 +75,22 @@ module TestAwsKmsEncryptedDataKeyFilter {
   method GetDiscoveryFilter() returns (discoveryFilter: Crypto.DiscoveryFilter)
   {
     return Crypto.DiscoveryFilter(
-      ACCOUNT_IDS,
-      PARTITION
-    );
+             ACCOUNT_IDS,
+             PARTITION
+           );
   }
 
   method GetNonKeyEncryptedDataKey() returns (edk: Crypto.EncryptedDataKey)
   {
     edk := GenerateMockEncryptedDataKey(
-      "aws-kms",
-      "arn:aws:kms:us-west-2:658956600833:alias/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
-    );
+             "aws-kms",
+             "arn:aws:kms:us-west-2:658956600833:alias/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
+           );
   }
 
   method NoOp()
   {
     return;
   }
-  
+
 }

--- a/test/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeryring/TestAwsKmsEncryptedDataKeyFilter.dfy
+++ b/test/AwsCryptographicMaterialProviders/Keyrings/AwsKms/AwsKmsDiscoveryKeryring/TestAwsKmsEncryptedDataKeyFilter.dfy
@@ -27,8 +27,8 @@ module TestAwsKmsEncryptedDataKeyFilter {
   {
     var discoveryFilter := GetDiscoveryFilter();
     var edkFilter := new AwsKmsDiscoveryKeyring.AwsKmsEncryptedDataKeyFilter(
-          Option.Some(discoveryFilter)
-        );
+      Option.Some(discoveryFilter)
+    );
     var badEdk := GetNonKeyEncryptedDataKey();
     var filterResult := Actions.FilterWithResult(edkFilter, [badEdk]);
     match filterResult {
@@ -48,25 +48,25 @@ module TestAwsKmsEncryptedDataKeyFilter {
   {
     var matchingEdk := GenerateMockEncryptedDataKey("aws-kms", SHARED_TEST_KEY_ARN);
     var mismatchEdkPartition := GenerateMockEncryptedDataKey(
-                                  "aws-kms",
-                                  "arn:aws-cn:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
-                                );
+      "aws-kms",
+      "arn:aws-cn:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
+    );
     var mismatchEdkAccount := GenerateMockEncryptedDataKey(
-                                "aws-kms",
-                                "arn:aws:kms:us-west-2:827585335069:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
-                              );
+      "aws-kms",
+      "arn:aws:kms:us-west-2:827585335069:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
+    );
     var mismatchEdkProviderId := GenerateMockEncryptedDataKey(
-                                   "aws",
-                                   SHARED_TEST_KEY_ARN
-                                 );
+      "aws",
+      SHARED_TEST_KEY_ARN
+    );
     var discoveryFilter := GetDiscoveryFilter();
     var edkFilter := new AwsKmsDiscoveryKeyring.AwsKmsEncryptedDataKeyFilter(
-          Option.Some(discoveryFilter)
-        );
+      Option.Some(discoveryFilter)
+    );
     var filterResult := Actions.FilterWithResult(
-                          edkFilter,
-                          [matchingEdk, mismatchEdkPartition, mismatchEdkAccount, mismatchEdkProviderId]
-                        );
+      edkFilter,
+      [matchingEdk, mismatchEdkPartition, mismatchEdkAccount, mismatchEdkProviderId]
+    );
     expect filterResult.Success?;
     expect |filterResult.value| == 1;
     expect filterResult.value[0] == matchingEdk;
@@ -83,9 +83,9 @@ module TestAwsKmsEncryptedDataKeyFilter {
   method GetNonKeyEncryptedDataKey() returns (edk: Crypto.EncryptedDataKey)
   {
     edk := GenerateMockEncryptedDataKey(
-             "aws-kms",
-             "arn:aws:kms:us-west-2:658956600833:alias/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
-           );
+      "aws-kms",
+      "arn:aws:kms:us-west-2:658956600833:alias/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f"
+    );
   }
 
   method NoOp()

--- a/test/AwsCryptographicMaterialProviders/Keyrings/TestMultiKeyring.dfy
+++ b/test/AwsCryptographicMaterialProviders/Keyrings/TestMultiKeyring.dfy
@@ -49,8 +49,8 @@ module TestMultiKeyring {
     // directly get materials using the generator
     var rawAESKeyring := setupRawAesKeyring(encryptionContext);
     var expectedEncryptionMaterials := rawAESKeyring.OnEncrypt(
-                                         Crypto.OnEncryptInput(materials:=encryptionMaterials)
-                                       );
+      Crypto.OnEncryptInput(materials:=encryptionMaterials)
+    );
     expect expectedEncryptionMaterials.Success?;
     var expectedPlaintextDataKey := expectedEncryptionMaterials.value.materials.plaintextDataKey;
     expect expectedPlaintextDataKey.Some?;
@@ -58,9 +58,9 @@ module TestMultiKeyring {
     var staticKeyring := new StaticKeyring(Some(expectedEncryptionMaterials.value.materials), None());
 
     var multiKeyring := new MultiKeyring.MultiKeyring(
-          generatorKeyring := Some(staticKeyring),
-          childKeyrings := [rawAESKeyring]
-        );
+      generatorKeyring := Some(staticKeyring),
+      childKeyrings := [rawAESKeyring]
+    );
 
     var result := multiKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterials));
     expect result.Success?;
@@ -101,9 +101,9 @@ module TestMultiKeyring {
     var failingKeyring := new FailingKeyring();
 
     var multiKeyring := new MultiKeyring.MultiKeyring(
-          generatorKeyring := Some(rawAESKeyring),
-          childKeyrings := [failingKeyring]
-        );
+      generatorKeyring := Some(rawAESKeyring),
+      childKeyrings := [failingKeyring]
+    );
 
     var encryptionMaterials := getInputEncryptionMaterials(encryptionContext);
 
@@ -124,9 +124,9 @@ module TestMultiKeyring {
     var rawAESKeyring := setupRawAesKeyring(encryptionContext);
 
     var multiKeyring := new MultiKeyring.MultiKeyring(
-          generatorKeyring := Some(failingKeyring),
-          childKeyrings := [rawAESKeyring]
-        );
+      generatorKeyring := Some(failingKeyring),
+      childKeyrings := [rawAESKeyring]
+    );
 
     var encryptionMaterials := getInputEncryptionMaterials(encryptionContext);
 
@@ -144,9 +144,9 @@ module TestMultiKeyring {
     var failingKeyring := new StaticKeyring(Some(encryptionMaterials), None());
 
     var multiKeyring := new MultiKeyring.MultiKeyring(
-          generatorKeyring := Some(failingKeyring),
-          childKeyrings := []
-        );
+      generatorKeyring := Some(failingKeyring),
+      childKeyrings := []
+    );
 
     var result := multiKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterials));
     expect result.IsFailure();
@@ -172,13 +172,13 @@ module TestMultiKeyring {
     var failingKeyring := new FailingKeyring();
 
     var multiKeyring := new MultiKeyring.MultiKeyring(
-          generatorKeyring := Some(rawAESKeyring),
-          childKeyrings := [failingKeyring]
-        );
+      generatorKeyring := Some(rawAESKeyring),
+      childKeyrings := [failingKeyring]
+    );
 
     var onDecryptInput := Crypto.OnDecryptInput(
-                            materials := inputDecryptionMaterials, encryptedDataKeys := encryptionMaterials.value.materials.encryptedDataKeys
-                          );
+      materials := inputDecryptionMaterials, encryptedDataKeys := encryptionMaterials.value.materials.encryptedDataKeys
+    );
 
     var decryptionMaterials := multiKeyring.OnDecrypt(input:=onDecryptInput);
     expect decryptionMaterials.Success?;
@@ -218,13 +218,13 @@ module TestMultiKeyring {
     // For children, we add failing keyrings on both sides of the valid keyring so we exercise
     // all paths
     var multiKeyring := new MultiKeyring.MultiKeyring(
-          generatorKeyring := Some(failingKeyring),
-          childKeyrings := [failingKeyring, rawAESKeyring, failingKeyring]
-        );
+      generatorKeyring := Some(failingKeyring),
+      childKeyrings := [failingKeyring, rawAESKeyring, failingKeyring]
+    );
 
     var onDecryptInput := Crypto.OnDecryptInput(
-                            materials := inputDecryptionMaterials, encryptedDataKeys := encryptionMaterials.value.materials.encryptedDataKeys
-                          );
+      materials := inputDecryptionMaterials, encryptedDataKeys := encryptionMaterials.value.materials.encryptedDataKeys
+    );
 
     //= compliance/framework/multi-keyring.txt#2.7.2
     //= type=TODO
@@ -261,16 +261,16 @@ module TestMultiKeyring {
 
     var failingKeyring := new FailingKeyring();
     var multiKeyring := new MultiKeyring.MultiKeyring(
-          generatorKeyring := None(),
-          childKeyrings := [failingKeyring, failingKeyring]
-        );
+      generatorKeyring := None(),
+      childKeyrings := [failingKeyring, failingKeyring]
+    );
 
     var materials := Crypto.DecryptionMaterials(
-                       encryptionContext:=encryptionContext,
-                       algorithmSuiteId := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
-                       verificationKey := None(),
-                       plaintextDataKey:=None()
-                     );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
+      verificationKey := None(),
+      plaintextDataKey:=None()
+    );
 
     var result := multiKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=materials, encryptedDataKeys:=[]));
     expect result.IsFailure();
@@ -280,14 +280,14 @@ module TestMultiKeyring {
   method setupRawAesKeyring(encryptionContext: Crypto.EncryptionContext) returns (res: Crypto.IKeyring) {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-          namespace,
-          name,
-          seq(32, i => 0),
-          AESEncryption.AES_GCM(
-          keyLength := 32 as AESEncryption.KeyLength,
-          tagLength := 16 as AESEncryption.TagLength,
-          ivLength := 12 as AESEncryption.IVLength
-          ));
+      namespace,
+      name,
+      seq(32, i => 0),
+      AESEncryption.AES_GCM(
+      keyLength := 32 as AESEncryption.KeyLength,
+      tagLength := 16 as AESEncryption.TagLength,
+      ivLength := 12 as AESEncryption.IVLength
+      ));
     return rawAESKeyring;
   }
 

--- a/test/AwsCryptographicMaterialProviders/Keyrings/TestMultiKeyring.dfy
+++ b/test/AwsCryptographicMaterialProviders/Keyrings/TestMultiKeyring.dfy
@@ -22,21 +22,21 @@ module TestMultiKeyring {
 
   method getInputEncryptionMaterials(encryptionContext: Crypto.EncryptionContext) returns (res: Crypto.EncryptionMaterials) {
     return Crypto.EncryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
-      signingKey := None(),
-      plaintextDataKey:=None(),
-      encryptedDataKeys:=[]
-    );
+             encryptionContext:=encryptionContext,
+             algorithmSuiteId := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
+             signingKey := None(),
+             plaintextDataKey:=None(),
+             encryptedDataKeys:=[]
+           );
   }
 
   method getInputDecryptionMaterials(encryptionContext: Crypto.EncryptionContext) returns (res: Crypto.DecryptionMaterials) {
     return Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
-      verificationKey := None(),
-      plaintextDataKey:=None()
-    );
+             encryptionContext:=encryptionContext,
+             algorithmSuiteId := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
+             verificationKey := None(),
+             plaintextDataKey:=None()
+           );
   }
 
   method {:test} TestHappyCase()
@@ -49,8 +49,8 @@ module TestMultiKeyring {
     // directly get materials using the generator
     var rawAESKeyring := setupRawAesKeyring(encryptionContext);
     var expectedEncryptionMaterials := rawAESKeyring.OnEncrypt(
-      Crypto.OnEncryptInput(materials:=encryptionMaterials)
-    );
+                                         Crypto.OnEncryptInput(materials:=encryptionMaterials)
+                                       );
     expect expectedEncryptionMaterials.Success?;
     var expectedPlaintextDataKey := expectedEncryptionMaterials.value.materials.plaintextDataKey;
     expect expectedPlaintextDataKey.Some?;
@@ -58,9 +58,9 @@ module TestMultiKeyring {
     var staticKeyring := new StaticKeyring(Some(expectedEncryptionMaterials.value.materials), None());
 
     var multiKeyring := new MultiKeyring.MultiKeyring(
-        generatorKeyring := Some(staticKeyring),
-        childKeyrings := [rawAESKeyring]
-    );
+          generatorKeyring := Some(staticKeyring),
+          childKeyrings := [rawAESKeyring]
+        );
 
     var result := multiKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterials));
     expect result.Success?;
@@ -101,9 +101,9 @@ module TestMultiKeyring {
     var failingKeyring := new FailingKeyring();
 
     var multiKeyring := new MultiKeyring.MultiKeyring(
-        generatorKeyring := Some(rawAESKeyring),
-        childKeyrings := [failingKeyring]
-    );
+          generatorKeyring := Some(rawAESKeyring),
+          childKeyrings := [failingKeyring]
+        );
 
     var encryptionMaterials := getInputEncryptionMaterials(encryptionContext);
 
@@ -124,9 +124,9 @@ module TestMultiKeyring {
     var rawAESKeyring := setupRawAesKeyring(encryptionContext);
 
     var multiKeyring := new MultiKeyring.MultiKeyring(
-        generatorKeyring := Some(failingKeyring),
-        childKeyrings := [rawAESKeyring]
-    );
+          generatorKeyring := Some(failingKeyring),
+          childKeyrings := [rawAESKeyring]
+        );
 
     var encryptionMaterials := getInputEncryptionMaterials(encryptionContext);
 
@@ -144,9 +144,9 @@ module TestMultiKeyring {
     var failingKeyring := new StaticKeyring(Some(encryptionMaterials), None());
 
     var multiKeyring := new MultiKeyring.MultiKeyring(
-        generatorKeyring := Some(failingKeyring),
-        childKeyrings := []
-    );
+          generatorKeyring := Some(failingKeyring),
+          childKeyrings := []
+        );
 
     var result := multiKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterials));
     expect result.IsFailure();
@@ -172,13 +172,13 @@ module TestMultiKeyring {
     var failingKeyring := new FailingKeyring();
 
     var multiKeyring := new MultiKeyring.MultiKeyring(
-        generatorKeyring := Some(rawAESKeyring),
-        childKeyrings := [failingKeyring]
-    );
+          generatorKeyring := Some(rawAESKeyring),
+          childKeyrings := [failingKeyring]
+        );
 
     var onDecryptInput := Crypto.OnDecryptInput(
-      materials := inputDecryptionMaterials, encryptedDataKeys := encryptionMaterials.value.materials.encryptedDataKeys
-    );
+                            materials := inputDecryptionMaterials, encryptedDataKeys := encryptionMaterials.value.materials.encryptedDataKeys
+                          );
 
     var decryptionMaterials := multiKeyring.OnDecrypt(input:=onDecryptInput);
     expect decryptionMaterials.Success?;
@@ -218,13 +218,13 @@ module TestMultiKeyring {
     // For children, we add failing keyrings on both sides of the valid keyring so we exercise
     // all paths
     var multiKeyring := new MultiKeyring.MultiKeyring(
-        generatorKeyring := Some(failingKeyring),
-        childKeyrings := [failingKeyring, rawAESKeyring, failingKeyring]
-    );
+          generatorKeyring := Some(failingKeyring),
+          childKeyrings := [failingKeyring, rawAESKeyring, failingKeyring]
+        );
 
     var onDecryptInput := Crypto.OnDecryptInput(
-      materials := inputDecryptionMaterials, encryptedDataKeys := encryptionMaterials.value.materials.encryptedDataKeys
-    );
+                            materials := inputDecryptionMaterials, encryptedDataKeys := encryptionMaterials.value.materials.encryptedDataKeys
+                          );
 
     //= compliance/framework/multi-keyring.txt#2.7.2
     //= type=TODO
@@ -261,16 +261,16 @@ module TestMultiKeyring {
 
     var failingKeyring := new FailingKeyring();
     var multiKeyring := new MultiKeyring.MultiKeyring(
-        generatorKeyring := None(),
-        childKeyrings := [failingKeyring, failingKeyring]
-    );
+          generatorKeyring := None(),
+          childKeyrings := [failingKeyring, failingKeyring]
+        );
 
     var materials := Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
-      verificationKey := None(),
-      plaintextDataKey:=None()
-    );
+                       encryptionContext:=encryptionContext,
+                       algorithmSuiteId := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256,
+                       verificationKey := None(),
+                       plaintextDataKey:=None()
+                     );
 
     var result := multiKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=materials, encryptedDataKeys:=[]));
     expect result.IsFailure();
@@ -280,14 +280,14 @@ module TestMultiKeyring {
   method setupRawAesKeyring(encryptionContext: Crypto.EncryptionContext) returns (res: Crypto.IKeyring) {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-      namespace,
-      name,
-      seq(32, i => 0),
-      AESEncryption.AES_GCM(
-        keyLength := 32 as AESEncryption.KeyLength,
-        tagLength := 16 as AESEncryption.TagLength,
-        ivLength := 12 as AESEncryption.IVLength
-      ));
+          namespace,
+          name,
+          seq(32, i => 0),
+          AESEncryption.AES_GCM(
+          keyLength := 32 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+          ));
     return rawAESKeyring;
   }
 

--- a/test/AwsCryptographicMaterialProviders/Keyrings/TestRawAESKeyring.dfy
+++ b/test/AwsCryptographicMaterialProviders/Keyrings/TestRawAESKeyring.dfy
@@ -26,24 +26,24 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-      namespace,
-      name,
-      seq(32, i => 0),
-      AESEncryption.AES_GCM(
-        keyLength := 32 as AESEncryption.KeyLength,
-        tagLength := 16 as AESEncryption.TagLength,
-        ivLength := 12 as AESEncryption.IVLength
-      ));
+          namespace,
+          name,
+          seq(32, i => 0),
+          AESEncryption.AES_GCM(
+          keyLength := 32 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+          ));
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=None(),
-      encryptedDataKeys:=[],
-      signingKey:=None()
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=None(),
+                                   encryptedDataKeys:=[],
+                                   signingKey:=None()
+                                 );
     var encryptionMaterialsOut :- expect rawAESKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterialsIn));
 
     //= compliance/framework/raw-aes-keyring.txt#2.7.1
@@ -62,11 +62,11 @@ module TestRawAESKeyring {
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=None(),
-      verificationKey:=None()
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=None(),
+                                   verificationKey:=None()
+                                 );
     var decryptionMaterialsOut :- expect rawAESKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk]));
 
     //= compliance/framework/raw-aes-keyring.txt#2.7.2
@@ -81,37 +81,37 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-      namespace,
-      name,
-      seq(32, i => 0),
-      AESEncryption.AES_GCM(
-        keyLength := 32 as AESEncryption.KeyLength,
-        tagLength := 16 as AESEncryption.TagLength,
-        ivLength := 12 as AESEncryption.IVLength
-      ));
+          namespace,
+          name,
+          seq(32, i => 0),
+          AESEncryption.AES_GCM(
+          keyLength := 32 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+          ));
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
 
     var pdk := seq(32, i => 0);
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Some(pdk),
-      encryptedDataKeys:=[],
-      signingKey:=None()
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Some(pdk),
+                                   encryptedDataKeys:=[],
+                                   signingKey:=None()
+                                 );
     var encryptionMaterialsOut :- expect rawAESKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterialsIn));
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
 
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=None(),
-      verificationKey:=None()
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=None(),
+                                   verificationKey:=None()
+                                 );
     var decryptionMaterialsOut :- expect rawAESKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk]));
 
     //= compliance/framework/raw-aes-keyring.txt#2.7.1
@@ -122,29 +122,29 @@ module TestRawAESKeyring {
     expect decryptionMaterialsOut.materials.plaintextDataKey == Some(pdk);
   }
 
-    method {:test} TestOnDecryptKeyNameMismatch()
+  method {:test} TestOnDecryptKeyNameMismatch()
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-      namespace,
-      name,
-      seq(32, i => 0),
-      AESEncryption.AES_GCM(
-        keyLength := 32 as AESEncryption.KeyLength,
-        tagLength := 16 as AESEncryption.TagLength,
-        ivLength := 12 as AESEncryption.IVLength
-      ));
+          namespace,
+          name,
+          seq(32, i => 0),
+          AESEncryption.AES_GCM(
+          keyLength := 32 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+          ));
 
     var mismatchName :- expect UTF8.Encode("mismatched");
     var mismatchedAESKeyring := new RawAESKeyring.RawAESKeyring(
-      namespace,
-      mismatchName,
-      seq(32, i => 0),
-      AESEncryption.AES_GCM(
-        keyLength := 32 as AESEncryption.KeyLength,
-        tagLength := 16 as AESEncryption.TagLength,
-        ivLength := 12 as AESEncryption.IVLength
-      ));
+          namespace,
+          mismatchName,
+          seq(32, i => 0),
+          AESEncryption.AES_GCM(
+          keyLength := 32 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+          ));
 
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
 
@@ -152,23 +152,23 @@ module TestRawAESKeyring {
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Some(pdk),
-      encryptedDataKeys:=[],
-      signingKey:=None()
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Some(pdk),
+                                   encryptedDataKeys:=[],
+                                   signingKey:=None()
+                                 );
     var encryptionMaterialsOut :- expect mismatchedAESKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterialsIn));
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
 
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=None(),
-      verificationKey:=None()
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=None(),
+                                   verificationKey:=None()
+                                 );
     var decryptionMaterialsOut := rawAESKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk]));
     expect decryptionMaterialsOut.IsFailure();
   }
@@ -177,47 +177,47 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-      namespace,
-      name,
-      seq(32, i => 0),
-      AESEncryption.AES_GCM(
-        keyLength := 32 as AESEncryption.KeyLength,
-        tagLength := 16 as AESEncryption.TagLength,
-        ivLength := 12 as AESEncryption.IVLength
-      ));
+          namespace,
+          name,
+          seq(32, i => 0),
+          AESEncryption.AES_GCM(
+          keyLength := 32 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+          ));
     var pdk := seq(32, i => 0);
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_NO_KDF;
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Some(pdk),
-      encryptedDataKeys:=[],
-      signingKey:=None()
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Some(pdk),
+                                   encryptedDataKeys:=[],
+                                   signingKey:=None()
+                                 );
     var encryptionMaterialsOut :- expect rawAESKeyring.OnEncrypt(
-      Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
-    );
+                                           Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
+                                         );
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=None(),
-      verificationKey:=None()
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=None(),
+                                   verificationKey:=None()
+                                 );
     var fakeEdk: Crypto.EncryptedDataKey := Crypto.EncryptedDataKey(
-      keyProviderId := edk.keyProviderId,
-      keyProviderInfo := edk.keyProviderInfo,
-      ciphertext := seq(|edk.ciphertext|, i => 0)
-    );
+                                              keyProviderId := edk.keyProviderId,
+                                              keyProviderInfo := edk.keyProviderInfo,
+                                              ciphertext := seq(|edk.ciphertext|, i => 0)
+                                            );
     var decryptionMaterialsOut :- expect rawAESKeyring.OnDecrypt(
-      Crypto.OnDecryptInput(
-        materials:=decryptionMaterialsIn,
-        encryptedDataKeys:=[fakeEdk, edk]
-      )
-    );
+                                           Crypto.OnDecryptInput(
+                                             materials:=decryptionMaterialsIn,
+                                             encryptedDataKeys:=[fakeEdk, edk]
+                                           )
+                                         );
     expect decryptionMaterialsOut.materials.plaintextDataKey == Some(pdk);
   }
 
@@ -234,23 +234,23 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-      namespace,
-      name,
-      seq(32, i => 0),
-      AESEncryption.AES_GCM(
-        keyLength := 32 as AESEncryption.KeyLength,
-        tagLength := 16 as AESEncryption.TagLength,
-        ivLength := 12 as AESEncryption.IVLength
-      ));
+          namespace,
+          name,
+          seq(32, i => 0),
+          AESEncryption.AES_GCM(
+          keyLength := 32 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+          ));
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384;
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
     var verificationKey := seq(32, i => 0);
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=None(),
-      verificationKey:=Some(verificationKey)
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=None(),
+                                   verificationKey:=Some(verificationKey)
+                                 );
     var decryptionMaterialsOut := rawAESKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[]));
     expect decryptionMaterialsOut.IsFailure();
   }
@@ -267,25 +267,25 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-      namespace,
-      name,
-      seq(32, i => 0),
-      AESEncryption.AES_GCM(
-        keyLength := 32 as AESEncryption.KeyLength,
-        tagLength := 16 as AESEncryption.TagLength,
-        ivLength := 12 as AESEncryption.IVLength
-      ));
+          namespace,
+          name,
+          seq(32, i => 0),
+          AESEncryption.AES_GCM(
+          keyLength := 32 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+          ));
     var unserializableEncryptionContext := generateUnserializableEncryptionContext();
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384;
     var signingKey := seq(32, i => 0);
-        var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-      encryptionContext:=unserializableEncryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=None(),
-      encryptedDataKeys:=[],
-      signingKey:=Some(signingKey)
-    );
+    var encryptionMaterialsIn := Crypto.EncryptionMaterials(
+                                   encryptionContext:=unserializableEncryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=None(),
+                                   encryptedDataKeys:=[],
+                                   signingKey:=Some(signingKey)
+                                 );
     var encryptionMaterialsOut := rawAESKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterialsIn));
     expect encryptionMaterialsOut.Failure?;
   }
@@ -303,22 +303,22 @@ module TestRawAESKeyring {
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-      namespace,
-      name,
-      seq(32, i => 0),
-      AESEncryption.AES_GCM(
-        keyLength := 32 as AESEncryption.KeyLength,
-        tagLength := 16 as AESEncryption.TagLength,
-        ivLength := 12 as AESEncryption.IVLength
-      ));
+          namespace,
+          name,
+          seq(32, i => 0),
+          AESEncryption.AES_GCM(
+          keyLength := 32 as AESEncryption.KeyLength,
+          tagLength := 16 as AESEncryption.TagLength,
+          ivLength := 12 as AESEncryption.IVLength
+          ));
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=None(),
-      encryptedDataKeys:=[],
-      signingKey:=None()
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=None(),
+                                   encryptedDataKeys:=[],
+                                   signingKey:=None()
+                                 );
     var encryptionMaterialsOut :- expect rawAESKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterialsIn));
     expect encryptionMaterialsOut.materials.plaintextDataKey.Some?;
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
@@ -328,11 +328,11 @@ module TestRawAESKeyring {
     var unserializableEncryptionContext := generateUnserializableEncryptionContext();
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-      encryptionContext:=unserializableEncryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=None(),
-      verificationKey:=None()
-    );
+                                   encryptionContext:=unserializableEncryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=None(),
+                                   verificationKey:=None()
+                                 );
     var decryptionMaterialsOut := rawAESKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk]));
     expect decryptionMaterialsOut.Failure?;
   }

--- a/test/AwsCryptographicMaterialProviders/Keyrings/TestRawAESKeyring.dfy
+++ b/test/AwsCryptographicMaterialProviders/Keyrings/TestRawAESKeyring.dfy
@@ -26,24 +26,24 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-          namespace,
-          name,
-          seq(32, i => 0),
-          AESEncryption.AES_GCM(
-          keyLength := 32 as AESEncryption.KeyLength,
-          tagLength := 16 as AESEncryption.TagLength,
-          ivLength := 12 as AESEncryption.IVLength
-          ));
+      namespace,
+      name,
+      seq(32, i => 0),
+      AESEncryption.AES_GCM(
+      keyLength := 32 as AESEncryption.KeyLength,
+      tagLength := 16 as AESEncryption.TagLength,
+      ivLength := 12 as AESEncryption.IVLength
+      ));
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=None(),
-                                   encryptedDataKeys:=[],
-                                   signingKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=None(),
+      encryptedDataKeys:=[],
+      signingKey:=None()
+    );
     var encryptionMaterialsOut :- expect rawAESKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterialsIn));
 
     //= compliance/framework/raw-aes-keyring.txt#2.7.1
@@ -62,11 +62,11 @@ module TestRawAESKeyring {
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=None(),
-                                   verificationKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=None(),
+      verificationKey:=None()
+    );
     var decryptionMaterialsOut :- expect rawAESKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk]));
 
     //= compliance/framework/raw-aes-keyring.txt#2.7.2
@@ -81,37 +81,37 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-          namespace,
-          name,
-          seq(32, i => 0),
-          AESEncryption.AES_GCM(
-          keyLength := 32 as AESEncryption.KeyLength,
-          tagLength := 16 as AESEncryption.TagLength,
-          ivLength := 12 as AESEncryption.IVLength
-          ));
+      namespace,
+      name,
+      seq(32, i => 0),
+      AESEncryption.AES_GCM(
+      keyLength := 32 as AESEncryption.KeyLength,
+      tagLength := 16 as AESEncryption.TagLength,
+      ivLength := 12 as AESEncryption.IVLength
+      ));
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
 
     var pdk := seq(32, i => 0);
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Some(pdk),
-                                   encryptedDataKeys:=[],
-                                   signingKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Some(pdk),
+      encryptedDataKeys:=[],
+      signingKey:=None()
+    );
     var encryptionMaterialsOut :- expect rawAESKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterialsIn));
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
 
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=None(),
-                                   verificationKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=None(),
+      verificationKey:=None()
+    );
     var decryptionMaterialsOut :- expect rawAESKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk]));
 
     //= compliance/framework/raw-aes-keyring.txt#2.7.1
@@ -126,25 +126,25 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-          namespace,
-          name,
-          seq(32, i => 0),
-          AESEncryption.AES_GCM(
-          keyLength := 32 as AESEncryption.KeyLength,
-          tagLength := 16 as AESEncryption.TagLength,
-          ivLength := 12 as AESEncryption.IVLength
-          ));
+      namespace,
+      name,
+      seq(32, i => 0),
+      AESEncryption.AES_GCM(
+      keyLength := 32 as AESEncryption.KeyLength,
+      tagLength := 16 as AESEncryption.TagLength,
+      ivLength := 12 as AESEncryption.IVLength
+      ));
 
     var mismatchName :- expect UTF8.Encode("mismatched");
     var mismatchedAESKeyring := new RawAESKeyring.RawAESKeyring(
-          namespace,
-          mismatchName,
-          seq(32, i => 0),
-          AESEncryption.AES_GCM(
-          keyLength := 32 as AESEncryption.KeyLength,
-          tagLength := 16 as AESEncryption.TagLength,
-          ivLength := 12 as AESEncryption.IVLength
-          ));
+      namespace,
+      mismatchName,
+      seq(32, i => 0),
+      AESEncryption.AES_GCM(
+      keyLength := 32 as AESEncryption.KeyLength,
+      tagLength := 16 as AESEncryption.TagLength,
+      ivLength := 12 as AESEncryption.IVLength
+      ));
 
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
 
@@ -152,23 +152,23 @@ module TestRawAESKeyring {
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Some(pdk),
-                                   encryptedDataKeys:=[],
-                                   signingKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Some(pdk),
+      encryptedDataKeys:=[],
+      signingKey:=None()
+    );
     var encryptionMaterialsOut :- expect mismatchedAESKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterialsIn));
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
 
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=None(),
-                                   verificationKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=None(),
+      verificationKey:=None()
+    );
     var decryptionMaterialsOut := rawAESKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk]));
     expect decryptionMaterialsOut.IsFailure();
   }
@@ -177,24 +177,24 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-          namespace,
-          name,
-          seq(32, i => 0),
-          AESEncryption.AES_GCM(
-          keyLength := 32 as AESEncryption.KeyLength,
-          tagLength := 16 as AESEncryption.TagLength,
-          ivLength := 12 as AESEncryption.IVLength
-          ));
+      namespace,
+      name,
+      seq(32, i => 0),
+      AESEncryption.AES_GCM(
+      keyLength := 32 as AESEncryption.KeyLength,
+      tagLength := 16 as AESEncryption.TagLength,
+      ivLength := 12 as AESEncryption.IVLength
+      ));
     var pdk := seq(32, i => 0);
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_NO_KDF;
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Some(pdk),
-                                   encryptedDataKeys:=[],
-                                   signingKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Some(pdk),
+      encryptedDataKeys:=[],
+      signingKey:=None()
+    );
     var encryptionMaterialsOut :- expect rawAESKeyring.OnEncrypt(
                                            Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
                                          );
@@ -202,16 +202,16 @@ module TestRawAESKeyring {
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=None(),
-                                   verificationKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=None(),
+      verificationKey:=None()
+    );
     var fakeEdk: Crypto.EncryptedDataKey := Crypto.EncryptedDataKey(
-                                              keyProviderId := edk.keyProviderId,
-                                              keyProviderInfo := edk.keyProviderInfo,
-                                              ciphertext := seq(|edk.ciphertext|, i => 0)
-                                            );
+      keyProviderId := edk.keyProviderId,
+      keyProviderInfo := edk.keyProviderInfo,
+      ciphertext := seq(|edk.ciphertext|, i => 0)
+    );
     var decryptionMaterialsOut :- expect rawAESKeyring.OnDecrypt(
                                            Crypto.OnDecryptInput(
                                              materials:=decryptionMaterialsIn,
@@ -234,23 +234,23 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-          namespace,
-          name,
-          seq(32, i => 0),
-          AESEncryption.AES_GCM(
-          keyLength := 32 as AESEncryption.KeyLength,
-          tagLength := 16 as AESEncryption.TagLength,
-          ivLength := 12 as AESEncryption.IVLength
-          ));
+      namespace,
+      name,
+      seq(32, i => 0),
+      AESEncryption.AES_GCM(
+      keyLength := 32 as AESEncryption.KeyLength,
+      tagLength := 16 as AESEncryption.TagLength,
+      ivLength := 12 as AESEncryption.IVLength
+      ));
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384;
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
     var verificationKey := seq(32, i => 0);
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=None(),
-                                   verificationKey:=Some(verificationKey)
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=None(),
+      verificationKey:=Some(verificationKey)
+    );
     var decryptionMaterialsOut := rawAESKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[]));
     expect decryptionMaterialsOut.IsFailure();
   }
@@ -267,25 +267,25 @@ module TestRawAESKeyring {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-          namespace,
-          name,
-          seq(32, i => 0),
-          AESEncryption.AES_GCM(
-          keyLength := 32 as AESEncryption.KeyLength,
-          tagLength := 16 as AESEncryption.TagLength,
-          ivLength := 12 as AESEncryption.IVLength
-          ));
+      namespace,
+      name,
+      seq(32, i => 0),
+      AESEncryption.AES_GCM(
+      keyLength := 32 as AESEncryption.KeyLength,
+      tagLength := 16 as AESEncryption.TagLength,
+      ivLength := 12 as AESEncryption.IVLength
+      ));
     var unserializableEncryptionContext := generateUnserializableEncryptionContext();
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384;
     var signingKey := seq(32, i => 0);
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-                                   encryptionContext:=unserializableEncryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=None(),
-                                   encryptedDataKeys:=[],
-                                   signingKey:=Some(signingKey)
-                                 );
+      encryptionContext:=unserializableEncryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=None(),
+      encryptedDataKeys:=[],
+      signingKey:=Some(signingKey)
+    );
     var encryptionMaterialsOut := rawAESKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterialsIn));
     expect encryptionMaterialsOut.Failure?;
   }
@@ -303,22 +303,22 @@ module TestRawAESKeyring {
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
     var namespace, name := TestUtils.NamespaceAndName(0);
     var rawAESKeyring := new RawAESKeyring.RawAESKeyring(
-          namespace,
-          name,
-          seq(32, i => 0),
-          AESEncryption.AES_GCM(
-          keyLength := 32 as AESEncryption.KeyLength,
-          tagLength := 16 as AESEncryption.TagLength,
-          ivLength := 12 as AESEncryption.IVLength
-          ));
+      namespace,
+      name,
+      seq(32, i => 0),
+      AESEncryption.AES_GCM(
+      keyLength := 32 as AESEncryption.KeyLength,
+      tagLength := 16 as AESEncryption.TagLength,
+      ivLength := 12 as AESEncryption.IVLength
+      ));
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_HKDF_SHA256;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=None(),
-                                   encryptedDataKeys:=[],
-                                   signingKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=None(),
+      encryptedDataKeys:=[],
+      signingKey:=None()
+    );
     var encryptionMaterialsOut :- expect rawAESKeyring.OnEncrypt(Crypto.OnEncryptInput(materials:=encryptionMaterialsIn));
     expect encryptionMaterialsOut.materials.plaintextDataKey.Some?;
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
@@ -328,11 +328,11 @@ module TestRawAESKeyring {
     var unserializableEncryptionContext := generateUnserializableEncryptionContext();
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-                                   encryptionContext:=unserializableEncryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=None(),
-                                   verificationKey:=None()
-                                 );
+      encryptionContext:=unserializableEncryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=None(),
+      verificationKey:=None()
+    );
     var decryptionMaterialsOut := rawAESKeyring.OnDecrypt(Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk]));
     expect decryptionMaterialsOut.Failure?;
   }

--- a/test/AwsCryptographicMaterialProviders/Keyrings/TestRawRSAKeyring.dfy
+++ b/test/AwsCryptographicMaterialProviders/Keyrings/TestRawRSAKeyring.dfy
@@ -26,103 +26,103 @@ module TestRawRSAKeying {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var publicKey, privateKey, rawRSAKeyring := GenerateKeyPairAndKeyring(
-      namespace,
-      name,
-      2048 as RSAEncryption.StrengthBits,
-      RSAEncryption.PaddingMode.OAEP_SHA1
-    );
+                                                  namespace,
+                                                  name,
+                                                  2048 as RSAEncryption.StrengthBits,
+                                                  RSAEncryption.PaddingMode.OAEP_SHA1
+                                                );
     var encryptionContext := TestUtils.SmallEncryptionContext(
-      TestUtils.SmallEncryptionContextVariation.A
-    );
+                               TestUtils.SmallEncryptionContextVariation.A
+                             );
     var pdk := seq(32, i => 0);
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_NO_KDF;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Some(pdk),
-      encryptedDataKeys:=[],
-      signingKey:=None()
-    );
-    expect Materials.ValidEncryptionMaterials(encryptionMaterialsIn);  
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Some(pdk),
+                                   encryptedDataKeys:=[],
+                                   signingKey:=None()
+                                 );
+    expect Materials.ValidEncryptionMaterials(encryptionMaterialsIn);
     var encryptionMaterialsOut :- expect rawRSAKeyring.OnEncrypt(
-      Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
-    );
-    expect Materials.ValidEncryptionMaterials(encryptionMaterialsOut.materials);  
+                                           Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
+                                         );
+    expect Materials.ValidEncryptionMaterials(encryptionMaterialsOut.materials);
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
 
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Option.None,
-      verificationKey:=Option.None
-    );    
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Option.None,
+                                   verificationKey:=Option.None
+                                 );
 
     var decryptionMaterialsOut :- expect rawRSAKeyring.OnDecrypt(
-      Crypto.OnDecryptInput(
-        materials:=decryptionMaterialsIn,
-        encryptedDataKeys:=[edk]
-      )
-    );
-      
+                                           Crypto.OnDecryptInput(
+                                             materials:=decryptionMaterialsIn,
+                                             encryptedDataKeys:=[edk]
+                                           )
+                                         );
+
     //= compliance/framework/raw-rsa-keyring.txt#2.6.1
     //= type=test
     //# The keyring MUST attempt to encrypt the plaintext data key in the
     //# encryption materials (structures.md#encryption-materials) using RSA.
     // We demonstrate this by showing OnEncrypt then OnDecrypt gets us the same pdk back.
-    expect decryptionMaterialsOut.materials.plaintextDataKey == Some(pdk);      
+    expect decryptionMaterialsOut.materials.plaintextDataKey == Some(pdk);
   }
 
   method {:test} TestOnDecryptKeyNameMismatch()
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var publicKey, privateKey, rawRSAKeyring := GenerateKeyPairAndKeyring(
-      namespace,
-      name,
-      2048 as RSAEncryption.StrengthBits,
-      RSAEncryption.PaddingMode.OAEP_SHA1
-    );
-    
+                                                  namespace,
+                                                  name,
+                                                  2048 as RSAEncryption.StrengthBits,
+                                                  RSAEncryption.PaddingMode.OAEP_SHA1
+                                                );
+
     var mismatchName :- expect UTF8.Encode("mismatched");
     var mismatchedRSAKeyring := new RawRSAKeyring.RawRSAKeyring(
-      namespace,
-      mismatchName,
-      Option.Some(publicKey.pem),
-      Option.Some(privateKey.pem),
-      RSAEncryption.PaddingMode.OAEP_SHA1
-    );
+          namespace,
+          mismatchName,
+          Option.Some(publicKey.pem),
+          Option.Some(privateKey.pem),
+          RSAEncryption.PaddingMode.OAEP_SHA1
+        );
 
     var encryptionContext := TestUtils.SmallEncryptionContext(
-      TestUtils.SmallEncryptionContextVariation.A
-    );
+                               TestUtils.SmallEncryptionContextVariation.A
+                             );
 
     var pdk := seq(32, i => 0);
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_NO_KDF;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Option.Some(pdk),
-      encryptedDataKeys:=[],
-      signingKey:=Option.None
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Option.Some(pdk),
+                                   encryptedDataKeys:=[],
+                                   signingKey:=Option.None
+                                 );
     var encryptionMaterialsOut :- expect mismatchedRSAKeyring.OnEncrypt(
-      Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
-    );
+                                           Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
+                                         );
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
 
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Option.None,
-      verificationKey:=Option.None
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Option.None,
+                                   verificationKey:=Option.None
+                                 );
     var decryptionMaterialsOut := rawRSAKeyring.OnDecrypt(
-      Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk])
-    );
+                                    Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk])
+                                  );
 
     expect decryptionMaterialsOut.IsFailure();
   }
@@ -131,17 +131,17 @@ module TestRawRSAKeying {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var _, _, encryptKeyring := GenerateKeyPairAndKeyring(
-      namespace,
-      name,
-      2048 as RSAEncryption.StrengthBits,
-      RSAEncryption.PaddingMode.OAEP_SHA1
-    );
+                                  namespace,
+                                  name,
+                                  2048 as RSAEncryption.StrengthBits,
+                                  RSAEncryption.PaddingMode.OAEP_SHA1
+                                );
     var _, _, decryptKeyring := GenerateKeyPairAndKeyring(
-      namespace,
-      name,
-      2048 as RSAEncryption.StrengthBits,
-      RSAEncryption.PaddingMode.OAEP_SHA1
-    );  
+                                  namespace,
+                                  name,
+                                  2048 as RSAEncryption.StrengthBits,
+                                  RSAEncryption.PaddingMode.OAEP_SHA1
+                                );
 
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
 
@@ -149,35 +149,35 @@ module TestRawRSAKeying {
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_NO_KDF;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Option.Some(pdk),
-      encryptedDataKeys:=[],
-      signingKey:=Option.None
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Option.Some(pdk),
+                                   encryptedDataKeys:=[],
+                                   signingKey:=Option.None
+                                 );
     var encryptionMaterialsOut :- expect encryptKeyring.OnEncrypt(
-      Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
-    );
+                                           Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
+                                         );
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
 
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Option.None,
-      verificationKey:=Option.None
-    );
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Option.None,
+                                   verificationKey:=Option.None
+                                 );
     var decryptionMaterialsOut := decryptKeyring.OnDecrypt(
-      Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk])
-    );
-    
+                                    Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk])
+                                  );
+
     //= compliance/framework/raw-rsa-keyring.txt#2.6.2
     //= type=test
     //# If no decryption succeeds, the keyring MUST fail and MUST NOT modify
     //# the decryption materials (structures.md#decryption-materials).
     expect decryptionMaterialsOut.IsFailure();
-  }  
+  }
 
   // The RSA Keyring should attempt to decrypt every EDK that matches its keyname
   // and namespace, until it succeeds.
@@ -189,62 +189,62 @@ module TestRawRSAKeying {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var publicKey, privateKey, rawRSAKeyring := GenerateKeyPairAndKeyring(
-      namespace,
-      name,
-      2048 as RSAEncryption.StrengthBits,
-      RSAEncryption.PaddingMode.OAEP_SHA1
-    );
+                                                  namespace,
+                                                  name,
+                                                  2048 as RSAEncryption.StrengthBits,
+                                                  RSAEncryption.PaddingMode.OAEP_SHA1
+                                                );
     var encryptionContext := TestUtils.SmallEncryptionContext(
-      TestUtils.SmallEncryptionContextVariation.A
-    );
+                               TestUtils.SmallEncryptionContextVariation.A
+                             );
     var pdk := seq(32, i => 0);
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_NO_KDF;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Some(pdk),
-      encryptedDataKeys:=[],
-      signingKey:=None()
-    );
-    expect Materials.ValidEncryptionMaterials(encryptionMaterialsIn);  
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Some(pdk),
+                                   encryptedDataKeys:=[],
+                                   signingKey:=None()
+                                 );
+    expect Materials.ValidEncryptionMaterials(encryptionMaterialsIn);
     var encryptionMaterialsOut :- expect rawRSAKeyring.OnEncrypt(
-      Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
-    );
-    expect Materials.ValidEncryptionMaterials(encryptionMaterialsOut.materials);  
+                                           Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
+                                         );
+    expect Materials.ValidEncryptionMaterials(encryptionMaterialsOut.materials);
     expect |encryptionMaterialsOut.materials.encryptedDataKeys| == 1;
 
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-      encryptionContext:=encryptionContext,
-      algorithmSuiteId:=wrappingAlgorithmID,
-      plaintextDataKey:=Option.None,
-      verificationKey:=Option.None
-    );    
+                                   encryptionContext:=encryptionContext,
+                                   algorithmSuiteId:=wrappingAlgorithmID,
+                                   plaintextDataKey:=Option.None,
+                                   verificationKey:=Option.None
+                                 );
     var fakeEdk: Crypto.EncryptedDataKey := Crypto.EncryptedDataKey(
-      keyProviderId := edk.keyProviderId,
-      keyProviderInfo := edk.keyProviderInfo,
-      ciphertext := seq(|edk.ciphertext|, i => 0)
-    );
+                                              keyProviderId := edk.keyProviderId,
+                                              keyProviderInfo := edk.keyProviderInfo,
+                                              ciphertext := seq(|edk.ciphertext|, i => 0)
+                                            );
 
     //= compliance/framework/raw-rsa-keyring.txt#2.6.2
     //= type=test
     //# The keyring MUST attempt to decrypt the input encrypted data keys, in
     //# list order, until it successfully decrypts one.
     var decryptionMaterialsOut :- expect rawRSAKeyring.OnDecrypt(
-      Crypto.OnDecryptInput(
-        materials:=decryptionMaterialsIn,
-        encryptedDataKeys:=[fakeEdk, edk]
-      )
-    );
+                                           Crypto.OnDecryptInput(
+                                             materials:=decryptionMaterialsIn,
+                                             encryptedDataKeys:=[fakeEdk, edk]
+                                           )
+                                         );
     //= compliance/framework/raw-rsa-keyring.txt#2.6.2
     //= type=test
     //# If any decryption succeeds, this keyring MUST immediately return the
     //# input decryption materials (structures.md#decryption-materials),
     //# modified in the following ways:
-    expect decryptionMaterialsOut.materials.plaintextDataKey == Some(pdk);      
+    expect decryptionMaterialsOut.materials.plaintextDataKey == Some(pdk);
   }
-  
+
   method GenerateKeyPairAndKeyring(
     namespace: UTF8.ValidUTF8Bytes,
     name: UTF8.ValidUTF8Bytes,
@@ -260,16 +260,16 @@ module TestRawRSAKeying {
     requires |name| < UINT16_LIMIT
   {
     publicKey, privateKey := RSAEncryption.GenerateKeyPair(
-      keyStrength
-    );
+                               keyStrength
+                             );
     keyring := new RawRSAKeyring.RawRSAKeyring(
-      namespace,
-      name,
-      Option.Some(publicKey.pem),
-      Option.Some(privateKey.pem),
-      padding
-    );
+                 namespace,
+                 name,
+                 Option.Some(publicKey.pem),
+                 Option.Some(privateKey.pem),
+                 padding
+               );
     return publicKey, privateKey, keyring;
   }
-  
+
 }

--- a/test/AwsCryptographicMaterialProviders/Keyrings/TestRawRSAKeyring.dfy
+++ b/test/AwsCryptographicMaterialProviders/Keyrings/TestRawRSAKeyring.dfy
@@ -26,24 +26,24 @@ module TestRawRSAKeying {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var publicKey, privateKey, rawRSAKeyring := GenerateKeyPairAndKeyring(
-                                                  namespace,
-                                                  name,
-                                                  2048 as RSAEncryption.StrengthBits,
-                                                  RSAEncryption.PaddingMode.OAEP_SHA1
-                                                );
+      namespace,
+      name,
+      2048 as RSAEncryption.StrengthBits,
+      RSAEncryption.PaddingMode.OAEP_SHA1
+    );
     var encryptionContext := TestUtils.SmallEncryptionContext(
-                               TestUtils.SmallEncryptionContextVariation.A
-                             );
+      TestUtils.SmallEncryptionContextVariation.A
+    );
     var pdk := seq(32, i => 0);
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_NO_KDF;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Some(pdk),
-                                   encryptedDataKeys:=[],
-                                   signingKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Some(pdk),
+      encryptedDataKeys:=[],
+      signingKey:=None()
+    );
     expect Materials.ValidEncryptionMaterials(encryptionMaterialsIn);
     var encryptionMaterialsOut :- expect rawRSAKeyring.OnEncrypt(
                                            Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
@@ -53,11 +53,11 @@ module TestRawRSAKeying {
 
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Option.None,
-                                   verificationKey:=Option.None
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Option.None,
+      verificationKey:=Option.None
+    );
 
     var decryptionMaterialsOut :- expect rawRSAKeyring.OnDecrypt(
                                            Crypto.OnDecryptInput(
@@ -78,35 +78,35 @@ module TestRawRSAKeying {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var publicKey, privateKey, rawRSAKeyring := GenerateKeyPairAndKeyring(
-                                                  namespace,
-                                                  name,
-                                                  2048 as RSAEncryption.StrengthBits,
-                                                  RSAEncryption.PaddingMode.OAEP_SHA1
-                                                );
+      namespace,
+      name,
+      2048 as RSAEncryption.StrengthBits,
+      RSAEncryption.PaddingMode.OAEP_SHA1
+    );
 
     var mismatchName :- expect UTF8.Encode("mismatched");
     var mismatchedRSAKeyring := new RawRSAKeyring.RawRSAKeyring(
-          namespace,
-          mismatchName,
-          Option.Some(publicKey.pem),
-          Option.Some(privateKey.pem),
-          RSAEncryption.PaddingMode.OAEP_SHA1
-        );
+      namespace,
+      mismatchName,
+      Option.Some(publicKey.pem),
+      Option.Some(privateKey.pem),
+      RSAEncryption.PaddingMode.OAEP_SHA1
+    );
 
     var encryptionContext := TestUtils.SmallEncryptionContext(
-                               TestUtils.SmallEncryptionContextVariation.A
-                             );
+      TestUtils.SmallEncryptionContextVariation.A
+    );
 
     var pdk := seq(32, i => 0);
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_NO_KDF;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Option.Some(pdk),
-                                   encryptedDataKeys:=[],
-                                   signingKey:=Option.None
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Option.Some(pdk),
+      encryptedDataKeys:=[],
+      signingKey:=Option.None
+    );
     var encryptionMaterialsOut :- expect mismatchedRSAKeyring.OnEncrypt(
                                            Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
                                          );
@@ -115,14 +115,14 @@ module TestRawRSAKeying {
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Option.None,
-                                   verificationKey:=Option.None
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Option.None,
+      verificationKey:=Option.None
+    );
     var decryptionMaterialsOut := rawRSAKeyring.OnDecrypt(
-                                    Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk])
-                                  );
+      Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk])
+    );
 
     expect decryptionMaterialsOut.IsFailure();
   }
@@ -131,17 +131,17 @@ module TestRawRSAKeying {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var _, _, encryptKeyring := GenerateKeyPairAndKeyring(
-                                  namespace,
-                                  name,
-                                  2048 as RSAEncryption.StrengthBits,
-                                  RSAEncryption.PaddingMode.OAEP_SHA1
-                                );
+      namespace,
+      name,
+      2048 as RSAEncryption.StrengthBits,
+      RSAEncryption.PaddingMode.OAEP_SHA1
+    );
     var _, _, decryptKeyring := GenerateKeyPairAndKeyring(
-                                  namespace,
-                                  name,
-                                  2048 as RSAEncryption.StrengthBits,
-                                  RSAEncryption.PaddingMode.OAEP_SHA1
-                                );
+      namespace,
+      name,
+      2048 as RSAEncryption.StrengthBits,
+      RSAEncryption.PaddingMode.OAEP_SHA1
+    );
 
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
 
@@ -149,12 +149,12 @@ module TestRawRSAKeying {
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_NO_KDF;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Option.Some(pdk),
-                                   encryptedDataKeys:=[],
-                                   signingKey:=Option.None
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Option.Some(pdk),
+      encryptedDataKeys:=[],
+      signingKey:=Option.None
+    );
     var encryptionMaterialsOut :- expect encryptKeyring.OnEncrypt(
                                            Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
                                          );
@@ -163,14 +163,14 @@ module TestRawRSAKeying {
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
 
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Option.None,
-                                   verificationKey:=Option.None
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Option.None,
+      verificationKey:=Option.None
+    );
     var decryptionMaterialsOut := decryptKeyring.OnDecrypt(
-                                    Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk])
-                                  );
+      Crypto.OnDecryptInput(materials:=decryptionMaterialsIn, encryptedDataKeys:=[edk])
+    );
 
     //= compliance/framework/raw-rsa-keyring.txt#2.6.2
     //= type=test
@@ -189,24 +189,24 @@ module TestRawRSAKeying {
   {
     var namespace, name := TestUtils.NamespaceAndName(0);
     var publicKey, privateKey, rawRSAKeyring := GenerateKeyPairAndKeyring(
-                                                  namespace,
-                                                  name,
-                                                  2048 as RSAEncryption.StrengthBits,
-                                                  RSAEncryption.PaddingMode.OAEP_SHA1
-                                                );
+      namespace,
+      name,
+      2048 as RSAEncryption.StrengthBits,
+      RSAEncryption.PaddingMode.OAEP_SHA1
+    );
     var encryptionContext := TestUtils.SmallEncryptionContext(
-                               TestUtils.SmallEncryptionContextVariation.A
-                             );
+      TestUtils.SmallEncryptionContextVariation.A
+    );
     var pdk := seq(32, i => 0);
 
     var wrappingAlgorithmID := Crypto.ALG_AES_256_GCM_IV12_TAG16_NO_KDF;
     var encryptionMaterialsIn := Crypto.EncryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Some(pdk),
-                                   encryptedDataKeys:=[],
-                                   signingKey:=None()
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Some(pdk),
+      encryptedDataKeys:=[],
+      signingKey:=None()
+    );
     expect Materials.ValidEncryptionMaterials(encryptionMaterialsIn);
     var encryptionMaterialsOut :- expect rawRSAKeyring.OnEncrypt(
                                            Crypto.OnEncryptInput(materials:=encryptionMaterialsIn)
@@ -216,16 +216,16 @@ module TestRawRSAKeying {
 
     var edk := encryptionMaterialsOut.materials.encryptedDataKeys[0];
     var decryptionMaterialsIn := Crypto.DecryptionMaterials(
-                                   encryptionContext:=encryptionContext,
-                                   algorithmSuiteId:=wrappingAlgorithmID,
-                                   plaintextDataKey:=Option.None,
-                                   verificationKey:=Option.None
-                                 );
+      encryptionContext:=encryptionContext,
+      algorithmSuiteId:=wrappingAlgorithmID,
+      plaintextDataKey:=Option.None,
+      verificationKey:=Option.None
+    );
     var fakeEdk: Crypto.EncryptedDataKey := Crypto.EncryptedDataKey(
-                                              keyProviderId := edk.keyProviderId,
-                                              keyProviderInfo := edk.keyProviderInfo,
-                                              ciphertext := seq(|edk.ciphertext|, i => 0)
-                                            );
+      keyProviderId := edk.keyProviderId,
+      keyProviderInfo := edk.keyProviderInfo,
+      ciphertext := seq(|edk.ciphertext|, i => 0)
+    );
 
     //= compliance/framework/raw-rsa-keyring.txt#2.6.2
     //= type=test
@@ -260,8 +260,8 @@ module TestRawRSAKeying {
     requires |name| < UINT16_LIMIT
   {
     publicKey, privateKey := RSAEncryption.GenerateKeyPair(
-                               keyStrength
-                             );
+      keyStrength
+    );
     keyring := new RawRSAKeyring.RawRSAKeyring(
                  namespace,
                  name,

--- a/test/AwsCryptographicMaterialProviders/TestDefaultClientProvider.dfy
+++ b/test/AwsCryptographicMaterialProviders/TestDefaultClientProvider.dfy
@@ -21,16 +21,16 @@ module TestDefaultClientProvider {
 
     var clientSupplier: Crypto.IClientSupplier;
     var clientSupplierRes := materialsClient.CreateDefaultClientSupplier(
-                               Crypto.CreateDefaultClientSupplierInput()
-                             );
+      Crypto.CreateDefaultClientSupplierInput()
+    );
     expect clientSupplierRes.Success?;
 
     clientSupplier := clientSupplierRes.value;
     var clientRes := clientSupplier.GetClient(
-                       Crypto.GetClientInput(
-                         "us-west-2"
-                       )
-                     );
+      Crypto.GetClientInput(
+        "us-west-2"
+      )
+    );
     var client : KMS.IKeyManagementServiceClient?;
     match clientRes {
       case Failure(error) => {
@@ -43,12 +43,12 @@ module TestDefaultClientProvider {
     expect client != null;
 
     var kmsRequest := KMS.GenerateDataKeyRequest(
-                        KeyId := TestUtils.SHARED_TEST_KEY_ARN,
-                        EncryptionContext := Option.None,
-                        GrantTokens := Option.None,
-                        NumberOfBytes := Option.Some(24 as int32),
-                        KeySpec := Option.None
-                      );
+      KeyId := TestUtils.SHARED_TEST_KEY_ARN,
+      EncryptionContext := Option.None,
+      GrantTokens := Option.None,
+      NumberOfBytes := Option.Some(24 as int32),
+      KeySpec := Option.None
+    );
 
     var kmsReply := client.GenerateDataKey(kmsRequest);
     match kmsReply {

--- a/test/AwsCryptographicMaterialProviders/TestDefaultClientProvider.dfy
+++ b/test/AwsCryptographicMaterialProviders/TestDefaultClientProvider.dfy
@@ -21,16 +21,16 @@ module TestDefaultClientProvider {
 
     var clientSupplier: Crypto.IClientSupplier;
     var clientSupplierRes := materialsClient.CreateDefaultClientSupplier(
-      Crypto.CreateDefaultClientSupplierInput()
-    );
+                               Crypto.CreateDefaultClientSupplierInput()
+                             );
     expect clientSupplierRes.Success?;
 
     clientSupplier := clientSupplierRes.value;
     var clientRes := clientSupplier.GetClient(
-      Crypto.GetClientInput(
-        "us-west-2"
-      )
-    );
+                       Crypto.GetClientInput(
+                         "us-west-2"
+                       )
+                     );
     var client : KMS.IKeyManagementServiceClient?;
     match clientRes {
       case Failure(error) => {
@@ -43,12 +43,12 @@ module TestDefaultClientProvider {
     expect client != null;
 
     var kmsRequest := KMS.GenerateDataKeyRequest(
-      KeyId := TestUtils.SHARED_TEST_KEY_ARN,
-      EncryptionContext := Option.None,
-      GrantTokens := Option.None,
-      NumberOfBytes := Option.Some(24 as int32),
-      KeySpec := Option.None
-    );
+                        KeyId := TestUtils.SHARED_TEST_KEY_ARN,
+                        EncryptionContext := Option.None,
+                        GrantTokens := Option.None,
+                        NumberOfBytes := Option.Some(24 as int32),
+                        KeySpec := Option.None
+                      );
 
     var kmsReply := client.GenerateDataKey(kmsRequest);
     match kmsReply {

--- a/test/SDK/Client/TestCommitmentPolicies.dfy
+++ b/test/SDK/Client/TestCommitmentPolicies.dfy
@@ -164,9 +164,9 @@ module TestCommitmentPolicies {
     returns (res: Result<Esdk.IAwsEncryptionSdk, string>)
   {
     var config := Esdk.AwsEncryptionSdkConfig(
-                    maxEncryptedDataKeys := None(),
-                    commitmentPolicy := commitmentPolicy
-                  );
+      maxEncryptedDataKeys := None(),
+      commitmentPolicy := commitmentPolicy
+    );
     var clientFactory := new AwsEncryptionSdkFactory.AwsEncryptionSdkFactory();
     var client :- expect clientFactory.CreateAwsEncryptionSdk(config);
     return Success(client);
@@ -192,12 +192,12 @@ module TestCommitmentPolicies {
     returns (res: Result<Esdk.EncryptOutput, Esdk.IAwsEncryptionSdkException>)
   {
     var input := Esdk.EncryptInput(
-                   plaintext := [],
-                   encryptionContext := None(),
-                   algorithmSuiteId := algorithmSuiteId,
-                   materialsManager := None(),
-                   keyring := Some(keyring),
-                   frameLength := None());
+      plaintext := [],
+      encryptionContext := None(),
+      algorithmSuiteId := algorithmSuiteId,
+      materialsManager := None(),
+      keyring := Some(keyring),
+      frameLength := None());
     var output := client.Encrypt(input);
     return output;
   }
@@ -216,9 +216,9 @@ module TestCommitmentPolicies {
     var encryptOutput :- expect TryEncrypt(encryptClient, keyring, Some(algorithmSuiteId));
 
     var decryptInput := Esdk.DecryptInput(
-                          ciphertext := encryptOutput.ciphertext,
-                          materialsManager := None(),
-                          keyring := Some(keyring));
+      ciphertext := encryptOutput.ciphertext,
+      materialsManager := None(),
+      keyring := Some(keyring));
     var decryptOutput := client.Decrypt(decryptInput);
     return decryptOutput;
   }

--- a/test/SDK/Client/TestCommitmentPolicies.dfy
+++ b/test/SDK/Client/TestCommitmentPolicies.dfy
@@ -37,7 +37,7 @@ module TestCommitmentPolicies {
     //# *  "03 78" MUST be the default algorithm suite
     var encryptOutputDefaultAlgSuite :- expect TryEncrypt(client, keyring, None());
     expect encryptOutputDefaultAlgSuite.algorithmSuiteId ==
-      SerializableTypes.GetAlgorithmSuiteId(0x0378 as SerializableTypes.ESDKAlgorithmSuiteId);
+           SerializableTypes.GetAlgorithmSuiteId(0x0378 as SerializableTypes.ESDKAlgorithmSuiteId);
 
     //= compliance/client-apis/client.txt#2.4.2.1
     //= type=test
@@ -81,7 +81,7 @@ module TestCommitmentPolicies {
     //# *  "05 78" MUST be the default algorithm suite
     var encryptOutputDefaultAlgSuite :- expect TryEncrypt(client, keyring, None());
     expect encryptOutputDefaultAlgSuite.algorithmSuiteId ==
-      SerializableTypes.GetAlgorithmSuiteId(0x0578 as SerializableTypes.ESDKAlgorithmSuiteId);
+           SerializableTypes.GetAlgorithmSuiteId(0x0578 as SerializableTypes.ESDKAlgorithmSuiteId);
 
     //= compliance/client-apis/client.txt#2.4.2.2
     //= type=test
@@ -125,7 +125,7 @@ module TestCommitmentPolicies {
     //# *  "05 78" MUST be the default algorithm suite
     var encryptOutputDefaultAlgSuite :- expect TryEncrypt(client, keyring, None());
     expect encryptOutputDefaultAlgSuite.algorithmSuiteId ==
-      SerializableTypes.GetAlgorithmSuiteId(0x0578 as SerializableTypes.ESDKAlgorithmSuiteId);
+           SerializableTypes.GetAlgorithmSuiteId(0x0578 as SerializableTypes.ESDKAlgorithmSuiteId);
 
     //= compliance/client-apis/client.txt#2.4.2.3
     //= type=test
@@ -164,9 +164,9 @@ module TestCommitmentPolicies {
     returns (res: Result<Esdk.IAwsEncryptionSdk, string>)
   {
     var config := Esdk.AwsEncryptionSdkConfig(
-      maxEncryptedDataKeys := None(),
-      commitmentPolicy := commitmentPolicy
-    );
+                    maxEncryptedDataKeys := None(),
+                    commitmentPolicy := commitmentPolicy
+                  );
     var clientFactory := new AwsEncryptionSdkFactory.AwsEncryptionSdkFactory();
     var client :- expect clientFactory.CreateAwsEncryptionSdk(config);
     return Success(client);
@@ -177,10 +177,10 @@ module TestCommitmentPolicies {
   {
     var materialsClient := new MaterialProviders.Client.AwsCryptographicMaterialProviders();
     var keyring :- expect materialsClient.CreateRawAesKeyring(Crypto.CreateRawAesKeyringInput(
-      keyNamespace := "someNamespace",
-      keyName := "someName",
-      wrappingKey := seq(32, i => 0),
-      wrappingAlg := Crypto.ALG_AES256_GCM_IV12_TAG16));
+                                                                keyNamespace := "someNamespace",
+                                                                keyName := "someName",
+                                                                wrappingKey := seq(32, i => 0),
+                                                                wrappingAlg := Crypto.ALG_AES256_GCM_IV12_TAG16));
     return Success(keyring);
   }
 
@@ -192,12 +192,12 @@ module TestCommitmentPolicies {
     returns (res: Result<Esdk.EncryptOutput, Esdk.IAwsEncryptionSdkException>)
   {
     var input := Esdk.EncryptInput(
-      plaintext := [],
-      encryptionContext := None(),
-      algorithmSuiteId := algorithmSuiteId,
-      materialsManager := None(),
-      keyring := Some(keyring),
-      frameLength := None());
+                   plaintext := [],
+                   encryptionContext := None(),
+                   algorithmSuiteId := algorithmSuiteId,
+                   materialsManager := None(),
+                   keyring := Some(keyring),
+                   frameLength := None());
     var output := client.Encrypt(input);
     return output;
   }
@@ -210,15 +210,15 @@ module TestCommitmentPolicies {
     returns (res: Result<Esdk.DecryptOutput, Esdk.IAwsEncryptionSdkException>)
   {
     var encryptCommitmentPolicy := if AlgorithmSuites.GetSuite(algorithmSuiteId).commitment.None?
-      then Crypto.FORBID_ENCRYPT_ALLOW_DECRYPT
-      else Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT;
+                                   then Crypto.FORBID_ENCRYPT_ALLOW_DECRYPT
+                                   else Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT;
     var encryptClient :- expect SetupEsdkClient(Some(encryptCommitmentPolicy));
     var encryptOutput :- expect TryEncrypt(encryptClient, keyring, Some(algorithmSuiteId));
 
     var decryptInput := Esdk.DecryptInput(
-      ciphertext := encryptOutput.ciphertext,
-      materialsManager := None(),
-      keyring := Some(keyring));
+                          ciphertext := encryptOutput.ciphertext,
+                          materialsManager := None(),
+                          keyring := Some(keyring));
     var decryptOutput := client.Decrypt(decryptInput);
     return decryptOutput;
   }

--- a/test/SDK/POCEncryptDecrypt.dfy
+++ b/test/SDK/POCEncryptDecrypt.dfy
@@ -35,24 +35,24 @@ module {:extern "TestClient"} TestClient {
 
     // Use material provider client API for RawAESKeyring creation
     var rawAESKeyringResult := materialsClient.CreateRawAesKeyring(Crypto.CreateRawAesKeyringInput(
-      keyNamespace := "someNamespace",
-      keyName := "someName",
-      wrappingKey := seq(32, i => 0),
-      wrappingAlg := Crypto.ALG_AES256_GCM_IV12_TAG16));
+                                                                     keyNamespace := "someNamespace",
+                                                                     keyName := "someName",
+                                                                     wrappingKey := seq(32, i => 0),
+                                                                     wrappingAlg := Crypto.ALG_AES256_GCM_IV12_TAG16));
     expect rawAESKeyringResult.Success?;
     var rawAESKeyring := rawAESKeyringResult.value;
 
     // Use material provider client API for DefaultCMM creation
     var cmmResult := materialsClient.CreateDefaultCryptographicMaterialsManager(Crypto.CreateDefaultCryptographicMaterialsManagerInput(
-      keyring := rawAESKeyring
-    ));
+                                                                                  keyring := rawAESKeyring
+                                                                                ));
     expect cmmResult.Success?;
     var cmm := cmmResult.value;
 
     var config := Esdk.AwsEncryptionSdkConfig(
-      maxEncryptedDataKeys := Option.Some(2 as int64),
-      commitmentPolicy := Option.Some(Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
-    );
+                    maxEncryptedDataKeys := Option.Some(2 as int64),
+                    commitmentPolicy := Option.Some(Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
+                  );
     var clientFactory := new AwsEncryptionSdkFactory.AwsEncryptionSdkFactory();
     var clientResult := clientFactory.CreateAwsEncryptionSdk(config);
     expect clientResult.Success?;
@@ -62,12 +62,12 @@ module {:extern "TestClient"} TestClient {
     var plaintext :- expect UTF8.Encode("hello");
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
     var input := Esdk.EncryptInput(
-      plaintext := plaintext,
-      encryptionContext := Some(encryptionContext),
-      algorithmSuiteId := Some(Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384),
-      materialsManager := Some(cmm),
-      keyring := None(),
-      frameLength := Option.None());
+                   plaintext := plaintext,
+                   encryptionContext := Some(encryptionContext),
+                   algorithmSuiteId := Some(Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384),
+                   materialsManager := Some(cmm),
+                   keyring := None(),
+                   frameLength := Option.None());
     var encryptRes :- expect client.Encrypt(input);
 
     //= compliance/client-apis/encrypt.txt#2.5
@@ -85,9 +85,9 @@ module {:extern "TestClient"} TestClient {
 
     // Use Decrypt API
     var decryptInput := Esdk.DecryptInput(
-      ciphertext := encryptRes.ciphertext,
-      materialsManager := Some(cmm),
-      keyring := None());
+                          ciphertext := encryptRes.ciphertext,
+                          materialsManager := Some(cmm),
+                          keyring := None());
     var decryptRes :- expect client.Decrypt(decryptInput);
 
     // ensure expected output

--- a/test/SDK/POCEncryptDecrypt.dfy
+++ b/test/SDK/POCEncryptDecrypt.dfy
@@ -50,9 +50,9 @@ module {:extern "TestClient"} TestClient {
     var cmm := cmmResult.value;
 
     var config := Esdk.AwsEncryptionSdkConfig(
-                    maxEncryptedDataKeys := Option.Some(2 as int64),
-                    commitmentPolicy := Option.Some(Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
-                  );
+      maxEncryptedDataKeys := Option.Some(2 as int64),
+      commitmentPolicy := Option.Some(Crypto.REQUIRE_ENCRYPT_ALLOW_DECRYPT)
+    );
     var clientFactory := new AwsEncryptionSdkFactory.AwsEncryptionSdkFactory();
     var clientResult := clientFactory.CreateAwsEncryptionSdk(config);
     expect clientResult.Success?;
@@ -62,12 +62,12 @@ module {:extern "TestClient"} TestClient {
     var plaintext :- expect UTF8.Encode("hello");
     var encryptionContext := TestUtils.SmallEncryptionContext(TestUtils.SmallEncryptionContextVariation.A);
     var input := Esdk.EncryptInput(
-                   plaintext := plaintext,
-                   encryptionContext := Some(encryptionContext),
-                   algorithmSuiteId := Some(Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384),
-                   materialsManager := Some(cmm),
-                   keyring := None(),
-                   frameLength := Option.None());
+      plaintext := plaintext,
+      encryptionContext := Some(encryptionContext),
+      algorithmSuiteId := Some(Crypto.AlgorithmSuiteId.ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384),
+      materialsManager := Some(cmm),
+      keyring := None(),
+      frameLength := Option.None());
     var encryptRes :- expect client.Encrypt(input);
 
     //= compliance/client-apis/encrypt.txt#2.5
@@ -85,9 +85,9 @@ module {:extern "TestClient"} TestClient {
 
     // Use Decrypt API
     var decryptInput := Esdk.DecryptInput(
-                          ciphertext := encryptRes.ciphertext,
-                          materialsManager := Some(cmm),
-                          keyring := None());
+      ciphertext := encryptRes.ciphertext,
+      materialsManager := Some(cmm),
+      keyring := None());
     var decryptRes :- expect client.Decrypt(decryptInput);
 
     // ensure expected output

--- a/test/StandardLibrary/Base64.dfy
+++ b/test/StandardLibrary/Base64.dfy
@@ -11,14 +11,14 @@ module TestBase64 {
   import opened Base64 = Base64
 
   const BASE64_TEST_VECTORS_ENCODED := ["", "VA==", "VGU=", "VGVz", "VGVzdA==", "VGVzdGk=", "VGVzdGlu", "VGVzdGluZw==",
-    "VGVzdGluZys=", "VGVzdGluZysx"];
+                                        "VGVzdGluZys=", "VGVzdGluZysx"];
   const BASE64_TEST_VECTORS_DECODED := ["", "T", "Te", "Tes", "Test", "Testi", "Testin", "Testing", "Testing+",
-    "Testing+1"];
+                                        "Testing+1"];
 
   const BASE64_TEST_VECTORS_DECODED_UINT8: seq<seq<uint8>> :=
     [[], [0x54], [0x54, 0x65], [0x54, 0x65, 0x73], [0x54, 0x65, 0x73, 0x74], [0x54, 0x65, 0x73, 0x74, 0x69],
-    [0x54, 0x65, 0x73, 0x74, 0x69, 0x6E], [0x54, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67],
-    [0x54, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67, 0x2B], [0x54, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67, 0x2B, 0x31]];
+     [0x54, 0x65, 0x73, 0x74, 0x69, 0x6E], [0x54, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67],
+     [0x54, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67, 0x2B], [0x54, 0x65, 0x73, 0x74, 0x69, 0x6E, 0x67, 0x2B, 0x31]];
 
   const BASE64_CHARS := "+/0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
@@ -294,12 +294,12 @@ module TestBase64 {
 
   method {:test} TestDecodeValidTestVectors() {
     expect forall i :: 0 <= i < |BASE64_TEST_VECTORS_ENCODED| ==>
-      DecodeValid(BASE64_TEST_VECTORS_ENCODED[i]) == BASE64_TEST_VECTORS_DECODED_UINT8[i];
+                         DecodeValid(BASE64_TEST_VECTORS_ENCODED[i]) == BASE64_TEST_VECTORS_DECODED_UINT8[i];
   }
 
   method {:test} TestDecodeTestVectors() {
     expect forall i :: 0 <= i < |BASE64_TEST_VECTORS_ENCODED| ==>
-      Decode(BASE64_TEST_VECTORS_ENCODED[i]) == Success(BASE64_TEST_VECTORS_DECODED_UINT8[i]);
+                         Decode(BASE64_TEST_VECTORS_ENCODED[i]) == Success(BASE64_TEST_VECTORS_DECODED_UINT8[i]);
   }
 
   method {:test} TestDecodeFailure() {
@@ -308,17 +308,17 @@ module TestBase64 {
 
   method {:test} TestEncode() {
     expect forall i :: 0 <= i < |BASE64_TEST_VECTORS_DECODED_UINT8| ==>
-      Encode(BASE64_TEST_VECTORS_DECODED_UINT8[i]) == BASE64_TEST_VECTORS_ENCODED[i];
+                         Encode(BASE64_TEST_VECTORS_DECODED_UINT8[i]) == BASE64_TEST_VECTORS_ENCODED[i];
   }
 
   method {:test} TestEncodeDecode() {
     expect forall i :: 0 <= i < |BASE64_TEST_VECTORS_DECODED_UINT8| ==>
-      Decode(Encode(BASE64_TEST_VECTORS_DECODED_UINT8[i])) == Success(BASE64_TEST_VECTORS_DECODED_UINT8[i]);
+                         Decode(Encode(BASE64_TEST_VECTORS_DECODED_UINT8[i])) == Success(BASE64_TEST_VECTORS_DECODED_UINT8[i]);
   }
 
   method {:test} TestDecodeEncode() {
     expect forall i :: 0 <= i < |BASE64_TEST_VECTORS_ENCODED| ==>
-      (Decode(BASE64_TEST_VECTORS_ENCODED[i]).Success?
-      && Encode(Decode(BASE64_TEST_VECTORS_ENCODED[i]).value) == BASE64_TEST_VECTORS_ENCODED[i]);
+                         (Decode(BASE64_TEST_VECTORS_ENCODED[i]).Success?
+                          && Encode(Decode(BASE64_TEST_VECTORS_ENCODED[i]).value) == BASE64_TEST_VECTORS_ENCODED[i]);
   }
 }

--- a/test/Util/TestUtils.dfy
+++ b/test/Util/TestUtils.dfy
@@ -26,7 +26,7 @@ module {:extern "TestUtils"} TestUtils {
   const ACCOUNT_IDS := ["658956600833"];
 
   const PARTITION := "aws";
-  
+
   // TODO correctly verify UTF8 validity of long sequences
   // This axiom should only be used by tests to skip UTF8 verification of long sequences
   // long to be serialized in 16 bytes, in order to avoid a false negative for from verification.
@@ -121,12 +121,12 @@ module {:extern "TestUtils"} TestUtils {
     var encodedKeyProviderInfo :- expect UTF8.Encode(keyProviderInfo);
     var fakeCiphertext :- expect UTF8.Encode("fakeCiphertext");
     return Crypto.EncryptedDataKey(
-      keyProviderId := encodedkeyProviderId,
-      keyProviderInfo := encodedKeyProviderInfo,
-      ciphertext := fakeCiphertext
-    );
+             keyProviderId := encodedkeyProviderId,
+             keyProviderInfo := encodedKeyProviderInfo,
+             ciphertext := fakeCiphertext
+           );
   }
-    
+
 
   // lemma ValidSmallEncryptionContext(encryptionContext: EncryptionContext.Crypto.EncryptionContext)
   //   requires |encryptionContext| <= 5


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
I applied the new in-review Dafny formatter to all the files of this repository to gather feedback.

*Squash/merge commit message, if applicable:*

# Formatting pass by Dafny
Note the following:
- `/** */` in datatypes has been indented because we decided that the docstring of a constructor is immediately after this constructor (so there is no separation between the doc and the vertical |)
- The Dafny formatter is opinionated such that `*` aligns to the second `*` in `/**`. This unifies some of your comments.
- If you want to reduce the indentation that Dafny formatter added in EncryptDecryptString.dfy, you have to add a newline after the :=
- The Dafny formatter deleted trailing spaces as well.
- If you want comments to be aligned with the | in datatypes, simply write //|, the Dafny formatter will recognized a commented out datatype and align it with the vertical bars.
- Same for //case that will align with case.
- Interesting note: only 12 files out of 42 actually were changed by the formatter, and it took only 2 seconds to format everything.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
