### PR TITLE
chore: Bump MPL dependency to 1.9.0, consolidate `project.properties` files

### DIFF
--- a/AwsEncryptionSDK/project.properties
+++ b/AwsEncryptionSDK/project.properties
@@ -1,4 +1,0 @@
-# This file stores the top level dafny version information.
-# All elements of the project need to agree on this version.
-dafnyVersion=4.9.0
-dafnyRuntimeJavaVersion=4.9.0

--- a/AwsEncryptionSDK/runtimes/java/build.gradle.kts
+++ b/AwsEncryptionSDK/runtimes/java/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 var props = Properties().apply {
     load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
 }
-var mplVersion = props.getProperty("mplDependencyJavaVersion")
+mplVersion = props.getProperty("mplDependencyJavaVersion")
 
 group = "software.amazon.cryptography"
 version = "1.0.0-SNAPSHOT"

--- a/AwsEncryptionSDK/runtimes/java/build.gradle.kts
+++ b/AwsEncryptionSDK/runtimes/java/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
 var props = Properties().apply {
     load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
 }
+mplVersion = props.getProperty("mplDependencyJavaVersion")
+
 group = "software.amazon.cryptography"
 version = "1.0.0-SNAPSHOT"
 description = "AwsEncryptionSdk"
@@ -32,7 +34,7 @@ repositories {
 dependencies {
     implementation("org.dafny:DafnyRuntime:4.9.0")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.8.0")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
 
     // Use JUnit test framework.
     testImplementation("junit:junit:4.13.2")

--- a/AwsEncryptionSDK/runtimes/java/build.gradle.kts
+++ b/AwsEncryptionSDK/runtimes/java/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 var props = Properties().apply {
     load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
 }
-mplVersion = props.getProperty("mplDependencyJavaVersion")
+var mplVersion = props.getProperty("mplDependencyJavaVersion")
 
 group = "software.amazon.cryptography"
 version = "1.0.0-SNAPSHOT"

--- a/AwsEncryptionSDK/runtimes/java/build.gradle.kts
+++ b/AwsEncryptionSDK/runtimes/java/build.gradle.kts
@@ -17,9 +17,9 @@ plugins {
 }
 
 var props = Properties().apply {
-    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+    load(FileInputStream(File(rootProject.rootDir, "../../../project.properties")))
 }
-mplVersion = props.getProperty("mplDependencyJavaVersion")
+var mplVersion = props.getProperty("mplDependencyJavaVersion")
 
 group = "software.amazon.cryptography"
 version = "1.0.0-SNAPSHOT"

--- a/TestVectors/project.properties
+++ b/TestVectors/project.properties
@@ -1,4 +1,0 @@
-# This file stores the top level dafny version information.
-# All elements of the project need to agree on this version.
-dafnyVersion=4.9.0
-dafnyRuntimeJavaVersion=4.9.0

--- a/TestVectors/runtimes/java/build.gradle.kts
+++ b/TestVectors/runtimes/java/build.gradle.kts
@@ -9,9 +9,9 @@ plugins {
 }
 
 var props = Properties().apply {
-    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+    load(FileInputStream(File(rootProject.rootDir, "../../../project.properties")))
 }
-mplVersion = props.getProperty("mplDependencyJavaVersion")
+var mplVersion = props.getProperty("mplDependencyJavaVersion")
 
 group = "software.amazon.cryptography"
 version = "1.0.0-SNAPSHOT"

--- a/TestVectors/runtimes/java/build.gradle.kts
+++ b/TestVectors/runtimes/java/build.gradle.kts
@@ -33,8 +33,8 @@ repositories {
 dependencies {
     implementation("org.dafny:DafnyRuntime:4.8.0")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.8.0")
-    implementation("software.amazon.cryptography:TestAwsCryptographicMaterialProviders:1.8.0-SNAPSHOT")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
+    implementation("software.amazon.cryptography:TestAwsCryptographicMaterialProviders:${mplVersion}")
     implementation("software.amazon.cryptography:aws-encryption-sdk:1.0.0-SNAPSHOT")
     implementation("com.amazonaws:aws-encryption-sdk-java:3.0.1")
     implementation(platform("software.amazon.awssdk:bom:2.25.1"))

--- a/TestVectors/runtimes/java/build.gradle.kts
+++ b/TestVectors/runtimes/java/build.gradle.kts
@@ -1,3 +1,7 @@
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
+
 tasks.wrapper {
     gradleVersion = "7.6"
 }

--- a/TestVectors/runtimes/java/build.gradle.kts
+++ b/TestVectors/runtimes/java/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 var props = Properties().apply {
     load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
 }
-var mplVersion = props.getProperty("mplDependencyJavaVersion")
+mplVersion = props.getProperty("mplDependencyJavaVersion")
 
 group = "software.amazon.cryptography"
 version = "1.0.0-SNAPSHOT"

--- a/TestVectors/runtimes/java/build.gradle.kts
+++ b/TestVectors/runtimes/java/build.gradle.kts
@@ -8,6 +8,11 @@ plugins {
     `application`
 }
 
+var props = Properties().apply {
+    load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
+}
+mplVersion = props.getProperty("mplDependencyJavaVersion")
+
 group = "software.amazon.cryptography"
 version = "1.0.0-SNAPSHOT"
 description = "AwsEncryptionSDKJavaTestVectors"

--- a/TestVectors/runtimes/java/build.gradle.kts
+++ b/TestVectors/runtimes/java/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 var props = Properties().apply {
     load(FileInputStream(File(rootProject.rootDir, "../../project.properties")))
 }
-mplVersion = props.getProperty("mplDependencyJavaVersion")
+var mplVersion = props.getProperty("mplDependencyJavaVersion")
 
 group = "software.amazon.cryptography"
 version = "1.0.0-SNAPSHOT"

--- a/project.properties
+++ b/project.properties
@@ -2,6 +2,6 @@ dafnyVersion=4.9.0
 dafnyVerifyVersion=4.9.0
 dafnyFormatVersion=4.9.0
 projectJavaVersion=4.1.0
-mplDependencyJavaVersion=1.8.0
+mplDependencyJavaVersion=1.9.0
 dafnyRuntimeJavaVersion=4.9.0
 smithyDafnyJavaConversionVersion=0.1.1

--- a/project.properties
+++ b/project.properties
@@ -2,6 +2,6 @@ dafnyVersion=4.9.0
 dafnyVerifyVersion=4.9.0
 dafnyFormatVersion=4.9.0
 projectJavaVersion=4.1.0
-mplDependencyJavaVersion=1.9.0
+mplDependencyJavaVersion=1.9.0-SNAPSHOT
 dafnyRuntimeJavaVersion=4.9.0
 smithyDafnyJavaConversionVersion=0.1.1

--- a/project.properties
+++ b/project.properties
@@ -1,3 +1,5 @@
+# This file stores the top level dafny version information.
+# All elements of the project need to agree on this version.
 dafnyVersion=4.9.0
 dafnyVerifyVersion=4.9.0
 dafnyFormatVersion=4.9.0


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

* Bumping to MPL 1.9.0
* Consolidate per Smithy-Dafny project `project.properties` files into top-level file. I believe we only want one of these, since the version variables should be shared across ESDK and TestVectors.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
