### PR TITLE
chore: re-enable Dafny for MacOS

### DIFF
--- a/.github/actions/setup_dafny/action.yml
+++ b/.github/actions/setup_dafny/action.yml
@@ -1,0 +1,29 @@
+#
+#
+# This local action consolidate all uses of dafny-lang/setup-dafny-action
+# Once the MPL is updated, this action can point to the MPL version.
+#
+name: "Setup Dafny"
+description: "This uses the setup Dafny action."
+inputs:
+  dafny-version:
+    description: "The Dafny version to setup"
+    required: true
+    type: string
+runs:
+  using: "composite"
+  steps:
+    # The dotnet tool requires >= 9.0.202 to work on MacOS
+    # See: https://github.com/dotnet/sdk/issues/46857#issuecomment-2734338347
+    # Ideally this action would only install this on MacOS,
+    # but I do not want to keep track of the various values
+    # See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#detecting-the-operating-system
+    - name: Setup .NET Core SDK '9.0.x'
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: "9.0.x"
+
+    - name: Setup Dafny with setup-dafny action
+      uses: dafny-lang/setup-dafny-action@v1.8.0
+      with:
+        dafny-version: ${{ inputs.dafny-version }}

--- a/.github/workflows/dafny_interop_test_net.yml
+++ b/.github/workflows/dafny_interop_test_net.yml
@@ -57,7 +57,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Setup MPL Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.mpl-dafny }}
 
@@ -91,7 +91,7 @@ jobs:
           make transpile_net CORES=$CORES
 
       - name: Setup ESDK Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.esdk-dafny}}
 

--- a/.github/workflows/dafny_interop_test_vector_net.yml
+++ b/.github/workflows/dafny_interop_test_vector_net.yml
@@ -56,7 +56,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Setup MPL Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.mpl-dafny }}
 
@@ -90,7 +90,7 @@ jobs:
           make transpile_net CORES=$CORES
 
       - name: Setup ESDK Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.esdk-dafny}}
 
@@ -163,7 +163,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Setup MPL Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.mpl-dafny }}
 
@@ -197,7 +197,7 @@ jobs:
           make transpile_net CORES=$CORES
 
       - name: Setup ESDK Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.esdk-dafny}}
 

--- a/.github/workflows/library_codegen.yml
+++ b/.github/workflows/library_codegen.yml
@@ -41,7 +41,7 @@ jobs:
       # and to translate version strings such as "nightly-latest"
       # to an actual DAFNY_VERSION.
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -43,7 +43,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 

--- a/.github/workflows/library_format.yml
+++ b/.github/workflows/library_format.yml
@@ -37,7 +37,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -50,7 +50,7 @@ jobs:
           role-session-name: GoTests
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 

--- a/.github/workflows/library_interop_test_vectors.yml
+++ b/.github/workflows/library_interop_test_vectors.yml
@@ -88,13 +88,13 @@ jobs:
 
       - name: Setup Dafny Rust
         if: matrix.language == 'rust'
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: nightly-2025-01-30-7db1e5f
 
       - name: Setup Dafny Not Rust
         if: matrix.language != 'rust'
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 
@@ -259,13 +259,13 @@ jobs:
 
       - name: Setup Dafny Rust
         if: matrix.decrypting_language == 'rust'
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: nightly-2025-01-30-7db1e5f
 
       - name: Setup Dafny Not Rust
         if: matrix.decrypting_language != 'rust'
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -56,7 +56,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 
@@ -150,7 +150,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -49,7 +49,7 @@ jobs:
           role-session-name: JavaTests
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 

--- a/.github/workflows/library_legacy_interop_test_vectors.yml
+++ b/.github/workflows/library_legacy_interop_test_vectors.yml
@@ -74,7 +74,7 @@ jobs:
           java-version: 17
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -63,7 +63,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 
@@ -169,7 +169,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: ${{ inputs.dafny }}
 

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -49,7 +49,7 @@ jobs:
           components: rustfmt
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: nightly-2025-01-30-7db1e5f
 
@@ -147,7 +147,7 @@ jobs:
           components: rustfmt
 
       - name: Setup Dafny
-        uses: dafny-lang/setup-dafny-action@v1.8.0
+        uses: ./.github/actions/setup_dafny
         with:
           dafny-version: nightly-2025-01-30-7db1e5f
 


### PR DESCRIPTION
.NET had a signature failure in MacOS.
This was fixed in 9.0.202.
This installs at least this version of .NET
to make the setup-dafny-action succeed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
