### PR TITLE
chore: dotnet 4.1.1 release using only mpl-1.7.6

### DIFF
--- a/.github/actions/polymorph_codegen/action.yml
+++ b/.github/actions/polymorph_codegen/action.yml
@@ -116,11 +116,11 @@ runs:
     #   run: |
     #     make polymorph_rust ${{ steps.dependencies.outputs.PROJECT_DEPENDENCIES }}
 
-    - name: Regenerate Go code using smithy-dafny
-      working-directory: ./${{ inputs.library }}
-      shell: bash
-      run: |
-        make polymorph_go
+    # - name: Regenerate Go code using smithy-dafny
+    #   working-directory: ./${{ inputs.library }}
+    #   shell: bash
+    #   run: |
+    #     make polymorph_go
 
     - name: Check regenerated code against commited code
       # Composite action inputs seem to not actually support booleans properly for some reason

--- a/.github/workflows/library_interop_test_vectors.yml
+++ b/.github/workflows/library_interop_test_vectors.yml
@@ -25,7 +25,7 @@ jobs:
             ubuntu-22.04,
             macos-13,
           ]
-        language: [java, net, rust, go]
+        language: [java, net]
         # https://taskei.amazon.dev/tasks/CrypTool-5284
         dotnet-version: ["6.0.x"]
     runs-on: ${{ matrix.os }}
@@ -195,8 +195,8 @@ jobs:
             ubuntu-22.04,
             macos-13,
           ]
-        encrypting_language: [java, net, rust, go]
-        decrypting_language: [java, net, rust, go]
+        encrypting_language: [java, net]
+        decrypting_language: [java, net]
         # https://taskei.amazon.dev/tasks/CrypTool-5284
         dotnet-version: ["6.0.x"]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -36,16 +36,16 @@ jobs:
     uses: ./.github/workflows/library_net_tests.yml
     with:
       dafny: ${{needs.getVersion.outputs.version}}
-  pr-ci-rust:
-    needs: getVersion
-    uses: ./.github/workflows/library_rust_tests.yml
-    with:
-      dafny: ${{needs.getVersion.outputs.version}}
-  pr-ci-go:
-    needs: getVersion
-    uses: ./.github/workflows/library_go_tests.yml
-    with:
-      dafny: ${{needs.getVersion.outputs.version}}
+  # pr-ci-rust:
+  #   needs: getVersion
+  #   uses: ./.github/workflows/library_rust_tests.yml
+  #   with:
+  #     dafny: ${{needs.getVersion.outputs.version}}
+  # pr-ci-go:
+  #   needs: getVersion
+  #   uses: ./.github/workflows/library_go_tests.yml
+  #   with:
+  #     dafny: ${{needs.getVersion.outputs.version}}
   pr-test-vectors:
     needs: getVersion
     uses: ./.github/workflows/library_interop_tests.yml
@@ -67,7 +67,7 @@ jobs:
       - pr-ci-codegen
       - pr-ci-verification
       - pr-ci-net
-      - pr-ci-rust
+      # - pr-ci-rust
       - pr-test-vectors
       - pr-dafny-test-vectors
       - pr-dafny-legacy-test-vectors

--- a/AwsEncryptionSDK/codebuild/release/release-staging.yml
+++ b/AwsEncryptionSDK/codebuild/release/release-staging.yml
@@ -82,6 +82,9 @@ phases:
       - aws sts get-caller-identity
       - make test_net
 
+      # Also transpile MPL test vectors which are needed for ESDK tests
+      - cd ../mpl/TestVectorsAwsCryptographicMaterialProviders && make transpile_implementation_net && cd ../../AwsEncryptionSDK
+
       # add staged artifact to testvectors
       - sed -i.backup  "/\<ProjectReference Include=\"..\/..\/ESDK.csproj\" \/>/d" runtimes/net/TestVectorsNative/TestVectorLib/AWSEncryptionSDKTestVectorLib.csproj
       - dotnet add runtimes/net/TestVectorsNative/TestVectorLib/AWSEncryptionSDKTestVectorLib.csproj package AWS.Cryptography.EncryptionSDK --version $VERSION

