### PR TITLE
test: restore CODEOWNERS and daily CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Each line is a file pattern followed by one or more owners.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default code owner for everything is our aws-crypto-tools group
+*       @aws/aws-crypto-tools

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -12,11 +12,11 @@ jobs:
     uses: ./.github/workflows/library_dafny_verification.yml
     with:
       dafny: '4.2.0'
-  daily-ci-java:
-    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
-    uses: ./.github/workflows/library_java_tests.yml
-    with:
-      dafny: '4.2.0'
+  # daily-ci-java:
+  #   if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+  #   uses: ./.github/workflows/library_java_tests.yml
+  #   with:
+  #     dafny: '4.2.0'
   daily-ci-net:
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     uses: ./.github/workflows/library_net_tests.yml

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,0 +1,24 @@
+# This workflow runs every weekday at 15:00 UTC (8AM PDT)
+name: Daily CI
+
+on:
+  schedule:
+    - cron: "00 15 * * 1-5"
+
+jobs:
+  daily-ci-verification:
+    # Don't run the cron builds on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/library_dafny_verification.yml
+    with:
+      dafny: '4.2.0'
+  daily-ci-java:
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/library_java_tests.yml
+    with:
+      dafny: '4.2.0'
+  daily-ci-net:
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/library_net_tests.yml
+    with:
+      dafny: '4.2.0'

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -2,31 +2,15 @@
 name: Library Dafny verification
 
 on:
-  pull_request:
-  push:
-    branches:
-      - public-v4
-  workflow_dispatch:
-    # Manual trigger for this workflow, either the normal version
-    # or the nightly build that uses the latest Dafny prerelease
-    # (accordingly to the "nightly" parameter).
+  workflow_call:
     inputs:
-      nightly:
-        description: 'Run the nightly build'
-        required: false
-        type: boolean
-  schedule:
-    # Nightly build against Dafny's nightly prereleases,
-    # for early warning of verification issues or regressions.
-    # Timing chosen to be adequately after Dafny's own nightly build,
-    # but this might need to be tweaked:
-    # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
-    - cron: "30 16 * * *"
+      dafny:
+        description: 'The Dafny version to run'
+        required: true
+        type: string  
 
 jobs:
   verification:
-    # Don't run the nightly build on forks
-    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     strategy:
       matrix:
         library: [
@@ -34,26 +18,24 @@ jobs:
         ]
         os: [ macos-latest ]
     runs-on: ${{ matrix.os }}
-    environment: "MPL_DAFNY"
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
     steps:
+      - name: Support longpaths
+        run: |
+          git config --global core.longpaths true
+          
       - uses: actions/checkout@v2
       - name: Init Submodules
         run: |
             git submodule update --init libraries
             git submodule update --init --recursive mpl
 
-      - name: Support longpaths
-        run: |
-          git config --global core.longpaths true
-
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
-          # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
-          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
+          dafny-version: ${{ inputs.dafny }}
 
       - name: Verify ${{ matrix.library }} Dafny code
         shell: bash

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -2,22 +2,15 @@
 name: Library Java tests
 
 on: 
-  pull_request:
-  push:
-    branches:
-      - public-v4
-  schedule:
-    # Nightly build against Dafny's nightly prereleases,
-    # for early warning of verification issues or regressions.
-    # Timing chosen to be adequately after Dafny's own nightly build,
-    # but this might need to be tweaked:
-    # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
-    - cron: "30 16 * * *"
+  workflow_call:
+    inputs:
+      dafny:
+        description: 'The Dafny version to run'
+        required: true
+        type: string
 
 jobs:
   testJava:
-    # Don't run the nightly build on forks
-    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     strategy:
       matrix:
         library: [
@@ -30,41 +23,31 @@ jobs:
           macos-latest
         ]
     runs-on: ${{ matrix.os }}
-    environment: "MPL_DAFNY"
     permissions:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
-      - name: Init Submodules
-        env:
-          # This secret is in the configured environment
-          # Token created on # 09/26/2023
-          # expires in ~30 days 10/26/2023
-          MPL_PAT: ${{ secrets.MPL_DAFNY }}
-        run: |
-            AUTH="$(echo -n "pat:${MPL_PAT}" | base64 | tr -d '\n')"
-            git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $AUTH"
-            git config --global --add url.https://github.com/.insteadOf git@github.com:
-            git submodule update --init libraries
-            git submodule update --init --recursive mpl
-
       - name: Support longpaths
         run: |
           git config --global core.longpaths true
