### PR TITLE
ci: reduce flakiness of install_smithy_dafny_codegen_dependencies

### DIFF
--- a/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
+++ b/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
@@ -13,6 +13,15 @@ runs:
       with:
         distribution: "corretto"
         java-version: "17"
+        cache: "gradle"
+
+    - name: Cache Maven local repository
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-smithy-dafny
+        restore-keys: |
+          ${{ runner.os }}-maven-
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
@@ -32,6 +41,7 @@ runs:
       with:
         python-version: 3.11
         architecture: x64
+        cache: "pip"
     - shell: bash
       run: |
         python -m pip install --upgrade pip
@@ -42,11 +52,16 @@ runs:
       uses: actions/setup-go@v6
       with:
         go-version: "1.23"
+        cache: false # No go.mod at repo root; project-level caching handled in test workflows
 
     - name: Install Go imports
-      shell: bash
-      run: |
-        go install golang.org/x/tools/cmd/goimports@v0.36.0
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 10
+        retry_wait_seconds: 30
+        max_attempts: 3
+        shell: bash
+        command: go install golang.org/x/tools/cmd/goimports@v0.36.0
 
     # Without this the if-dafny-at-least command includes "Downloading ..." output
     - name: Arbitrary makefile target to force downloading Gradle (with retry)


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Ports CI caching and retry improvements from the material providers library to reduce flakiness in CI jobs.

Source PRs:
- https://github.com/aws/aws-cryptographic-material-providers-library/pull/1824
- https://github.com/aws/aws-cryptographic-material-providers-library/pull/1825

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.