### PR TITLE
chore(dafny): update makefile to only use prettier 3.5.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,4 +68,4 @@ format_java_misc-check: setup_prettier
 	npx prettier --plugin=prettier-plugin-java . --check
 
 setup_prettier:
-	npm i --no-save prettier@3 prettier-plugin-java@2.5
+	npm i --no-save prettier@3.5.3 prettier-plugin-java@2.5


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
prettier 3.6.0 has a breaking change.

_Squash/merge commit message, if applicable:_
chore(dafny): update makefile to only use prettier 3.5.3 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
