### PR TITLE
chore(MessageBody): CorrectlyRead for Dafny 4.4

### DIFF
--- a/AwsEncryptionSDK/dafny/AwsEncryptionSdk/src/MessageBody.dfy
+++ b/AwsEncryptionSDK/dafny/AwsEncryptionSdk/src/MessageBody.dfy
@@ -974,7 +974,6 @@ module MessageBody {
     ==>
       && res.value.data.finalFrame.header == header
   {
-    reveal CorrectlyReadRange();
     var sequenceNumber :- ReadUInt32(continuation);
 
     //= compliance/client-apis/decrypt.txt#2.7.4
@@ -1034,6 +1033,12 @@ module MessageBody {
       assert CorrectlyRead(buffer, Success(SuccessfulRead(nextRegularFrames, regularFrame.tail)), WriteMessageRegularFrames) by {
         reveal CorrectlyReadRange();
       }
+      assert buffer.start <= regularFrame.tail.start by {
+        reveal CorrectlyReadRange();
+      }
+      assert CorrectlyReadRange(buffer, regularFrame.tail, buffer.bytes[buffer.start..regularFrame.tail.start]) by {
+        reveal CorrectlyReadRange();
+      }
 
       ReadFramedMessageBody(
         buffer,
@@ -1069,6 +1074,9 @@ module MessageBody {
       assert {:split_here} true;
       assert CorrectlyRead(continuation, Success(finalFrame), Frames.WriteFinalFrame);
       assert {:split_here} true;
+      assert CorrectlyRead(buffer, Success(SuccessfulRead(body, finalFrame.tail)), WriteFramedMessageBody) by {
+        reveal CorrectlyReadRange();
+      }
       Success(SuccessfulRead(body, finalFrame.tail))
   }
 

--- a/AwsEncryptionSDK/dafny/AwsEncryptionSdk/src/MessageBody.dfy
+++ b/AwsEncryptionSDK/dafny/AwsEncryptionSdk/src/MessageBody.dfy
@@ -1063,8 +1063,6 @@ module MessageBody {
       );
 
       assert {:split_here} true;
-      assert MessageFramesAreMonotonic(regularFrames + [finalFrame.data]);
-      assert MessageFramesAreForTheSameMessage(regularFrames + [finalFrame.data]);
 
       var body: FramedMessage := FramedMessageBody(
         regularFrames := regularFrames,
@@ -1075,6 +1073,8 @@ module MessageBody {
       assert CorrectlyRead(continuation, Success(finalFrame), Frames.WriteFinalFrame);
       assert {:split_here} true;
       assert CorrectlyRead(buffer, Success(SuccessfulRead(body, finalFrame.tail)), WriteFramedMessageBody) by {
+        assert MessageFramesAreMonotonic(regularFrames + [finalFrame.data]);
+        assert MessageFramesAreForTheSameMessage(regularFrames + [finalFrame.data]);
         reveal CorrectlyReadRange();
       }
       Success(SuccessfulRead(body, finalFrame.tail))

--- a/AwsEncryptionSDK/runtimes/net/ESDK.csproj
+++ b/AwsEncryptionSDK/runtimes/net/ESDK.csproj
@@ -32,7 +32,7 @@
       <PackageReference Include="AWSSDK.Core" Version="3.7.103" />
       <PackageReference Include="DafnyRuntime" Version="4.2.0" />
       <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
-      <PackageReference Include="AWS.Cryptography.MaterialProviders" Version="1.0.0" />
+      <PackageReference Include="AWS.Cryptography.MaterialProviders" Version="1.2.0" />
       <!--
         System.Collections.Immutable can be removed once dafny.msbuild is updated with
         https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned

--- a/AwsEncryptionSDK/runtimes/net/ESDK.csproj
+++ b/AwsEncryptionSDK/runtimes/net/ESDK.csproj
@@ -29,18 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="AWSSDK.Core" Version="3.7.103" />
       <PackageReference Include="DafnyRuntime" Version="4.2.0" />
-      <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
       <PackageReference Include="AWS.Cryptography.MaterialProviders" Version="1.2.0" />
-      <!--
-        System.Collections.Immutable can be removed once dafny.msbuild is updated with
-        https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned
-      -->
-      <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
-      <!-- Work around for dafny-lang/dafny/issues/1951; remove once resolved -->
-      <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-
       <Compile Include="Generated/**/*.cs" />
       <Compile Include="ImplementationFromDafny.cs" />
   </ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
@atomb 's Changes to allow the ESDK to verify with Dafny 4.4.

*Squash/merge commit message, if applicable:*
```
chore(MessageBody): CorrectlyRead for Dafny 4.4

Also fixes .NET dependencies,
which cannot pin indirect dependencies.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