+      
+      - uses: actions/checkout@v3
+      - name: Init Submodules
+        run: |
+            git submodule update --init libraries
+            git submodule update --init --recursive mpl
+
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-west-2
-          # TODO: This role was manually created.
-          role-to-assume: arn:aws:iam::370957321024:role/ESDK-Dafny-Private-CA-Read
-          role-session-name: JavaPrivateESDKDafnyTests
+          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-Public-ESDK-Dafny-Role-us-west-2
+          role-session-name: JavaTests
 
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
-          # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
-          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
+          dafny-version: ${{ inputs.dafny }}
 
       - name: Setup Java 8
         uses: actions/setup-java@v3
@@ -80,19 +63,8 @@ jobs:
           CORES=$(node -e 'console.log(os.cpus().length)')
           make build_java CORES=$CORES
 
-      # KMS and MPL tests need to use credentials which can call KMS
-      - name: Configure AWS Credentials for Tests
-        uses: aws-actions/configure-aws-credentials@v1
-        if: matrix.library == 'ComAmazonawsKms' || matrix.library == 'AwsCryptographicMaterialProviders' || matrix.library == 'TestVectorsAwsCryptographicMaterialProviders'
-        with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-ESDK-Dafny-Role-us-west-2
-          role-session-name: JavaTests
-
       - name: Test ${{ matrix.library }}
         working-directory: ./${{ matrix.library }}
-        # TODO: DDB currently has no tests
-        if: matrix.library != 'ComAmazonawsDynamodb'
         run: |
           make test_java
 

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -2,17 +2,12 @@
 name: Library net tests
 
 on: 
-  pull_request:
-  push:
-    branches:
-      - mainline 
-  schedule:
-    # Nightly build against Dafny's nightly prereleases,
-    # for early warning of verification issues or regressions.
-    # Timing chosen to be adequately after Dafny's own nightly build,
-    # but this might need to be tweaked:
-    # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
-    - cron: "30 16 * * *"
+  workflow_call:
+    inputs:
+      dafny:
+        description: 'The Dafny version to run'
+        required: true
+        type: string  
 
 env:
   # Used in examples
@@ -27,8 +22,6 @@ env:
 
 jobs:
   testDotNet:
-    # Don't run the nightly build on forks
-    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     strategy:
       matrix:
         os: [
@@ -69,8 +62,7 @@ jobs:
       - name: Setup Dafny
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
-          # A && B || C is the closest thing to an if .. then ... else ... or ?: expression the GitHub Actions syntax supports.
-          dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '4.2.0' }}
+          dafny-version: ${{ inputs.dafny }}
 
       - name: Download Dependencies 
         working-directory: ./AwsEncryptionSDK

--- a/.github/workflows/nighly_dafny.yml
+++ b/.github/workflows/nighly_dafny.yml
@@ -17,11 +17,11 @@ jobs:
     uses: ./.github/workflows/library_dafny_verification.yml
     with:
       dafny: 'nightly-latest'
-  dafny-nightly-java:
-    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
-    uses: ./.github/workflows/library_java_tests.yml
-    with:
-      dafny: 'nightly-latest'
+  # dafny-nightly-java:
+  #   if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+  #   uses: ./.github/workflows/library_java_tests.yml
+  #   with:
+  #     dafny: 'nightly-latest'
   dafny-nightly-net:
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     uses: ./.github/workflows/library_net_tests.yml

--- a/.github/workflows/nighly_dafny.yml
+++ b/.github/workflows/nighly_dafny.yml
@@ -1,0 +1,35 @@
+# This workflow invokes other workflows with the nightly Dafny build
+name: Dafny Nightly
+
+on:
+  schedule:
+    # Nightly build against Dafny's nightly prereleases,
+    # for early warning of verification issues or regressions.
+    # Timing chosen to be adequately after Dafny's own nightly build,
+    # but this might need to be tweaked:
+    # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
+    - cron: "30 16 * * *"
+
+jobs:
+  dafny-nightly-format:
+    # Don't run the cron builds on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/library_dafny_verification.yml
+    with:
+      dafny: 'nightly-latest'
+  dafny-nightly-verification:
+    # Don't run the cron builds on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/library_dafny_verification.yml
+    with:
+      dafny: 'nightly-latest'
+  dafny-nightly-java:
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/library_java_tests.yml
+    with:
+      dafny: 'nightly-latest'
+  dafny-nightly-net:
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/library_net_tests.yml
+    with:
+      dafny: 'nightly-latest'

