### PR TITLE
chore: update Node.js version to 22 in workflow 

### DIFF
--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -266,7 +266,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 17
+          node-version: 22
 
       - name: Install deps
         run: |


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
CI is broken because of https://github.com/smithy-lang/smithy-typescript/issues/2022. The node version is already too old in CI, so updating it instead of waiting for the fix.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
