### PR TITLE
fix: match arms in Fixtures.dfy use CD to match datatype variant

### DIFF
--- a/AwsEncryptionSDK/dafny/AwsEncryptionSdk/test/Fixtures.dfy
+++ b/AwsEncryptionSDK/dafny/AwsEncryptionSdk/test/Fixtures.dfy
@@ -56,7 +56,7 @@ module Fixtures {
         encryptionContext := map[keyB := valB, keyA := valA];
       case C =>
         encryptionContext := map[keyC := valC];
-      case CE =>
+      case CD =>
         encryptionContext := map[keyC := valC, keyD := valD];
     }
   }
@@ -91,7 +91,7 @@ module Fixtures {
         encryptionContextKeys := [keyB, keyA];
       case C =>
         encryptionContextKeys := [keyC];
-      case CE =>
+      case CD =>
         encryptionContextKeys := [keyC, keyD];
     }
   }
@@ -120,7 +120,7 @@ module Fixtures {
         encryptionContext := map[keyB := valA, keyA := valB];
       case C =>
         encryptionContext := map[keyC := valA];
-      case CE =>
+      case CD =>
         encryptionContext := map[keyC := valA, keyD := valB];
     }
   }


### PR DESCRIPTION
The `SmallEncryptionContextVariation` datatype declares a `CD` variant, but all match arms in `SmallEncryptionContext`, `SmallEncryptionContextKeys`, and `SmallMismatchedEncryptionContex` used `CE`. Dafny treated `CE` as a variable binding (catch-all) rather than a constructor match, masking the bug.

This renames the match arms from `CE` to `CD` to match the declared variant.

**Testing:** Ran `make verify_single FILE=dafny/AwsEncryptionSdk/test/Fixtures.dfy` — all three affected methods verify as Correct.