### PR TITLE
chore(rust): run clippy on CI and allow large error for Clippy 

### DIFF
--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Rust Toolchain for GitHub CI
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Setup Dafny
         uses: ./mpl/.github/actions/setup_dafny
@@ -93,6 +93,13 @@ jobs:
           # This works because `node` is installed by default on GHA runners
           CORES=$(node -e 'console.log(os.cpus().length)')
           make transpile_rust CORES=$CORES
+
+      - name: Run clippy
+        working-directory: ${{ matrix.library }}/runtimes/rust
+        shell: bash
+        run: |
+          cargo clippy
+          cargo clippy --example main
 
       - name: Test Rust
         working-directory: ${{ matrix.library }}

--- a/AwsEncryptionSDK/runtimes/rust/examples/main.rs
+++ b/AwsEncryptionSDK/runtimes/rust/examples/main.rs
@@ -4,6 +4,7 @@
 #![deny(warnings, unconditional_panic)]
 #![deny(nonstandard_style)]
 #![deny(clippy::all)]
+#![allow(clippy::result_large_err)]
 
 pub mod client_supplier;
 pub mod cryptographic_materials_manager;


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

- We run Clippy while doing the release ([here](https://github.com/aws/aws-encryption-sdk/blob/mainline/AwsEncryptionSDK/runtimes/rust/start_release.sh#L64-L66)). We should do the same in the CI to catch issues faster and make release smooth. 

- Allowing large error as I don't think changing MPL error is a right path.

_Squash/merge commit message, if applicable:_
```
chore(rust): run clippy on CI and allow large error for Clippy 
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
