### PR TITLE
fix: throw an exception when MemoryStream instance has an empty backi…

### DIFF
--- a/AwsEncryptionSDK/runtimes/net/Generated/AwsEncryptionSdk/TypeConversion.cs
+++ b/AwsEncryptionSDK/runtimes/net/Generated/AwsEncryptionSdk/TypeConversion.cs
@@ -754,6 +754,17 @@ namespace AWS.Cryptography.EncryptionSDK
 
         public static Dafny.ISequence<byte> ToDafny_N6_smithy__N3_api__S4_Blob(System.IO.MemoryStream value)
         {
+            // BEGIN MANUAL EDIT
+            // It is possible for a MemoryStream to be implemented by another stream,
+            // which may or may not be backed with an array.
+            // If the array is empty, but the stream isn't, then
+            // the backing stream cannot be treated as a MemoryStream
+            // for purposes of type conversion through ToArray().
+            if (value.ToArray().Length == 0 && value.Length > 0)
+            {
+                throw new System.ArgumentException("Fatal Error: MemoryStream instance not backed by an array!");
+            }
+            // END MANUAL EDIT
             return Dafny.Sequence<byte>.FromArray(value.ToArray());
         }
 


### PR DESCRIPTION
…ng array

*Issue #, if available:* n/a

*Description of changes:* The encrypt/decrypt input/output classes use `MemoryStream` to pass the plaintext/ciphertext. It is possible to extend `MemoryStream` with a stream that, contrary to the specification of `MemoryStream`, does not store its contents in an array. This case is not supported by the current type conversion library; for now we will manually add an exception. 

An alternative solution considered would be to read from the stream, which is the correct way to handle streams in general. The code would look like this:

```
            bool originalStreamHasBeenRead;
            if (value.Position == value.Length)
            {
                // stream has been read to completion,
                // seek back to beginning
                value.Seek(0, SeekOrigin.Begin);
                originalStreamHasBeenRead = true;
            }
            else
            {
                originalStreamHasBeenRead = false;
            }
            
            // copy to a new stream backed by an in-memory array
            using(var memoryStream = new MemoryStream())
            {
                value.CopyTo(memoryStream);
                if (!originalStreamHasBeenRead)
                {
                   // rewind the original stream to preserve original behavior
                   value.Seek(0, SeekOrigin.Begin);
                }
                // send the backing array to Dafny 
                return Dafny.Sequence<byte>.FromArray(memoryStream.ToArray());
            }
```

Since this is meant to be a bug fix, I prefer to not change the fundamental nature of the type conversion, particularly not in the case of a manual edit. 

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
