### PR TITLE
chore: split vc gen on some methods to migrate to Dafny 4.4

### DIFF
--- a/AwsEncryptionSDK/dafny/AwsEncryptionSdk/src/MessageBody.dfy
+++ b/AwsEncryptionSDK/dafny/AwsEncryptionSdk/src/MessageBody.dfy
@@ -653,7 +653,7 @@ module MessageBody {
     return Success(finalFrame);
   }
 
-  method DecryptFramedMessageBody(
+  method {:vcs_split_on_every_assert} DecryptFramedMessageBody(
     body: FramedMessage,
     key: seq<uint8>,
     crypto: Primitives.AtomicPrimitivesClient

--- a/AwsEncryptionSDK/dafny/AwsEncryptionSdk/src/Serialize/EncryptedDataKeys.dfy
+++ b/AwsEncryptionSDK/dafny/AwsEncryptionSdk/src/Serialize/EncryptedDataKeys.dfy
@@ -263,7 +263,7 @@ module {:options "/functionSyntax:4" } EncryptedDataKeys {
     }
   }
 
-  lemma ReadEncryptedDataKeysSectionIsComplete(
+  lemma {:vcs_split_on_every_assert} ReadEncryptedDataKeysSectionIsComplete(
     data: ESDKEncryptedDataKeys,
     bytes: seq<uint8>,
     buffer: ReadableBuffer,


### PR DESCRIPTION
Verification of some methods fail for upcoming Dafny 4.4. Changes split the vc generation for these methods for verification to pass. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
