### PR TITLE
ci: fix test-installation

### DIFF
--- a/.github/workflows/test-installation.yml
+++ b/.github/workflows/test-installation.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/aws-encryption-sdk-net
         aws codeartifact login --tool dotnet --domain github --domain-owner 587316601012 --repository dotnet-esdk --duration-seconds 900
-        dotnet nuget push build/AWS.EncryptionSDK.$UNIQUE_VERSION.nupkg --source github/dotnet-esdk
+        dotnet nuget push build/AWS.EncryptionSDK.$UNIQUE_VERSION.nupkg --source github/dotnet-esdk --skip-duplicate
 
   test_installation:
     name: test_installation_${{ matrix.os }}

--- a/.github/workflows/test-installation.yml
+++ b/.github/workflows/test-installation.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/aws-encryption-sdk-net
         export BASE_VERSION=`grep '<Version>' Source/AWSEncryptionSDK.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/'`
-        export UNIQUE_VERSION=$BASE_VERSION-`git rev-parse --short HEAD`
+        export UNIQUE_VERSION=$BASE_VERSION-`git rev-parse --short HEAD`-`date +%Y-%m-%d`
         echo "::set-output name=UNIQUE_VERSION::$UNIQUE_VERSION"
         echo "UNIQUE_VERSION=$UNIQUE_VERSION" >> $GITHUB_ENV
     - name: Build and pack
@@ -151,4 +151,4 @@ jobs:
         export UNIQUE_VERSION=${{ needs.push_to_code_artifact.outputs.UNIQUE_VERSION }}
         echo "UNIQUE_VERSION=$UNIQUE_VERSION" >> $GITHUB_ENV
     - name: CodeArtifact Purger
-      run: aws codeartifact delete-package-versions --domain github --repository dotnet-esdk --format nuget --package awsencryptionsdk --versions $UNIQUE_VERSION
+      run: aws codeartifact delete-package-versions --domain github --repository dotnet-esdk --format nuget --package awsencryptionsdk --versions "${{ needs.push_to_code_artifact.outputs.UNIQUE_VERSION }}"

--- a/.github/workflows/test-installation.yml
+++ b/.github/workflows/test-installation.yml
@@ -70,6 +70,10 @@ jobs:
       id-token: write
       contents: read
     steps:
+    - name: Setup .NET Core SDK 3.1.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '3.1.x'
     - name: Configure AWS credentials for pulling from CA
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/test-installation.yml
+++ b/.github/workflows/test-installation.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         dafny-version: "3.5.0"
     - name: Configure AWS credentials for pulling from CA
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::587316601012:role/GitHub-DotNet-CA-Writer
         role-session-name: push_to_code_artifact
@@ -75,7 +75,7 @@ jobs:
       with:
         dotnet-version: '3.1.x'
     - name: Configure AWS credentials for pulling from CA
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::587316601012:role/GitHub-DotNet-CA-Reader
         aws-region: us-west-2
@@ -112,7 +112,7 @@ jobs:
       contents: read
     steps:
     - name: Configure AWS credentials for pulling from CA
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::587316601012:role/GitHub-DotNet-CA-Reader
         aws-region: us-west-2
@@ -146,7 +146,7 @@ jobs:
       contents: read
     steps:
     - name: Configure AWS credentials for pulling from CA
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::587316601012:role/GitHub-DotNet-CA-Purger
         aws-region: us-west-2

--- a/.github/workflows/test-installation.yml
+++ b/.github/workflows/test-installation.yml
@@ -46,7 +46,7 @@ jobs:
         cd $GITHUB_WORKSPACE/aws-encryption-sdk-net
         export BASE_VERSION=`grep '<Version>' Source/AWSEncryptionSDK.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/'`
         export UNIQUE_VERSION=$BASE_VERSION-`git rev-parse --short HEAD`-`date +%Y-%m-%d`
-        echo "::set-output name=UNIQUE_VERSION::$UNIQUE_VERSION"
+        echo "UNIQUE_VERSION=$UNIQUE_VERSION" >> $GITHUB_OUTPUT
         echo "UNIQUE_VERSION=$UNIQUE_VERSION" >> $GITHUB_ENV
     - name: Build and pack
       run: |
@@ -155,4 +155,4 @@ jobs:
         export UNIQUE_VERSION=${{ needs.push_to_code_artifact.outputs.UNIQUE_VERSION }}
         echo "UNIQUE_VERSION=$UNIQUE_VERSION" >> $GITHUB_ENV
     - name: CodeArtifact Purger
-      run: aws codeartifact delete-package-versions --domain github --repository dotnet-esdk --format nuget --package awsencryptionsdk --versions "${{ needs.push_to_code_artifact.outputs.UNIQUE_VERSION }}"
+      run: aws codeartifact delete-package-versions --domain github --repository dotnet-esdk --format nuget --package aws.encryptionsdk --versions "${{ needs.push_to_code_artifact.outputs.UNIQUE_VERSION }}"


### PR DESCRIPTION
*Issue #, if available:* CI broken due to:
- *Pushing to CodeArtifact* always fails due to already existing version
- *Test Installation Ubuntu Latest* always fails due to GitHub removing .NET 3.1.x
- *Purge* always fails as it was aiming at the wrong package

*Description of changes:*
- Make the Unique Version a concatenation of `Major.Minor.Patch-GitSha-YYYY-MM-DD`.
   It will always succeed at least once a day
- Push with Skip Duplicate. Even if a version match occurs, testing with the published
   artifact will execute.
   This is very important as the purge will not run unless the tests succeed.
- Use [`actions/setup-dotnet@v3`](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net) to setup DotNet.
- Correct the package name in Purge

*Squash/merge commit message, if applicable:*
`ci: restore test-installation workflow`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