--- a/.github/workflows/nighly_dafny.yml
+++ b/.github/workflows/nighly_dafny.yml
@@ -11,12 +11,6 @@ on:
     - cron: "30 16 * * *"
 
 jobs:
-  dafny-nightly-format:
-    # Don't run the cron builds on forks
-    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
-    uses: ./.github/workflows/library_dafny_verification.yml
-    with:
-      dafny: 'nightly-latest'
   dafny-nightly-verification:
     # Don't run the cron builds on forks
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,0 +1,23 @@
+# This workflow runs for every pull request
+name: PR CI
+
+on:
+  pull_request:
+
+jobs:
+  pr-ci-format:
+    uses: ./.github/workflows/library_dafny_format.yml
+    with:
+      dafny: '4.2.0'
+  pr-ci-verification:
+    uses: ./.github/workflows/library_dafny_verification.yml
+    with:
+      dafny: '4.2.0'
+  pr-ci-java:
+    uses: ./.github/workflows/library_java_tests.yml
+    with:
+      dafny: '4.2.0'
+  pr-ci-net:
+    uses: ./.github/workflows/library_net_tests.yml
+    with:
+      dafny: '4.2.0'

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -9,10 +9,10 @@ jobs:
     uses: ./.github/workflows/library_dafny_verification.yml
     with:
       dafny: '4.2.0'
-  pr-ci-java:
-    uses: ./.github/workflows/library_java_tests.yml
-    with:
-      dafny: '4.2.0'
+  # pr-ci-java:
+  #   uses: ./.github/workflows/library_java_tests.yml
+  #   with:
+  #     dafny: '4.2.0'
   pr-ci-net:
     uses: ./.github/workflows/library_net_tests.yml
     with:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -5,10 +5,6 @@ on:
   pull_request:
 
 jobs:
-  pr-ci-format:
-    uses: ./.github/workflows/library_dafny_format.yml
-    with:
-      dafny: '4.2.0'
   pr-ci-verification:
     uses: ./.github/workflows/library_dafny_verification.yml
     with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,10 +11,10 @@ jobs:
     uses: ./.github/workflows/library_dafny_verification.yml
     with:
       dafny: '4.2.0'
-  push-ci-java:
-    uses: ./.github/workflows/library_java_tests.yml
-    with:
-      dafny: '4.2.0'
+  # push-ci-java:
+  #   uses: ./.github/workflows/library_java_tests.yml
+  #   with:
+  #     dafny: '4.2.0'
   push-ci-net:
     uses: ./.github/workflows/library_net_tests.yml
     with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,25 @@
+# This workflow runs for every push to main
+name: Push CI
+
+on:
+  push:
+    branches:
+      - main    
+
+jobs:
+  push-ci-format:
+    uses: ./.github/workflows/library_dafny_format.yml
+    with:
+      dafny: '4.2.0'
+  push-ci-verification:
+    uses: ./.github/workflows/library_dafny_verification.yml
+    with:
+      dafny: '4.2.0'
+  push-ci-java:
+    uses: ./.github/workflows/library_java_tests.yml
+    with:
+      dafny: '4.2.0'
+  push-ci-net:
+    uses: ./.github/workflows/library_net_tests.yml
+    with:
+      dafny: '4.2.0'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,10 +7,6 @@ on:
       - main    
 
 jobs:
-  push-ci-format:
-    uses: ./.github/workflows/library_dafny_format.yml
-    with:
-      dafny: '4.2.0'
   push-ci-verification:
     uses: ./.github/workflows/library_dafny_verification.yml
     with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add back the CODEOWNERS file
2. Run CI every day against Dafny 4.2, as compared to only running it against Dafny Nightly.

It may help to compare the Workflow files to those in the MPL:
https://github.com/aws/aws-cryptographic-material-providers-library-java/tree/main/.github/workflows

*Squash/merge commit message, if applicable:*
```
 test: restore CODEOWNERS and daily CI
```

Note: I will update the Branch Protection once this has been approved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
