### PR TITLE
chore: replace Portable BC with BC Crypto

### DIFF
--- a/aws-encryption-sdk-net/Source/AWSEncryptionSDK.csproj
+++ b/aws-encryption-sdk-net/Source/AWSEncryptionSDK.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.7.9.2" />
     <PackageReference Include="AWSSDK.KeyManagementService" Version="3.7.2" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5.2" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
     <!--
       System.Collections.Immutable can be removed once dafny.msbuild is updated with
       https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned

--- a/aws-encryption-sdk-net/Test/AWSEncryptionSDKTests.csproj
+++ b/aws-encryption-sdk-net/Test/AWSEncryptionSDKTests.csproj
@@ -60,7 +60,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.7.9" />
     <PackageReference Include="AWSSDK.KeyManagementService" Version="3.7.2.83" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5.2" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
     <!-- Work around for dafny-lang/dafny/issues/1951; remove once resolved -->
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
It does not appear that BouncyCastle is going to continue development of 
`Portable.BouncyCastle`, which apparently is a labor of love/brilliance by one developer. 

Instead, they seem to be committing to `BouncyCastle.Cryptography`.

See: https://www.bouncycastle.org/csharp/#DOWNLOAD20200

*Squash/merge commit message, if applicable:*
`chore: replace Portable BC with BC Crypto`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Due to [dafny-lang/dafny#2500](https://github.com/dafny-lang/dafny/issues/2500), Traits are dangerous:
1. [ ] Does this PR add any traits or classes that extend a trait?
2. [ ] Are these traits annotated with `{:termination false}`?

The override checks on 
the specifications on
a class' functions/methods/etc. validating
that specifications are 
at least as strong as those on
the traits it implements
are not working correctly when 
that trait is defined in a different module 
(and hence must have `{:termination false}` on it).

As such, if either (1.) or (2.) is true:
- [ ] manually verified all the trait specifications are copied onto classes that extend them?
