### PR TITLE
fix: Remove --recursive from action to update mpl submodule

### DIFF
--- a/.github/actions/polymorph_codegen/action.yml
+++ b/.github/actions/polymorph_codegen/action.yml
@@ -61,7 +61,7 @@ runs:
       if: inputs.update-and-regenerate-mpl == 'true'
       shell: bash
       run: |
-        git submodule update --init --recursive --remote --merge mpl
+        git submodule update --remote --merge mpl
 
     - name: Don't regenerate dependencies unless requested
       id: dependencies


### PR DESCRIPTION
*Description of changes:*

Fixes both failures in the nightly build, since it was trying to also update the specification, which wasn't necessary and doesn't update cleanly: https://github.com/aws/aws-encryption-sdk-dafny/actions/runs/10475570505.

Also removed --init since that was pointless in this case.

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
