### PR TITLE
fix(dotnet): resolve AWS SDK and MPL Dependency to supported version

### DIFF
--- a/AwsEncryptionSDK/runtimes/net/ESDK.csproj
+++ b/AwsEncryptionSDK/runtimes/net/ESDK.csproj
@@ -30,10 +30,10 @@
 
   <ItemGroup>
       <!-- TODO: manually upgraded to match the latest from MPL, is that reasonable? -->
-      <PackageReference Include="AWSSDK.Core" Version="3.7.*" />
       <PackageReference Include="DafnyRuntime" Version="4.9.0" />
       <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
-      <ProjectReference Include="../../../mpl/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj" />
+      <!-- See https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges   -->
+      <PackageReference Include="AWS.Cryptography.MaterialProviders" Version="[1.7.5, 1.7.6]" />
       <!--
         System.Collections.Immutable can be removed once dafny.msbuild is updated with
         https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

_Squash/merge commit message, if applicable:_

NOTE: This downgraded the MPL submodule to MPL just pass 1.7.5; I expect only .NET will pass tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
