### PR TITLE
fix: add apt-get update before libcurl install in CI workflows

### DIFF
--- a/.github/workflows/library_interop_keyring_test_vectors.yml
+++ b/.github/workflows/library_interop_keyring_test_vectors.yml
@@ -65,7 +65,10 @@ jobs:
 
       - name: Install LibCurl
         if: matrix.os == 'ubuntu-22.04' && matrix.language == 'c'
-        run: sudo apt-get install libcurl4-openssl-dev
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev --fix-missing
 
       - name: Checkout C-ESDK
         if: matrix.language == 'c'
@@ -352,7 +355,10 @@ jobs:
 
       - name: Install LibCurl
         if: matrix.os == 'ubuntu-22.04' && matrix.decrypting_language == 'c'
-        run: sudo apt-get install libcurl4-openssl-dev
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev --fix-missing
 
       - name: Checkout C-ESDK
         if: matrix.decrypting_language == 'c'


### PR DESCRIPTION
Run `apt-get update` before installing `libcurl4-openssl-dev` to avoid stale package index failures. Also adds `--fix-missing` flag and explicit `shell: bash` to both Install LibCurl steps in the interop keyring test vectors workflow.