--- a/AwsEncryptionSDK/codebuild/release/test-prod.yml
+++ b/AwsEncryptionSDK/codebuild/release/test-prod.yml
@@ -43,6 +43,9 @@ phases:
       - aws sts get-caller-identity
       - make test_net
 
+      # Also transpile MPL test vectors which are needed for ESDK tests
+      - cd ../mpl/TestVectorsAwsCryptographicMaterialProviders && make transpile_implementation_net && cd ../../AwsEncryptionSDK
+
       # add released artifact to testvectors
       - sed -i.backup  "/\<ProjectReference Include=\"..\/..\/ESDK.csproj\" \/>/d" runtimes/net/TestVectorsNative/TestVectorLib/AWSEncryptionSDKTestVectorLib.csproj
       - dotnet add runtimes/net/TestVectorsNative/TestVectorLib/AWSEncryptionSDKTestVectorLib.csproj package AWS.Cryptography.EncryptionSDK --version $VERSION

--- a/AwsEncryptionSDK/dafny/AwsEncryptionSdk/test/Fixtures.dfy
+++ b/AwsEncryptionSDK/dafny/AwsEncryptionSdk/test/Fixtures.dfy
@@ -20,7 +20,7 @@ module Fixtures {
 
   const branchKeyStoreName := "KeyStoreDdbTable"
   const logicalKeyStoreName := branchKeyStoreName
-  const branchKeyId := "75789115-1deb-4fe3-a2ec-be9e885d1945"
+  const branchKeyId := "3f43a9af-08c5-4317-b694-3d3e883dcaef"
 
   // UTF-8 encoded "aws-crypto-"
   const RESERVED_ENCRYPTION_CONTEXT: UTF8.ValidUTF8Bytes :=

--- a/AwsEncryptionSDK/runtimes/net/CHANGELOG.md
+++ b/AwsEncryptionSDK/runtimes/net/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.1.1
+
+### Notes
+
+Update .csproj files to prevent use of AWS-SDK-NET V4
+
 ## 4.1.0
 
 ### Notes

--- a/AwsEncryptionSDK/runtimes/net/ESDK.csproj
+++ b/AwsEncryptionSDK/runtimes/net/ESDK.csproj
@@ -8,7 +8,7 @@
       <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
       <IsPackable>true</IsPackable>
       
-      <Version>4.1.0</Version>
+      <Version>4.1.1</Version>
 
       <AssemblyName>AWS.Cryptography.EncryptionSDK</AssemblyName>
       <PackageId>AWS.Cryptography.EncryptionSDK</PackageId>
@@ -30,10 +30,8 @@
 
   <ItemGroup>
       <!-- TODO: manually upgraded to match the latest from MPL, is that reasonable? -->
-      <PackageReference Include="AWSSDK.Core" Version="3.7.*" />
-      <PackageReference Include="DafnyRuntime" Version="4.9.0" />
-      <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
-      <ProjectReference Include="../../../mpl/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj" />
+      <PackageReference Include="DafnyRuntime" Version="[4.9.0]" />
+      <PackageReference Include="AWS.Cryptography.MaterialProviders" Version="[1.7.6]" />
       <!--
         System.Collections.Immutable can be removed once dafny.msbuild is updated with
         https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned

--- a/TestVectors/runtimes/java/settings.gradle.kts
+++ b/TestVectors/runtimes/java/settings.gradle.kts
@@ -8,4 +8,3 @@
  */
 
 rootProject.name = "TestVectors"
-include("lib")


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

- Release ESDK dotnet by only updating MPL version 'ESDK.csproj' and not bumping to the MPL dotnet commit.
- See #830 for CI checks when a submodule is updated to MPL dotnet commit.
   - All checks pass except Codegen on #830 will fail while MPL polymorph, because MPL dotnet and ESDK dotnet base have different smithy dafny.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
