### PR TITLE
chore(RSA): limit RSA Key Gen to 4096 bits

### DIFF
--- a/aws-encryption-sdk-net/Source/Extern/RSAEncryption.cs
+++ b/aws-encryption-sdk-net/Source/Extern/RSAEncryption.cs
@@ -121,6 +121,10 @@ namespace RSAEncryption {
         }
 
         public static void GenerateKeyPairBytes(int strength, out byte[] publicKeyBytes, out byte[] privateKeyBytes) {
+            if (strength > 4096)
+            {
+                throw new ArgumentException("AWS Crypto will not generate an RSA Key greater than 4096.");
+            }
             RsaKeyPairGenerator keygen = new RsaKeyPairGenerator();
             SecureRandom secureRandom = new SecureRandom();
             keygen.Init(new RsaKeyGenerationParameters(

--- a/src/Crypto/RSAEncryption.dfy
+++ b/src/Crypto/RSAEncryption.dfy
@@ -65,7 +65,7 @@ module {:extern "RSAEncryption"} RSAEncryption {
 
   method GenerateKeyPair(strength: StrengthBits)
     returns (publicKey: PublicKey, privateKey: PrivateKey)
-    requires strength <= 15360
+    requires strength <= 4096
     ensures privateKey.Valid()
     ensures publicKey.Valid()
   {

--- a/src/Crypto/RSAEncryption.dfy
+++ b/src/Crypto/RSAEncryption.dfy
@@ -64,7 +64,8 @@ module {:extern "RSAEncryption"} RSAEncryption {
   }
 
   method GenerateKeyPair(strength: StrengthBits)
-      returns (publicKey: PublicKey, privateKey: PrivateKey)
+    returns (publicKey: PublicKey, privateKey: PrivateKey)
+    requires strength <= 15360
     ensures privateKey.Valid()
     ensures publicKey.Valid()
   {

--- a/test/AwsCryptographicMaterialProviders/Keyrings/TestRawRSAKeyring.dfy
+++ b/test/AwsCryptographicMaterialProviders/Keyrings/TestRawRSAKeyring.dfy
@@ -258,7 +258,7 @@ module TestRawRSAKeying {
     )
     requires |namespace| < UINT16_LIMIT
     requires |name| < UINT16_LIMIT
-    requires keyStrength <= 15360
+    requires keyStrength <= 4096
   {
     publicKey, privateKey := RSAEncryption.GenerateKeyPair(
       keyStrength

--- a/test/AwsCryptographicMaterialProviders/Keyrings/TestRawRSAKeyring.dfy
+++ b/test/AwsCryptographicMaterialProviders/Keyrings/TestRawRSAKeyring.dfy
@@ -258,6 +258,7 @@ module TestRawRSAKeying {
     )
     requires |namespace| < UINT16_LIMIT
     requires |name| < UINT16_LIMIT
+    requires keyStrength <= 15360
   {
     publicKey, privateKey := RSAEncryption.GenerateKeyPair(
       keyStrength


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Limit RSA Key Generation input to 4096 bits

This does NOT impact the public behavior of the ESDK in any way.

The RSA Key Generator is ONLY used for testing.

[4096 is the largest RSA Key size KMS supports](https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html#key-spec-rsa).

*Squash/merge commit message, if applicable:* `chore(RSA): limit RSA Key Gen to 4096 bits`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Due to [dafny-lang/dafny#2500](https://github.com/dafny-lang/dafny/issues/2500), Traits are dangerous:
1. [ ] Does this PR add any traits or classes that extend a trait?
2. [ ] Are these traits annotated with `{:termination false}`?

The override checks on 
the specifications on
a class' functions/methods/etc. validating
that specifications are 
at least as strong as those on
the traits it implements
are not working correctly when 
that trait is defined in a different module 
(and hence must have `{:termination false}` on it).

As such, if either (1.) or (2.) is true:
- [ ] manually verified all the trait specifications are copied onto classes that extend them?
