### PR TITLE
feat(native-rust): message body framing (framed and non-framed)

### DIFF
--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -3,7 +3,7 @@
 
 //! Frame decryption and body deserialization.
 
-use super::{BodyAADContent, body_aad, get_encrypt};
+use super::{BodyAADContent, body_aad, get_aes_gcm};
 use crate::error::esdk_err;
 use crate::message::header::{ENDFRAME_SEQUENCE_NUMBER, HeaderInfo, START_SEQUENCE_NUMBER};
 use crate::message::serializable_types::{get_iv_length, get_tag_length};
@@ -34,7 +34,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
     //# The authentication tag length MUST be equal to the authentication tag length of the algorithm suite
     //# specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
     let mut auth_tag = vec![0u8; usize::from(get_tag_length(&header.suite))];
-    let alg = get_encrypt(&header.suite)?;
+    let aes_gcm = get_aes_gcm(&header.suite)?;
     let frame_length_u64 = u64::from(header.body.frame_length());
     let Ok(frame_length_usize) = usize::try_from(header.body.frame_length()) else {
         return ser_err(&format!(
@@ -259,7 +259,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                 // final frame is empty, so return last full frame
                 let mut empty_result = Vec::new();
                 aes_decrypt(
-                    alg,
+                    aes_gcm,
                     key,
                     &enc_content,
                     //= spec/data-format/message-body.md#final-frame-authentication-tag
@@ -282,7 +282,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                 if expected_frame != START_SEQUENCE_NUMBER {
                     if fail_if_multi_frame {
                         return Err(esdk_err(
-                            "Streaming interface can return data before signature has been validated. Set `allow_unsafe_unverified_signature` in the DecryptStreamInput struct if this is ok",
+                            "Streaming a multi-frame signed message would release plaintext before signature verification. Set `unsafe_release_plaintext_before_verify = true` in DecryptStreamInput to allow this.",
                         ));
                     }
                     write_bytes(w, &result)?;
@@ -291,7 +291,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                 //= reason=`?` propagates aes_decrypt errors, halting decryption immediately
                 //# If this decryption fails, this operation MUST immediately halt and fail.
                 aes_decrypt(
-                    alg,
+                    aes_gcm,
                     key,
                     &enc_content,
                     &auth_tag,
@@ -339,7 +339,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         if expected_frame != START_SEQUENCE_NUMBER {
             if fail_if_multi_frame {
                 return Err(esdk_err(
-                    "Streaming interface can return data before signature has been validated. Set `allow_unsafe_unverified_signature` in the DecryptStreamInput struct if this is ok",
+                    "Streaming a multi-frame signed message would release plaintext before signature verification. Set `unsafe_release_plaintext_before_verify = true` in DecryptStreamInput to allow this.",
                 ));
             }
             write_bytes(w, &result)?;
@@ -460,7 +460,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         //= reason=`?` propagates aes_decrypt errors, halting decryption immediately
         //# If this decryption fails, this operation MUST immediately halt and fail.
         aes_decrypt(
-            alg,
+            aes_gcm,
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=key is the derived data key passed from step_decrypt_body
             //# - The cipherkey MUST be the derived data key
@@ -647,7 +647,7 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     //= reason=`?` propagates aes_decrypt errors, halting decryption immediately
     //# If this decryption fails, this operation MUST immediately halt and fail.
     aes_decrypt(
-        get_encrypt(&header.suite)?,
+        get_aes_gcm(&header.suite)?,
         //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
         //# - The cipherkey MUST be the derived data key.
         //

--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -27,15 +27,20 @@ pub(crate) fn read_and_decrypt_framed_message_body(
 
     //= spec/data-format/message-body.md#regular-frame-iv
     //# The IV length MUST be equal to the IV length of the algorithm suite specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
-    let mut iv = vec![0u8; get_iv_length(&header.suite) as usize];
+    let mut iv = vec![0u8; usize::from(get_iv_length(&header.suite))];
 
     //= spec/data-format/message-body.md#regular-frame-authentication-tag
     //# The authentication tag length MUST be equal to the authentication tag length of the algorithm suite
     //# specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
-    let mut auth_tag = vec![0u8; get_tag_length(&header.suite) as usize];
+    let mut auth_tag = vec![0u8; usize::from(get_tag_length(&header.suite))];
     let alg = get_encrypt(&header.suite)?;
     let frame_length_u64 = u64::from(header.body.frame_length());
-    let frame_length_usize = header.body.frame_length() as usize;
+    let Ok(frame_length_usize) = usize::try_from(header.body.frame_length()) else {
+        return ser_err(&format!(
+            "Frame length {} exceeds usize::MAX",
+            header.body.frame_length()
+        ));
+    };
     let mut enc_content = vec![0u8; frame_length_usize];
     let mut result = vec![0; frame_length_usize];
     let mut aad = Vec::new();
@@ -211,7 +216,13 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                 //# field in the message header.
                 {
                     debug_assert!(enc_content.len() <= frame_length_usize);
-                    enc_content.len() as u64
+                    let Ok(enc_len_u64) = u64::try_from(enc_content.len()) else {
+                        return ser_err(&format!(
+                            "Final-frame encrypted content length {} exceeds u64::MAX",
+                            enc_content.len()
+                        ));
+                    };
+                    enc_len_u64
                 },
                 &mut aad,
             );
@@ -472,10 +483,10 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     //# The IV MUST be interpreted as bytes.
     let iv = serialize_functions::read_vec(
         ciphertext,
-        get_iv_length(&header.suite) as usize,
+        usize::from(get_iv_length(&header.suite)),
         sig_digest,
     )?;
-    debug_assert_eq!(iv.len(), get_iv_length(&header.suite) as usize);
+    debug_assert_eq!(iv.len(), usize::from(get_iv_length(&header.suite)));
 
     //= spec/data-format/message-body.md#nonframed-data-encrypted-content-length
     //# The encrypted content length MUST be interpreted as a UInt64.
@@ -505,7 +516,11 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     )?;
     // read_seq_u64_bounded reads the u64 length then reads exactly that many bytes,
     // so enc_content.len() is guaranteed to equal the deserialized content length field.
-    debug_assert!(enc_content.len() as u64 <= header::SAFE_MAX_ENCRYPT);
+    debug_assert!(
+        u64::try_from(enc_content.len())
+            .map(|n| n <= header::SAFE_MAX_ENCRYPT)
+            .unwrap_or(false)
+    );
 
     // Authentication Tag
     //= spec/data-format/message-body.md#nonframed-data-authentication-tag
@@ -523,10 +538,10 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     //# The authentication tag value MUST be interpreted as bytes.
     let auth_tag = serialize_functions::read_vec(
         ciphertext,
-        get_tag_length(&header.suite) as usize,
+        usize::from(get_tag_length(&header.suite)),
         sig_digest,
     )?;
-    debug_assert_eq!(auth_tag.len(), get_tag_length(&header.suite) as usize);
+    debug_assert_eq!(auth_tag.len(), usize::from(get_tag_length(&header.suite)));
     let mut aad = Vec::new();
 
     //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
@@ -568,7 +583,12 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
             //= reason=enc_content.len() equals the length of the encrypted content
             //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
             //# equal to the length of the plaintext that was encrypted.
-            let content_len = enc_content.len() as u64;
+            let Ok(content_len) = u64::try_from(enc_content.len()) else {
+                return ser_err(&format!(
+                    "Nonframed encrypted content length {} exceeds u64::MAX",
+                    enc_content.len()
+                ));
+            };
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=enc_content.len() is the nonframed data encrypted content length deserialized from the body
             //# If this is nonframed data, this MUST be determined by using the [nonframed data encrypted content length](../data-format/message-body.md#nonframed-data-encrypted-content-length).

--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -223,6 +223,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             //# specified by the [algorithm suite](../framework/algorithm-suites.md), with the following inputs:
             if enc_content.is_empty() {
                 //= spec/client-apis/decrypt.md#decrypt-the-message-body
+                //= reason=`?` propagates aes_decrypt errors, halting decryption immediately
                 //# If this decryption fails, this operation MUST immediately halt and fail.
                 // final frame is empty, so return last full frame
                 let mut empty_result = Vec::new();
@@ -249,6 +250,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                     write_bytes(w, &result)?;
                 }
                 //= spec/client-apis/decrypt.md#decrypt-the-message-body
+                //= reason=`?` propagates aes_decrypt errors, halting decryption immediately
                 //# If this decryption fails, this operation MUST immediately halt and fail.
                 aes_decrypt(
                     alg,
@@ -400,6 +402,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         //# specified by the [algorithm suite](../framework/algorithm-suites.md), with the following inputs:
         //
         //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=`?` propagates aes_decrypt errors, halting decryption immediately
         //# If this decryption fails, this operation MUST immediately halt and fail.
         aes_decrypt(
             alg,
@@ -578,6 +581,7 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     let mut result: Vec<u8> = enc_content.clone();
 
     //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //= reason=`?` propagates aes_decrypt errors, halting decryption immediately
     //# If this decryption fails, this operation MUST immediately halt and fail.
     aes_decrypt(
         get_encrypt(&header.suite)?,

--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -140,6 +140,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             //# The length of the IV field MUST be equal to the IV length of the [algorithm suite](../framework/algorithm-suites.md) that generated the message.
             //
             //= spec/data-format/message-body.md#final-frame-iv
+            //= type=implication
+            //= reason=read_bytes fills a &mut [u8] buffer; the bytes are not reinterpreted as any other type
             //# The IV MUST be interpreted as bytes.
             read_bytes(ciphertext, &mut iv, sig_digest)?;
 
@@ -167,6 +169,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             //# - MUST deserialize the [Encrypted Content](../data-format/message-body.md#final-frame-encrypted-content).
             //
             //= spec/data-format/message-body.md#final-frame-encrypted-content
+            //= type=implication
+            //= reason=read_seq_u32_bounded fills a &mut [u8] buffer; the bytes are not reinterpreted as any other type
             //# The encrypted content MUST be interpreted as bytes.
             read_seq_u32_bounded(
                 ciphertext,
@@ -191,6 +195,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             //# specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
             //
             //= spec/data-format/message-body.md#final-frame-authentication-tag
+            //= type=implication
+            //= reason=read_bytes fills a &mut [u8] buffer; the bytes are not reinterpreted as any other type
             //# The authentication tag MUST be interpreted as bytes.
             read_bytes(ciphertext, &mut auth_tag, sig_digest)?;
 
@@ -351,6 +357,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         //# - MUST deserialize the [IV](../data-format/message-body.md#regular-frame-iv).
         //
         //= spec/data-format/message-body.md#regular-frame-iv
+        //= type=implication
+        //= reason=read_bytes fills a &mut [u8] buffer; the bytes are not reinterpreted as any other type
         //# The IV MUST be interpreted as bytes.
         //
         //= spec/client-apis/decrypt.md#decrypt-the-message-body
@@ -371,6 +379,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         //# The length of the encrypted content of a Regular Frame MUST be equal to the Frame Length.
         //
         //= spec/data-format/message-body.md#regular-frame-encrypted-content
+        //= type=implication
+        //= reason=read_bytes fills a &mut [u8] buffer; the bytes are not reinterpreted as any other type
         //# The encrypted content MUST be interpreted as bytes.
         read_bytes(ciphertext, &mut enc_content, sig_digest)?;
 
@@ -381,6 +391,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         //# - MUST deserialize the [Authentication Tag](../data-format/message-body.md#regular-frame-authentication-tag).
         //
         //= spec/data-format/message-body.md#regular-frame-authentication-tag
+        //= type=implication
+        //= reason=read_bytes fills a &mut [u8] buffer; the bytes are not reinterpreted as any other type
         //# The authentication tag MUST be interpreted as bytes.
         read_bytes(ciphertext, &mut auth_tag, sig_digest)?;
 
@@ -511,6 +523,7 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     //# padded to the [IV length](../data-format/message-header.md#iv-length) with 0.
     //
     //= spec/data-format/message-body.md#nonframed-data-iv
+    //= type=implication
     //= reason=read_vec returns Vec<u8>
     //# The IV MUST be interpreted as bytes.
     let iv = serialize_functions::read_vec(
@@ -538,6 +551,7 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     //# - The ciphertext MUST be the [Encrypted Content](../data-format/message-body.md#nonframed-data-encrypted-content) deserialized from the message body.
     //
     //= spec/data-format/message-body.md#nonframed-data-encrypted-content
+    //= type=implication
     //= reason=read_seq_u64_bounded returns Vec<u8>
     //# The encrypted content value MUST be interpreted as bytes.
     let enc_content = serialize_functions::read_seq_u64_bounded(
@@ -565,6 +579,7 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     //# - The tag MUST be the authentication tag deserialized from the frame or body.
     //
     //= spec/data-format/message-body.md#nonframed-data-authentication-tag
+    //= type=implication
     //= reason=read_vec returns Vec<u8>
     //# The authentication tag value MUST be interpreted as bytes.
     let auth_tag = serialize_functions::read_vec(

--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -108,6 +108,9 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             //# Encrypted Content,
             //# and Authentication Tag.
 
+            // Sequence Number End — already read above (the 4 bytes that matched ENDFRAME_SEQUENCE_NUMBER).
+
+            // Sequence Number
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=read_u32 reads the final frame sequence number after the ENDFRAME marker
             //# - MUST deserialize the [Sequence Number](../data-format/message-body.md#final-frame-sequence-number).
@@ -126,6 +129,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                 return ser_err("Final sequence number out of order");
             }
 
+            // IV
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=read_bytes reads IV bytes from the final frame
             //# - MUST deserialize the [IV](../data-format/message-body.md#final-frame-iv).
@@ -137,6 +141,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             //# The IV MUST be interpreted as bytes.
             read_bytes(ciphertext, &mut iv, sig_digest)?;
 
+            // Encrypted Content Length + Encrypted Content
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=read_seq_u32_bounded reads the encrypted content length field from the final frame
             //# - MUST deserialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
@@ -172,6 +177,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                 sig_digest,
             )?;
 
+            // Authentication Tag
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=read_bytes reads the authentication tag bytes from the final frame
             //# - MUST deserialize the [Authentication Tag](../data-format/message-body.md#final-frame-authentication-tag).

--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -1,0 +1,602 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//! Frame decryption and body deserialization.
+
+use super::{BodyAADContent, body_aad, get_encrypt};
+use crate::error::esdk_err;
+use crate::message::header::{ENDFRAME_SEQUENCE_NUMBER, HeaderInfo, START_SEQUENCE_NUMBER};
+use crate::message::serializable_types::{get_iv_length, get_tag_length};
+use crate::message::serialize_functions::{
+    read_bytes, read_seq_u32_bounded, read_u32, write_bytes,
+};
+use crate::message::{Error, header, ser_err, serialize_functions};
+use crate::types::{SafeRead, SafeWrite};
+use aws_mpl_legacy::primitives::aes_decrypt;
+
+pub(crate) fn read_and_decrypt_framed_message_body(
+    ciphertext: &mut dyn SafeRead,
+    w: &mut dyn SafeWrite,
+    header: &HeaderInfo,
+    key: &[u8],
+    sig_digest: &mut dyn SafeWrite,
+    fail_if_multi_frame: bool,
+) -> Result<Vec<u8>, Error> {
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //# If this is framed data and the first frame sequentially, this value MUST be 1.
+    let mut expected_frame: u32 = START_SEQUENCE_NUMBER;
+
+    //= spec/data-format/message-body.md#regular-frame-iv
+    //# The IV length MUST be equal to the IV length of the algorithm suite specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
+    let mut iv = vec![0u8; get_iv_length(&header.suite) as usize];
+
+    //= spec/data-format/message-body.md#regular-frame-authentication-tag
+    //# The authentication tag length MUST be equal to the authentication tag length of the algorithm suite
+    //# specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
+    let mut auth_tag = vec![0u8; get_tag_length(&header.suite) as usize];
+    let alg = get_encrypt(&header.suite)?;
+    let frame_length_u64 = u64::from(header.body.frame_length());
+    let frame_length_usize = header.body.frame_length() as usize;
+    let mut enc_content = vec![0u8; frame_length_usize];
+    let mut result = vec![0; frame_length_usize];
+    let mut aad = Vec::new();
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= reason=The loop continuously reads and decrypts frames from the ciphertext stream, processing each frame as its bytes become available, until the final frame is encountered
+    //# If there could still be message body left to deserialize and decrypt,
+    //# this operation MUST either wait for more of the encrypted message bytes to become consumable,
+    //# wait for the end to the encrypted message to be indicated,
+    //# or deserialize and/or decrypt the consumable bytes.
+    loop {
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# If deserializing [framed data](../data-format/message-body.md#framed-data),
+        //# the Decrypt operation MUST use the first 4 bytes of a frame to determine
+        //# whether the operation will deserialize the frame as a [final frame](../data-format/message-body.md#final-frame)
+        //# or [regular frame](../data-format/message-body.md#regular-frame).
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# The Decrypt operation MUST inspect the first 4 bytes of each frame.
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=read_u32 reads the first 4 bytes as a UInt32, which is the sequence number for regular frames
+        //# - MUST deserialize the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number).
+        //
+        //= spec/data-format/message-body.md#regular-frame-sequence-number
+        //# The length of the serialized sequence number field MUST be 4 bytes.
+        //
+        //= spec/data-format/message-body.md#regular-frame-sequence-number
+        //# The sequence number MUST be interpreted as a UInt32.
+        let seq_num = read_u32(ciphertext, sig_digest)?;
+
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# If the first 4 bytes have a value of 0xFFFFFFFF,
+        //# the Decrypt operation MUST treat them as the [Sequence Number End](../data-format/message-body.md#sequence-number-end)
+        //# and deserialize the following bytes according to the [final frame spec](../data-format/message-body.md#final-frame).
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=The ENDFRAME_SEQUENCE_NUMBER constant equals 0xFFFFFFFF, validated by the if-guard below
+        //# The value MUST be `0xFFFFFFFF`.
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=read_u32 reads the first 4 bytes which serve as both the Sequence Number End check and the Sequence Number for regular frames
+        //# - MUST deserialize the [Sequence Number End](../data-format/message-body.md#sequence-number-end).
+        //
+        //= spec/data-format/message-body.md#sequence-number-end
+        //# The length of the sequence number end field MUST be 4 bytes.
+        //
+        //= spec/data-format/message-body.md#sequence-number-end
+        //# The sequence number end MUST be interpreted as bytes.
+        if seq_num == ENDFRAME_SEQUENCE_NUMBER {
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //# Final frame deserialization MUST conform to the [Final Frame](../data-format/message-body.md#final-frame) specification.
+            //
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //# For a final frame, each field MUST be deserialized according to its specification:
+            //
+            //= spec/data-format/message-body.md#final-frame
+            //= reason=The fields are read in order: Sequence Number End (the 4 bytes above), Sequence Number, IV, Encrypted Content Length, Encrypted Content, Authentication Tag
+            //# A final frame MUST consist of, in order,
+            //# Sequence Number End,
+            //# Sequence Number,
+            //# IV,
+            //# Encrypted Content Length,
+            //# Encrypted Content,
+            //# and Authentication Tag.
+
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=read_u32 reads the final frame sequence number after the ENDFRAME marker
+            //# - MUST deserialize the [Sequence Number](../data-format/message-body.md#final-frame-sequence-number).
+            //
+            //= spec/data-format/message-body.md#final-frame-sequence-number
+            //# The Final Frame Sequence Number MUST be interpreted as the same type as the
+            //# [Regular Frame Sequence Number](#regular-frame-sequence-number).
+            //
+            //= spec/data-format/message-body.md#regular-frame-sequence-number
+            //# The length of the serialized sequence number field MUST be 4 bytes.
+            //
+            //= spec/data-format/message-body.md#regular-frame-sequence-number
+            //# The sequence number MUST be interpreted as a UInt32.
+            let seq_num: u32 = read_u32(ciphertext, sig_digest)?;
+            if seq_num != expected_frame {
+                return ser_err("Final sequence number out of order");
+            }
+
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=read_bytes reads IV bytes from the final frame
+            //# - MUST deserialize the [IV](../data-format/message-body.md#final-frame-iv).
+            //
+            //= spec/data-format/message-body.md#final-frame-iv
+            //# The length of the IV field MUST be equal to the IV length of the [algorithm suite](../framework/algorithm-suites.md) that generated the message.
+            //
+            //= spec/data-format/message-body.md#final-frame-iv
+            //# The IV MUST be interpreted as bytes.
+            read_bytes(ciphertext, &mut iv, sig_digest)?;
+
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=read_seq_u32_bounded reads the encrypted content length field from the final frame
+            //# - MUST deserialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
+            //
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //# MUST ensure that the length of the encrypted content field is
+            //# less than or equal to the frame length deserialized in the message header.
+            //
+            //= spec/data-format/message-body.md#final-frame-encrypted-content-length
+            //# The length of the serialized encrypted content length field MUST be 4 bytes.
+            //
+            //= spec/data-format/message-body.md#final-frame-encrypted-content-length
+            //# The encrypted content length MUST be a UInt32.
+            //
+            //= spec/data-format/message-body.md#final-frame-encrypted-content
+            //# The length of the serialized encrypted content field MUST be equal to the value of the [Encrypted Content Length](#final-frame-encrypted-content-length) field.
+            //
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=enc_content holds the encrypted content bytes deserialized from the final frame by read_seq_u32_bounded
+            //# - MUST deserialize the [Encrypted Content](../data-format/message-body.md#final-frame-encrypted-content).
+            //
+            //= spec/data-format/message-body.md#final-frame-encrypted-content
+            //# The encrypted content MUST be interpreted as bytes.
+            read_seq_u32_bounded(
+                ciphertext,
+                //= spec/data-format/message-body.md#final-frame
+                //= reason=read_seq_u32_bounded enforces encrypted content length <= frame_length, which bounds the plaintext length
+                //# The length of the plaintext to be encrypted in the Final Frame MUST be
+                //# greater than or equal to 0 and less than or equal to the [Frame Length](message-header.md#frame-length).
+                header.body.frame_length(),
+                "Content length MUST NOT exceed the frame length",
+                &mut enc_content,
+                sig_digest,
+            )?;
+
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=read_bytes reads the authentication tag bytes from the final frame
+            //# - MUST deserialize the [Authentication Tag](../data-format/message-body.md#final-frame-authentication-tag).
+            //
+            //= spec/data-format/message-body.md#final-frame-authentication-tag
+            //# The authentication tag length MUST be equal to the authentication tag length of the algorithm suite
+            //# specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
+            //
+            //= spec/data-format/message-body.md#final-frame-authentication-tag
+            //# The authentication tag MUST be interpreted as bytes.
+            read_bytes(ciphertext, &mut auth_tag, sig_digest)?;
+
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
+            //# constructed according to the [Message Body AAD](../data-format/message-body-aad.md) specification, as follows:
+            body_aad(
+                //= spec/client-apis/decrypt.md#decrypt-the-message-body
+                //= reason=header.body.message_id() is the message ID deserialized from the header
+                //# - The [message ID](../data-format/message-body-aad.md#message-id) MUST be the same as the
+                //# [message ID](../data-format/message-header.md#message-id) deserialized from the header of this message.
+                header.body.message_id(),
+                //= spec/client-apis/decrypt.md#decrypt-the-message-body
+                //= reason=BodyAADContent::FinalFrame selects the correct AAD content type for the final frame
+                //# - The [Body AAD Content](../data-format/message-body-aad.md#body-aad-content) MUST be constructed
+                //# according to [Message Body AAD](../data-format/message-body-aad.md) depending on
+                //# whether the bytes being decrypted are a regular frame, final frame, or nonframed data.
+                //
+                //= spec/data-format/message-body-aad.md#body-aad-content
+                //= reason=BodyAADContent::FinalFrame maps to "AWSKMSEncryptionClient Final Frame"
+                //# - The [final frame](message-body.md#final-frame) in [framed data](message-body.md#framed-data) MUST use the value `AWSKMSEncryptionClient Final Frame`.
+                BodyAADContent::FinalFrame,
+                //= spec/client-apis/decrypt.md#decrypt-the-message-body
+                //= reason=seq_num is the sequence number deserialized from this final frame via read_u32
+                //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be the sequence
+                //# number deserialized from the frame being decrypted.
+                seq_num,
+                //= spec/client-apis/decrypt.md#decrypt-the-message-body
+                //# If this is a final frame, this MUST be determined by using the [final frame encrypted content length](../data-format/message-body.md#final-frame-encrypted-content-length).
+                //
+                //= spec/data-format/message-body-aad.md#content-length
+                //# - For the [final frame](message-body.md#final-frame), this value MUST be greater than or equal to
+                //# 0 and less than or equal to the value of the [frame length](message-header.md#frame-length)
+                //# field in the message header.
+                {
+                    debug_assert!(enc_content.len() <= frame_length_usize);
+                    enc_content.len() as u64
+                },
+                &mut aad,
+            );
+
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //# Once at least a single frame is deserialized (or the entire body in the nonframed case),
+            //# the Decrypt operation MUST decrypt and authenticate the frame (or body) using the
+            //# [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
+            //# specified by the [algorithm suite](../framework/algorithm-suites.md), with the following inputs:
+            if enc_content.is_empty() {
+                //= spec/client-apis/decrypt.md#decrypt-the-message-body
+                //# If this decryption fails, this operation MUST immediately halt and fail.
+                // final frame is empty, so return last full frame
+                let mut empty_result = Vec::new();
+                aes_decrypt(
+                    alg,
+                    key,
+                    &enc_content,
+                    //= spec/data-format/message-body.md#final-frame-authentication-tag
+                    //= reason=auth_tag is passed to aes_decrypt which uses it to authenticate the final frame
+                    //# It MUST be used to authenticate the final frame.
+                    &auth_tag,
+                    &iv,
+                    &aad,
+                    &mut empty_result[..],
+                )?;
+            } else {
+                // write previous frame's data, now that we know we have another frame.
+                if expected_frame != START_SEQUENCE_NUMBER {
+                    if fail_if_multi_frame {
+                        return Err(esdk_err(
+                            "Streaming interface can return data before signature has been validated. Set `allow_unsafe_unverified_signature` in the DecryptStreamInput struct if this is ok",
+                        ));
+                    }
+                    write_bytes(w, &result)?;
+                }
+                //= spec/client-apis/decrypt.md#decrypt-the-message-body
+                //# If this decryption fails, this operation MUST immediately halt and fail.
+                aes_decrypt(
+                    alg,
+                    key,
+                    &enc_content,
+                    &auth_tag,
+                    &iv,
+                    &aad,
+                    &mut result[0..enc_content.len()],
+                )?;
+                result.resize(enc_content.len(), 0);
+            }
+
+            //= spec/data-format/message-body.md#final-frame
+            //= reason=return exits the loop after the one final frame is decrypted
+            //# Framed data MUST contain exactly one final frame.
+            //
+            //= spec/data-format/message-body.md#final-frame
+            //# The final frame MUST be the last frame.
+            return Ok(result);
+        }
+
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# Regular frame deserialization MUST conform to the [Regular Frame](../data-format/message-body.md#regular-frame) specification.
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# For a regular frame, each field MUST be deserialized according to its specification:
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# Otherwise, the Decrypt operation MUST treat them as the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number)
+        //# and deserialize the following bytes according to the [regular frame spec](../data-format/message-body.md#regular-frame).
+        if seq_num != expected_frame {
+            return ser_err("Sequence number out of order");
+        }
+
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# - If the streamed Decrypt operation is using an algorithm suite with a signature algorithm,
+        //# all plaintext decrypted from regular frames SHOULD be released as soon as the above calculation,
+        //# including tag verification, succeeds.
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# - If the streamed Decrypt operation is using an algorithm suite without a signature algorithm,
+        //# plaintext SHOULD be released as soon as the above calculation, including tag verification,
+        //# succeeds.
+        // write previous frame's data, now that we know we have another frame.
+        if expected_frame != START_SEQUENCE_NUMBER {
+            if fail_if_multi_frame {
+                return Err(esdk_err(
+                    "Streaming interface can return data before signature has been validated. Set `allow_unsafe_unverified_signature` in the DecryptStreamInput struct if this is ok",
+                ));
+            }
+            write_bytes(w, &result)?;
+        }
+
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# Otherwise, this value MUST be 1 greater than the value of the sequence number
+        //# of the previous frame.
+        expected_frame += 1;
+
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=read_bytes reads IV bytes from the regular frame
+        //# - MUST deserialize the [IV](../data-format/message-body.md#regular-frame-iv).
+        //
+        //= spec/data-format/message-body.md#regular-frame-iv
+        //# The IV MUST be interpreted as bytes.
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=sig_digest is threaded through each read_bytes call, feeding the serialized frame to the signature algorithm as it is deserialized
+        //# - The streamed Decrypt operation SHOULD input the serialized frame to the signature algorithm as soon as it is deserialized,
+        //# such that the serialized frame isn't required to remain in memory to complete
+        //# the [signature verification](#verify-the-signature).
+        read_bytes(ciphertext, &mut iv, sig_digest)?;
+
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=read_bytes reads the encrypted content bytes from the regular frame
+        //# - MUST deserialize the [Encrypted Content](../data-format/message-body.md#regular-frame-encrypted-content).
+        //
+        //= spec/data-format/message-body.md#regular-frame-encrypted-content
+        //= reason=enc_content is pre-allocated to frame_length_usize; read_bytes fills exactly that many bytes
+        //# The length of the encrypted content of a Regular Frame MUST be equal to the Frame Length.
+        //
+        //= spec/data-format/message-body.md#regular-frame-encrypted-content
+        //# The encrypted content MUST be interpreted as bytes.
+        read_bytes(ciphertext, &mut enc_content, sig_digest)?;
+
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=read_bytes reads the authentication tag bytes from the regular frame
+        //# - MUST deserialize the [Authentication Tag](../data-format/message-body.md#regular-frame-authentication-tag).
+        //
+        //= spec/data-format/message-body.md#regular-frame-authentication-tag
+        //# The authentication tag MUST be interpreted as bytes.
+        read_bytes(ciphertext, &mut auth_tag, sig_digest)?;
+
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
+        //# constructed according to the [Message Body AAD](../data-format/message-body-aad.md) specification, as follows:
+        body_aad(
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=header.body.message_id() is the message ID deserialized from the header
+            //# - The [message ID](../data-format/message-body-aad.md#message-id) MUST be the same as the
+            //# [message ID](../data-format/message-header.md#message-id) deserialized from the header of this message.
+            header.body.message_id(),
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=BodyAADContent::RegularFrame selects the correct AAD content type for regular frames
+            //# - The [Body AAD Content](../data-format/message-body-aad.md#body-aad-content) MUST be constructed
+            //# according to [Message Body AAD](../data-format/message-body-aad.md) depending on
+            //# whether the bytes being decrypted are a regular frame, final frame, or nonframed data.
+            //
+            //= spec/data-format/message-body-aad.md#body-aad-content
+            //= reason=BodyAADContent::RegularFrame maps to "AWSKMSEncryptionClient Frame"
+            //# - The [regular frames](message-body.md#regular-frame) in [framed data](message-body.md#framed-data) MUST use the value `AWSKMSEncryptionClient Frame`.
+            BodyAADContent::RegularFrame,
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=seq_num is the sequence number deserialized from this frame via read_u32
+            //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be the sequence
+            //# number deserialized from the frame being decrypted.
+            //
+            //= spec/data-format/message-body-aad.md#sequence-number
+            //= reason=seq_num is the frame sequence number read from the regular frame
+            //# For [framed data](message-body.md#framed-data), the value of this field MUST be the [frame sequence number](message-body.md#regular-frame-sequence-number).
+            seq_num,
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //# If this is a regular frame, this MUST be determined by using the [frame length](../data-format/message-header.md#frame-length)
+            //# deserialized from the message header.
+            //
+            //= spec/data-format/message-body-aad.md#content-length
+            //# - For [regular frames](message-body.md#regular-frame), this value MUST equal the value of
+            //# the [frame length](message-header.md#frame-length) field in the message header.
+            //
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=frame_length_u64 equals the frame length from the header, which equals the plaintext length for regular frames
+            //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
+            //# equal to the length of the plaintext that was encrypted.
+            {
+                debug_assert_eq!(enc_content.len(), frame_length_usize);
+                frame_length_u64
+            },
+            &mut aad,
+        );
+
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=aes_decrypt is called before write_bytes; the ? operator prevents any plaintext release on decryption failure
+        //# This operation MUST NOT release any unauthenticated plaintext.
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# Once at least a single frame is deserialized (or the entire body in the nonframed case),
+        //# the Decrypt operation MUST decrypt and authenticate the frame (or body) using the
+        //# [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
+        //# specified by the [algorithm suite](../framework/algorithm-suites.md), with the following inputs:
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# If this decryption fails, this operation MUST immediately halt and fail.
+        aes_decrypt(
+            alg,
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=key is the derived data key passed from step_decrypt_body
+            //# - The cipherkey MUST be the derived data key
+            key,
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=enc_content is the encrypted content deserialized from the frame
+            //# - The ciphertext MUST be the encrypted content deserialized from the frame or body.
+            &enc_content,
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=auth_tag is the authentication tag deserialized from the frame
+            //# - The tag MUST be the authentication tag deserialized from the frame or body.
+            &auth_tag,
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //# - The IV MUST be the [sequence number](../data-format/message-body-aad.md#sequence-number)
+            //# used in the message body AAD above,
+            //# padded to the [IV length](../data-format/message-header.md#iv-length) with 0.
+            &iv,
+            &aad,
+            &mut result,
+        )?;
+    }
+}
+
+pub(crate) fn read_and_decrypt_non_framed_message_body(
+    ciphertext: &mut dyn SafeRead,
+    header: &HeaderInfo,
+    key: &[u8],
+    sig_digest: &mut dyn SafeWrite,
+) -> Result<Vec<u8>, Error> {
+    // nonframed write-path requirements: ESDK only encrypts framed data
+    //= spec/data-format/message-body.md#nonframed-data-iv
+    //= type=exception
+    //= reason=The ESDK only encrypts framed data; nonframed write path is not implemented
+    //# A generated IV MUST be a unique IV within the message.
+    if header.body.frame_length() != 0 {
+        //= spec/data-format/message-header.md#frame-length
+        //# When the [content type](#content-type) is nonframed, the value of this field MUST be 0.
+        return ser_err("nonframed message contains non-zero frame length");
+    }
+
+    //= spec/data-format/message-body.md#nonframed-data
+    //= reason=The fields are read in order: IV, then content length + content (via read_seq_u64_bounded), then auth tag
+    //# Nonframed data MUST consist of, in order,
+    //# IV,
+    //# Encrypted Content Length,
+    //# Encrypted Content,
+    //# and Authentication Tag.
+
+    // IV
+    //= spec/data-format/message-body.md#nonframed-data-iv
+    //# The length of the IV field MUST be [IV Length](message-header.md#iv-length) bytes.
+    //
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //# - The IV MUST be the [IV](../data-format/message-body.md#nonframed-data-iv) deserialized from the message body.
+    //
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= reason=iv is deserialized here and passed to aes_decrypt below
+    //# - The IV MUST be the [sequence number](../data-format/message-body-aad.md#sequence-number)
+    //# used in the message body AAD above,
+    //# padded to the [IV length](../data-format/message-header.md#iv-length) with 0.
+    //
+    //= spec/data-format/message-body.md#nonframed-data-iv
+    //= reason=read_vec returns Vec<u8>
+    //# The IV MUST be interpreted as bytes.
+    let iv = serialize_functions::read_vec(
+        ciphertext,
+        get_iv_length(&header.suite) as usize,
+        sig_digest,
+    )?;
+    debug_assert_eq!(iv.len(), get_iv_length(&header.suite) as usize);
+
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content-length
+    //# The encrypted content length MUST be interpreted as a UInt64.
+    //
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content-length
+    //= reason=SAFE_MAX_ENCRYPT equals 2^36 - 32; read_seq_u64_bounded rejects values above this limit
+    //# The value of this field MUST NOT be greater than `2^36 - 32`, or 64 gibibytes (64 GiB),
+    //# due to restrictions imposed by the [implemented algorithms](../framework/algorithm-suites.md).
+    //
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content-length
+    //# The length of the Encrypted Content Length field MUST be 8 bytes.
+    //
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content
+    //# The length of the serialized encrypted content field MUST be equal to the value of the [Encrypted Content Length](#nonframed-data-encrypted-content-length) field.
+    //
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //# - The ciphertext MUST be the [Encrypted Content](../data-format/message-body.md#nonframed-data-encrypted-content) deserialized from the message body.
+    //
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content
+    //= reason=read_seq_u64_bounded returns Vec<u8>
+    //# The encrypted content value MUST be interpreted as bytes.
+    let enc_content = serialize_functions::read_seq_u64_bounded(
+        ciphertext,
+        header::SAFE_MAX_ENCRYPT,
+        "Frame exceeds AES-GCM cryptographic safety for a single key/iv.",
+        sig_digest,
+    )?;
+    // read_seq_u64_bounded reads the u64 length then reads exactly that many bytes,
+    // so enc_content.len() is guaranteed to equal the deserialized content length field.
+    debug_assert!(enc_content.len() as u64 <= header::SAFE_MAX_ENCRYPT);
+
+    // Authentication Tag
+    //= spec/data-format/message-body.md#nonframed-data-authentication-tag
+    //# The length of the serialized authentication tag field MUST be equal to the [authentication tag length](../framework/algorithm-suites.md#authentication-tag-length) of the [algorithm suite](../framework/algorithm-suites.md) specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
+    //
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //# - The tag MUST be the [Authentication Tag](../data-format/message-body.md#nonframed-data-authentication-tag) deserialized from the message body.
+    //
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= reason=auth_tag is deserialized here and passed to aes_decrypt below
+    //# - The tag MUST be the authentication tag deserialized from the frame or body.
+    //
+    //= spec/data-format/message-body.md#nonframed-data-authentication-tag
+    //= reason=read_vec returns Vec<u8>
+    //# The authentication tag value MUST be interpreted as bytes.
+    let auth_tag = serialize_functions::read_vec(
+        ciphertext,
+        get_tag_length(&header.suite) as usize,
+        sig_digest,
+    )?;
+    debug_assert_eq!(auth_tag.len(), get_tag_length(&header.suite) as usize);
+    let mut aad = Vec::new();
+
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
+    //# constructed with:
+    body_aad(
+        header.body.message_id(),
+        //= spec/data-format/message-body-aad.md#body-aad-content
+        //= reason=BodyAADContent::SingleBlock maps to "AWSKMSEncryptionClient Single Block"
+        //# - [Non-framed data](message-body.md#nonframed-data) MUST use the value `AWSKMSEncryptionClient Single Block`.
+        //
+        //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+        //# - The [Body AAD Content](../data-format/message-body-aad.md#body-aad-content) MUST use the value for
+        //# [nonframed data](../data-format/message-body-aad.md#body-aad-content).
+        BodyAADContent::SingleBlock,
+        //= spec/data-format/message-body-aad.md#sequence-number
+        //# For [non-framed data](message-body.md#nonframed-data), the value of this field MUST be `1`.
+        {
+            //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+            //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be `1`.
+            //
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=NONFRAMED_SEQUENCE_NUMBER is defined as 1
+            //# If this is nonframed data, this value MUST be 1.
+            debug_assert_eq!(header::NONFRAMED_SEQUENCE_NUMBER, 1);
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=NONFRAMED_SEQUENCE_NUMBER is the constant 1
+            //# If this is nonframed data, this value MUST be 1.
+            header::NONFRAMED_SEQUENCE_NUMBER
+        },
+        //= spec/data-format/message-body-aad.md#content-length
+        //# - For [non-framed data](message-body.md#nonframed-data), this value MUST equal the length, in bytes,
+        //# of the plaintext data provided to the algorithm for encryption.
+        {
+            //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+            //# - The [content length](../data-format/message-body-aad.md#content-length) MUST equal the length of the plaintext.
+            //
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=enc_content.len() equals the length of the encrypted content
+            //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
+            //# equal to the length of the plaintext that was encrypted.
+            let content_len = enc_content.len() as u64;
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //= reason=enc_content.len() is the nonframed data encrypted content length deserialized from the body
+            //# If this is nonframed data, this MUST be determined by using the [nonframed data encrypted content length](../data-format/message-body.md#nonframed-data-encrypted-content-length).
+            debug_assert!(content_len <= header::SAFE_MAX_ENCRYPT);
+            content_len
+        },
+        &mut aad,
+    );
+
+    let mut result: Vec<u8> = enc_content.clone();
+
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //# If this decryption fails, this operation MUST immediately halt and fail.
+    aes_decrypt(
+        get_encrypt(&header.suite)?,
+        //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+        //# - The cipherkey MUST be the derived data key.
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=key parameter is the derived data key from decryption materials
+        //# - The cipherkey MUST be the derived data key
+        key,
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=enc_content is passed as the ciphertext input to aes_decrypt
+        //# - The ciphertext MUST be the encrypted content deserialized from the frame or body.
+        &enc_content,
+        &auth_tag,
+        &iv,
+        &aad,
+        result.as_mut(),
+    )?;
+
+    Ok(result)
+}

--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 //! Frame decryption and body deserialization.
 
 use super::{BodyAADContent, body_aad, get_encrypt};
@@ -250,6 +251,13 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                     &aad,
                     &mut empty_result[..],
                 )?;
+                // If this empty final frame is also the FIRST frame (i.e. the entire
+                // plaintext is empty), there is no "last full frame" to return. The
+                // preallocated `result` (vec![0; frame_length_usize]) would otherwise
+                // leak frame_length zero bytes to the caller. Truncate to empty.
+                if expected_frame == START_SEQUENCE_NUMBER {
+                    result.clear();
+                }
             } else {
                 // write previous frame's data, now that we know we have another frame.
                 if expected_frame != START_SEQUENCE_NUMBER {

--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -3,7 +3,7 @@
 
 //! Frame decryption and body deserialization.
 
-use super::{BodyAADContent, body_aad, get_aes_gcm};
+use super::{BodyAADContent, body_aad, get_alg_suite};
 use crate::error::esdk_err;
 use crate::message::header::{ENDFRAME_SEQUENCE_NUMBER, HeaderInfo, START_SEQUENCE_NUMBER};
 use crate::message::serializable_types::{get_iv_length, get_tag_length};
@@ -34,7 +34,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
     //# The authentication tag length MUST be equal to the authentication tag length of the algorithm suite
     //# specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
     let mut auth_tag = vec![0u8; usize::from(get_tag_length(&header.suite))];
-    let aes_gcm = get_aes_gcm(&header.suite)?;
+    let alg_suite = get_alg_suite(&header.suite)?;
     let frame_length_u64 = u64::from(header.body.frame_length());
     let Ok(frame_length_usize) = usize::try_from(header.body.frame_length()) else {
         return ser_err(&format!(
@@ -259,7 +259,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                 // final frame is empty, so return last full frame
                 let mut empty_result = Vec::new();
                 aes_decrypt(
-                    aes_gcm,
+                    alg_suite,
                     key,
                     &enc_content,
                     //= spec/data-format/message-body.md#final-frame-authentication-tag
@@ -291,7 +291,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                 //= reason=`?` propagates aes_decrypt errors, halting decryption immediately
                 //# If this decryption fails, this operation MUST immediately halt and fail.
                 aes_decrypt(
-                    aes_gcm,
+                    alg_suite,
                     key,
                     &enc_content,
                     &auth_tag,
@@ -460,7 +460,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         //= reason=`?` propagates aes_decrypt errors, halting decryption immediately
         //# If this decryption fails, this operation MUST immediately halt and fail.
         aes_decrypt(
-            aes_gcm,
+            alg_suite,
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=key is the derived data key passed from step_decrypt_body
             //# - The cipherkey MUST be the derived data key
@@ -647,7 +647,7 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     //= reason=`?` propagates aes_decrypt errors, halting decryption immediately
     //# If this decryption fails, this operation MUST immediately halt and fail.
     aes_decrypt(
-        get_aes_gcm(&header.suite)?,
+        get_alg_suite(&header.suite)?,
         //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
         //# - The cipherkey MUST be the derived data key.
         //

--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -194,6 +194,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             //# The authentication tag MUST be interpreted as bytes.
             read_bytes(ciphertext, &mut auth_tag, sig_digest)?;
 
+            // AAD
+
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
             //# constructed according to the [Message Body AAD](../data-format/message-body-aad.md) specification, as follows:
@@ -302,6 +304,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             //# The final frame MUST be the last frame.
             return Ok(result);
         }
+
+        // Validate sequence; release previous frame
 
         //= spec/client-apis/decrypt.md#decrypt-the-message-body
         //# Regular frame deserialization MUST conform to the [Regular Frame](../data-format/message-body.md#regular-frame) specification.

--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -111,6 +111,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             // Sequence Number End — already read above (the 4 bytes that matched ENDFRAME_SEQUENCE_NUMBER).
 
             // Sequence Number
+
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=read_u32 reads the final frame sequence number after the ENDFRAME marker
             //# - MUST deserialize the [Sequence Number](../data-format/message-body.md#final-frame-sequence-number).
@@ -130,6 +131,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             }
 
             // IV
+
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=read_bytes reads IV bytes from the final frame
             //# - MUST deserialize the [IV](../data-format/message-body.md#final-frame-iv).
@@ -142,6 +144,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             read_bytes(ciphertext, &mut iv, sig_digest)?;
 
             // Encrypted Content Length + Encrypted Content
+
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=read_seq_u32_bounded reads the encrypted content length field from the final frame
             //# - MUST deserialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
@@ -178,6 +181,7 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             )?;
 
             // Authentication Tag
+
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=read_bytes reads the authentication tag bytes from the final frame
             //# - MUST deserialize the [Authentication Tag](../data-format/message-body.md#final-frame-authentication-tag).

--- a/esdk/src/message/body/body_decrypt.rs
+++ b/esdk/src/message/body/body_decrypt.rs
@@ -197,6 +197,21 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
             //# constructed according to the [Message Body AAD](../data-format/message-body-aad.md) specification, as follows:
+            //
+            //= spec/client-apis/decrypt.md#decrypt-the-message-body
+            //# If this is a final frame, this MUST be determined by using the [final frame encrypted content length](../data-format/message-body.md#final-frame-encrypted-content-length).
+            //
+            //= spec/data-format/message-body-aad.md#content-length
+            //# - For the [final frame](message-body.md#final-frame), this value MUST be greater than or equal to
+            //# 0 and less than or equal to the value of the [frame length](message-header.md#frame-length)
+            //# field in the message header.
+            debug_assert!(enc_content.len() <= frame_length_usize);
+            let Ok(final_content_len_u64) = u64::try_from(enc_content.len()) else {
+                return ser_err(&format!(
+                    "Final-frame encrypted content length {} exceeds u64::MAX",
+                    enc_content.len()
+                ));
+            };
             body_aad(
                 //= spec/client-apis/decrypt.md#decrypt-the-message-body
                 //= reason=header.body.message_id() is the message ID deserialized from the header
@@ -218,25 +233,11 @@ pub(crate) fn read_and_decrypt_framed_message_body(
                 //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be the sequence
                 //# number deserialized from the frame being decrypted.
                 seq_num,
-                //= spec/client-apis/decrypt.md#decrypt-the-message-body
-                //# If this is a final frame, this MUST be determined by using the [final frame encrypted content length](../data-format/message-body.md#final-frame-encrypted-content-length).
-                //
-                //= spec/data-format/message-body-aad.md#content-length
-                //# - For the [final frame](message-body.md#final-frame), this value MUST be greater than or equal to
-                //# 0 and less than or equal to the value of the [frame length](message-header.md#frame-length)
-                //# field in the message header.
-                {
-                    debug_assert!(enc_content.len() <= frame_length_usize);
-                    let Ok(enc_len_u64) = u64::try_from(enc_content.len()) else {
-                        return ser_err(&format!(
-                            "Final-frame encrypted content length {} exceeds u64::MAX",
-                            enc_content.len()
-                        ));
-                    };
-                    enc_len_u64
-                },
+                final_content_len_u64,
                 &mut aad,
             );
+
+            // Decrypt + authenticate
 
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //# Once at least a single frame is deserialized (or the entire body in the nonframed case),
@@ -339,6 +340,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         //# of the previous frame.
         expected_frame += 1;
 
+        // IV
+
         //= spec/client-apis/decrypt.md#decrypt-the-message-body
         //= reason=read_bytes reads IV bytes from the regular frame
         //# - MUST deserialize the [IV](../data-format/message-body.md#regular-frame-iv).
@@ -353,6 +356,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         //# the [signature verification](#verify-the-signature).
         read_bytes(ciphertext, &mut iv, sig_digest)?;
 
+        // Encrypted Content
+
         //= spec/client-apis/decrypt.md#decrypt-the-message-body
         //= reason=read_bytes reads the encrypted content bytes from the regular frame
         //# - MUST deserialize the [Encrypted Content](../data-format/message-body.md#regular-frame-encrypted-content).
@@ -365,6 +370,8 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         //# The encrypted content MUST be interpreted as bytes.
         read_bytes(ciphertext, &mut enc_content, sig_digest)?;
 
+        // Authentication Tag
+
         //= spec/client-apis/decrypt.md#decrypt-the-message-body
         //= reason=read_bytes reads the authentication tag bytes from the regular frame
         //# - MUST deserialize the [Authentication Tag](../data-format/message-body.md#regular-frame-authentication-tag).
@@ -373,9 +380,25 @@ pub(crate) fn read_and_decrypt_framed_message_body(
         //# The authentication tag MUST be interpreted as bytes.
         read_bytes(ciphertext, &mut auth_tag, sig_digest)?;
 
+        // AAD
+
         //= spec/client-apis/decrypt.md#decrypt-the-message-body
         //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
         //# constructed according to the [Message Body AAD](../data-format/message-body-aad.md) specification, as follows:
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //# If this is a regular frame, this MUST be determined by using the [frame length](../data-format/message-header.md#frame-length)
+        //# deserialized from the message header.
+        //
+        //= spec/data-format/message-body-aad.md#content-length
+        //# - For [regular frames](message-body.md#regular-frame), this value MUST equal the value of
+        //# the [frame length](message-header.md#frame-length) field in the message header.
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=frame_length_u64 equals the frame length from the header, which equals the plaintext length for regular frames
+        //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
+        //# equal to the length of the plaintext that was encrypted.
+        debug_assert_eq!(enc_content.len(), frame_length_usize);
         body_aad(
             //= spec/client-apis/decrypt.md#decrypt-the-message-body
             //= reason=header.body.message_id() is the message ID deserialized from the header
@@ -401,24 +424,11 @@ pub(crate) fn read_and_decrypt_framed_message_body(
             //= reason=seq_num is the frame sequence number read from the regular frame
             //# For [framed data](message-body.md#framed-data), the value of this field MUST be the [frame sequence number](message-body.md#regular-frame-sequence-number).
             seq_num,
-            //= spec/client-apis/decrypt.md#decrypt-the-message-body
-            //# If this is a regular frame, this MUST be determined by using the [frame length](../data-format/message-header.md#frame-length)
-            //# deserialized from the message header.
-            //
-            //= spec/data-format/message-body-aad.md#content-length
-            //# - For [regular frames](message-body.md#regular-frame), this value MUST equal the value of
-            //# the [frame length](message-header.md#frame-length) field in the message header.
-            //
-            //= spec/client-apis/decrypt.md#decrypt-the-message-body
-            //= reason=frame_length_u64 equals the frame length from the header, which equals the plaintext length for regular frames
-            //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
-            //# equal to the length of the plaintext that was encrypted.
-            {
-                debug_assert_eq!(enc_content.len(), frame_length_usize);
-                frame_length_u64
-            },
+            frame_length_u64,
             &mut aad,
         );
+
+        // Decrypt + authenticate
 
         //= spec/client-apis/decrypt.md#decrypt-the-message-body
         //= reason=aes_decrypt is called before write_bytes; the ? operator prevents any plaintext release on decryption failure
@@ -534,11 +544,10 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     )?;
     // read_seq_u64_bounded reads the u64 length then reads exactly that many bytes,
     // so enc_content.len() is guaranteed to equal the deserialized content length field.
-    debug_assert!(
-        u64::try_from(enc_content.len())
-            .map(|n| n <= header::SAFE_MAX_ENCRYPT)
-            .unwrap_or(false)
-    );
+    debug_assert!(matches!(
+        u64::try_from(enc_content.len()),
+        Ok(n) if n <= header::SAFE_MAX_ENCRYPT
+    ));
 
     // Authentication Tag
     //= spec/data-format/message-body.md#nonframed-data-authentication-tag
@@ -565,6 +574,27 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
     //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
     //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
     //# constructed with:
+    //= spec/data-format/message-body-aad.md#content-length
+    //# - For [non-framed data](message-body.md#nonframed-data), this value MUST equal the length, in bytes,
+    //# of the plaintext data provided to the algorithm for encryption.
+    //
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //# - The [content length](../data-format/message-body-aad.md#content-length) MUST equal the length of the plaintext.
+    //
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= reason=enc_content.len() equals the length of the encrypted content
+    //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
+    //# equal to the length of the plaintext that was encrypted.
+    let Ok(nonframed_content_len_u64) = u64::try_from(enc_content.len()) else {
+        return ser_err(&format!(
+            "Nonframed encrypted content length {} exceeds u64::MAX",
+            enc_content.len()
+        ));
+    };
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= reason=enc_content.len() is the nonframed data encrypted content length deserialized from the body
+    //# If this is nonframed data, this MUST be determined by using the [nonframed data encrypted content length](../data-format/message-body.md#nonframed-data-encrypted-content-length).
+    debug_assert!(nonframed_content_len_u64 <= header::SAFE_MAX_ENCRYPT);
     body_aad(
         header.body.message_id(),
         //= spec/data-format/message-body-aad.md#body-aad-content
@@ -577,42 +607,18 @@ pub(crate) fn read_and_decrypt_non_framed_message_body(
         BodyAADContent::SingleBlock,
         //= spec/data-format/message-body-aad.md#sequence-number
         //# For [non-framed data](message-body.md#nonframed-data), the value of this field MUST be `1`.
+        //
+        //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+        //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be `1`.
+        //
+        //= spec/client-apis/decrypt.md#decrypt-the-message-body
+        //= reason=NONFRAMED_SEQUENCE_NUMBER is defined as 1
+        //# If this is nonframed data, this value MUST be 1.
         {
-            //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
-            //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be `1`.
-            //
-            //= spec/client-apis/decrypt.md#decrypt-the-message-body
-            //= reason=NONFRAMED_SEQUENCE_NUMBER is defined as 1
-            //# If this is nonframed data, this value MUST be 1.
             debug_assert_eq!(header::NONFRAMED_SEQUENCE_NUMBER, 1);
-            //= spec/client-apis/decrypt.md#decrypt-the-message-body
-            //= reason=NONFRAMED_SEQUENCE_NUMBER is the constant 1
-            //# If this is nonframed data, this value MUST be 1.
             header::NONFRAMED_SEQUENCE_NUMBER
         },
-        //= spec/data-format/message-body-aad.md#content-length
-        //# - For [non-framed data](message-body.md#nonframed-data), this value MUST equal the length, in bytes,
-        //# of the plaintext data provided to the algorithm for encryption.
-        {
-            //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
-            //# - The [content length](../data-format/message-body-aad.md#content-length) MUST equal the length of the plaintext.
-            //
-            //= spec/client-apis/decrypt.md#decrypt-the-message-body
-            //= reason=enc_content.len() equals the length of the encrypted content
-            //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
-            //# equal to the length of the plaintext that was encrypted.
-            let Ok(content_len) = u64::try_from(enc_content.len()) else {
-                return ser_err(&format!(
-                    "Nonframed encrypted content length {} exceeds u64::MAX",
-                    enc_content.len()
-                ));
-            };
-            //= spec/client-apis/decrypt.md#decrypt-the-message-body
-            //= reason=enc_content.len() is the nonframed data encrypted content length deserialized from the body
-            //# If this is nonframed data, this MUST be determined by using the [nonframed data encrypted content length](../data-format/message-body.md#nonframed-data-encrypted-content-length).
-            debug_assert!(content_len <= header::SAFE_MAX_ENCRYPT);
-            content_len
-        },
+        nonframed_content_len_u64,
         &mut aad,
     );
 

--- a/esdk/src/message/body/body_encrypt.rs
+++ b/esdk/src/message/body/body_encrypt.rs
@@ -1,0 +1,454 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//! Frame encryption and body serialization.
+
+use super::{BodyAADContent, body_aad, get_encrypt, iv_seq};
+use crate::error::val_err;
+use crate::message::header::{ENDFRAME_SEQUENCE_NUMBER, HeaderInfo, START_SEQUENCE_NUMBER};
+use crate::message::serializable_types::{get_iv_length, get_tag_length};
+use crate::message::serialize_functions::{read_opt_u8, read_up_to_peek, write_bytes, write_u32};
+use crate::message::{DigestWriter, Error, ser_err};
+use crate::types::{SafeRead, SafeWrite};
+use aws_mpl_legacy::primitives::{AesGcm, aes_encrypt};
+
+const MAX_DATA: usize = (1usize << 36) - 32;
+
+/// Input for constructing a single frame (regular or final).
+pub(crate) struct ConstructFrameInput<'a> {
+    pub(crate) alg: AesGcm,
+    pub(crate) key: &'a [u8],
+    pub(crate) plaintext: &'a [u8],
+    pub(crate) message_id: &'a [u8],
+    pub(crate) aad_content: BodyAADContent,
+    pub(crate) sequence_number: u32,
+    pub(crate) is_final: bool,
+}
+
+/// Construct and serialize a single frame (regular or final).
+pub(crate) fn construct_frame(
+    input: &ConstructFrameInput<'_>,
+    iv: &mut [u8],
+    aad: &mut Vec<u8>,
+    frame_buf: &mut Vec<u8>,
+    ciphertext: &mut dyn SafeWrite,
+    sig_digest: &mut DigestWriter,
+) -> Result<(), Error> {
+    frame_buf.clear();
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
+    //# constructed according to the [Message Body AAD](../data-format/message-body-aad.md) specification, as follows:
+    body_aad(
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //# - The [message ID](../data-format/message-body-aad.md#message-id) MUST be the same as the
+        //# [message ID](../data-format/message-header.md#message-id) serialized in the header of this message.
+        //
+        //= spec/data-format/message-header.md#message-id
+        //= reason=input.message_id is the message ID from the header, interpreted as raw bytes for AAD construction
+        //# The message ID MUST be interpreted as bytes.
+        input.message_id,
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //# - The [Body AAD Content](../data-format/message-body-aad.md#body-aad-content) MUST be the structure defined in
+        //# [Message Body AAD](../data-format/message-body-aad.md).
+        input.aad_content,
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be the sequence
+        //# number of the frame being encrypted.
+        //
+        //= spec/data-format/message-body-aad.md#sequence-number
+        //= reason=The sequence_number parameter is the frame sequence number passed from encrypt_and_serialize_body
+        //# For [framed data](message-body.md#framed-data), the value of this field MUST be the [frame sequence number](message-body.md#regular-frame-sequence-number).
+        input.sequence_number,
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
+        //# equal to the length of the plaintext being encrypted.
+        //
+        //= spec/data-format/message-body-aad.md#content-length
+        //= reason=plaintext.len() is the length of the plaintext being encrypted in this frame
+        //# - For [framed data](message-body.md#framed-data), this value MUST equal the length, in bytes,
+        //# of the plaintext being encrypted in this frame.
+        input.plaintext.len() as u64,
+        aad,
+    );
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# - The IV MUST be the [sequence number](../data-format/message-body-aad.md#sequence-number)
+    //# used in the message body AAD for this frame,
+    //# padded to the [IV length](../data-format/message-header.md#iv-length).
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# The Encrypt operation MUST serialize a regular frame or final frame with the following specifics:
+    //
+    //= spec/data-format/message-body.md#regular-frame-iv
+    //# Each frame in the [Framed Data](#framed-data) MUST include an IV that is unique within the message.
+    //
+    //= spec/data-format/message-body.md#final-frame-iv
+    //# A generated IV MUST be a unique IV within the message.
+    iv_seq(input.sequence_number, iv);
+
+    //= spec/data-format/message-body.md#final-frame
+    //= reason=The two `if input.is_final` blocks below add Sequence Number End and Encrypted Content Length to the shared frame serialization path
+    //# A final frame MUST only differ from a regular frame by the addition of the
+    //# Sequence Number End
+    //# and Encrypted Content Length.
+    if input.is_final {
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //= reason=The following lines serialize SeqNumEnd, SeqNum, IV, EncContentLen, EncContent, and AuthTag in order per the Final Frame spec
+        //# For a final frame, each field MUST be serialized according to its specification:
+        //
+        //= spec/data-format/message-body.md#final-frame
+        //# A final frame MUST consist of, in order,
+        //# Sequence Number End,
+        //# Sequence Number,
+        //# IV,
+        //# Encrypted Content Length,
+        //# Encrypted Content,
+        //# and Authentication Tag.
+        //
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //# - MUST serialize the [Sequence Number End](../data-format/message-body.md#sequence-number-end).
+        //
+        //= spec/data-format/message-body.md#sequence-number-end
+        //# The value MUST be encoded as the 4 bytes `FF FF FF FF` in hexadecimal notation.
+        write_u32(frame_buf, ENDFRAME_SEQUENCE_NUMBER)?;
+    }
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= reason=The following lines serialize SeqNum, IV, EncContent, and AuthTag in order per the Regular Frame spec
+    //# For a regular frame, each field MUST be serialized according to its specification:
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# - MUST serialize the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number).
+    //# The value MUST be the sequence number of this frame.
+    //
+    //= spec/data-format/message-body.md#regular-frame-sequence-number
+    //# The sequence number MUST be interpreted as a UInt32.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= reason=write_u32 above serializes the sequence number for both regular and final frames in this shared code path
+    //# - MUST serialize the [Sequence Number](../data-format/message-body.md#final-frame-sequence-number).
+    //
+    //= spec/data-format/message-body.md#final-frame-sequence-number
+    //= reason=write_u32 serializes the sequence number as a UInt32, same type as the regular frame sequence number
+    //# The Final Frame Sequence Number MUST be interpreted as the same type as the
+    //# [Regular Frame Sequence Number](#regular-frame-sequence-number).
+    //
+    //= spec/data-format/message-body.md#final-frame-sequence-number
+    //= reason=write_u32 writes exactly 4 bytes, the same length as the regular frame sequence number field
+    //# The length of the Final Frame Sequence number field MUST be the same as the
+    //# [Regular Frame Sequence Number](#regular-frame-sequence-number).
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# The value MUST be the sequence number of this frame.
+    write_u32(frame_buf, input.sequence_number)?;
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# - MUST serialize the [IV](../data-format/message-body.md#regular-frame-iv).
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# The value MUST be the IV used when calculating the encrypted content for this frame.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= reason=write_bytes above serializes the IV for both regular and final frames in this shared code path
+    //# - MUST serialize the [IV](../data-format/message-body.md#final-frame-iv).
+    //
+    //= spec/data-format/message-body.md#final-frame-iv
+    //= reason=iv is &[u8], interpreted as raw bytes
+    //# The IV MUST be interpreted as bytes.
+    write_bytes(frame_buf, iv)?;
+
+    if input.is_final {
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //# - MUST serialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
+        //
+        //= spec/data-format/message-body.md#final-frame-encrypted-content-length
+        //# The encrypted content length MUST be a UInt32.
+        let Ok(enc_content_len) = u32::try_from(input.plaintext.len()) else {
+            return ser_err("Plaintext length exceeds u32");
+        };
+
+        //= spec/data-format/message-body.md#final-frame-encrypted-content-length
+        //# The length of the serialized encrypted content length field MUST be 4 bytes.
+        //
+        //= spec/data-format/message-header.md#frame-length
+        //= reason=enc_content_len is bounded by the frame length from the header, interpreted as a UInt32
+        //# The frame length MUST be interpreted as a UInt32.
+        write_u32(frame_buf, enc_content_len)?;
+    }
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# To construct a regular or final frame that represents the next frame in the encrypted message's body,
+    //# the Encrypt operation MUST calculate the encrypted content and an authentication tag using the
+    //# [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
+    //# specified by the [algorithm suite](../framework/algorithm-suites.md),
+    //# with the following inputs:
+    aes_encrypt(
+        input.alg,
+        iv,
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //= reason=input.key is set from the derived data key in encrypt_and_serialize_body
+        //# - The cipherkey MUST be the derived data key
+        input.key,
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //# - The plaintext MUST be the next subsequence of consumable plaintext bytes that have not yet been encrypted.
+        input.plaintext,
+        aad,
+        frame_buf,
+    )?;
+
+    // aes_encrypt writes encrypted content followed by authentication tag to frame_buf
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#regular-frame-encrypted-content).
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= reason=aes_encrypt writes encrypted content to frame_buf for both regular and final frames in this shared code path
+    //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#final-frame-encrypted-content).
+    //
+    //= spec/data-format/message-body.md#final-frame-encrypted-content
+    //= reason=aes_encrypt output bytes are written directly to frame_buf, interpreted as raw bytes
+    //# The encrypted content MUST be interpreted as bytes.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# The value MUST be the encrypted content calculated for this frame.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#regular-frame-authentication-tag).
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= reason=aes_encrypt writes the authentication tag to frame_buf for both regular and final frames in this shared code path
+    //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#final-frame-authentication-tag).
+    //
+    //= spec/data-format/message-body.md#final-frame-authentication-tag
+    //= reason=aes_encrypt output tag bytes are written directly to frame_buf, interpreted as raw bytes
+    //# The authentication tag MUST be interpreted as bytes.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# The value MUST be the authentication tag output when calculating the encrypted content for this frame.
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= reason=Frame is fully serialized into frame_buf before being written to ciphertext; frame_buf.clear() at function start and write_bytes(ciphertext, frame_buf) here ensure atomic release
+    //# The serialized frame bytes MUST NOT be released until the entire frame has been serialized.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# If the Encrypt operation is streaming the encrypted message and
+    //# the entire frame has been serialized,
+    //# the serialized frame MUST be released.
+    write_bytes(ciphertext, frame_buf)?;
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= reason=DigestWriter feeds the serialized frame bytes to the signature algorithm
+    //# If the algorithm suite contains a signature algorithm and
+    //# the Encrypt operation is [streaming](streaming.md) the encrypted message output to the caller,
+    //# the Encrypt operation MUST input the serialized frame to the signature algorithm as soon as it is serialized,
+    //# such that the serialized frame isn't required to remain in memory to [construct the signature](#construct-the-signature).
+    write_bytes(sig_digest, frame_buf)?;
+    Ok(())
+}
+
+/// Encrypt plaintext and serialize the message body (framed) to the output stream.
+pub(crate) fn encrypt_and_serialize_body(
+    plaintext: &mut dyn SafeRead,
+    header: &HeaderInfo,
+    key: &[u8],
+    ciphertext: &mut dyn SafeWrite,
+    sig_digest: &mut DigestWriter,
+    max_plaintext_length: Option<usize>,
+) -> Result<(), Error> {
+    let mut total_data_size: usize = 0;
+    let frame_length = header.body.frame_length() as usize;
+    let iv_len = get_iv_length(&header.suite) as usize;
+    let auth_len = get_tag_length(&header.suite) as usize;
+    let frame_len = frame_length + iv_len + auth_len + 4;
+    let mut frame_buf = Vec::with_capacity(frame_len);
+
+    //= spec/data-format/message-body.md#regular-frame-sequence-number
+    //= reason=START_SEQUENCE_NUMBER is defined as 1
+    //# Framed Data MUST start at Sequence Number 1.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= reason=START_SEQUENCE_NUMBER is defined as 1
+    //# If this is the first frame sequentially, the sequence number value MUST be 1.
+    let mut sequence_number = START_SEQUENCE_NUMBER;
+    let alg = get_encrypt(&header.suite)?;
+
+    let mut iv = vec![0; iv_len];
+    let mut plaintext_frame = vec![0; frame_length];
+    let mut aad = Vec::new();
+    let mut in_size: usize;
+    let mut next_char: Option<u8> = None;
+
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //# Before the end of the input is indicated,
+    //# this operation MUST process as much of the consumable bytes as possible
+    //# by [constructing regular frames](#construct-a-frame).
+    loop {
+        in_size = read_up_to_peek(plaintext, &mut plaintext_frame, next_char)?;
+
+        //= spec/client-apis/encrypt.md#construct-the-body
+        //# - If there are not enough input consumable plaintext bytes to create a new regular frame,
+        //# then this operation MUST [construct a final frame](#construct-a-frame)
+        //
+        //= spec/data-format/message-body.md#final-frame
+        //= reason=When in_size < frame_length on the first iteration, the loop breaks immediately to construct a single final frame
+        //# - When the length of the Plaintext is less than the Frame Length,
+        //# the body MUST contain exactly one frame and that frame MUST be a Final Frame.
+        if in_size != frame_length {
+            break;
+        }
+        next_char = read_opt_u8(plaintext)?;
+
+        //= spec/client-apis/encrypt.md#construct-the-body
+        //# - If there are exactly enough consumable plaintext bytes to create one regular frame,
+        //# such that creating a regular frame processes all consumable bytes,
+        //# then this operation MUST [construct either a final frame or regular frame](#construct-a-frame)
+        //# with the remaining plaintext.
+        //
+        //= spec/data-format/message-body.md#final-frame
+        //# - When the length of the Plaintext is an exact multiple of the Frame Length
+        //# (including if it is equal to the frame length),
+        //# the Final Frame encrypted content length SHOULD be equal to the frame length but MAY be 0.
+        if next_char.is_none() {
+            break;
+        }
+
+        //= spec/client-apis/encrypt.md#construct-the-body
+        //# - If there are enough input plaintext bytes consumable to create a new regular frame,
+        //# such that creating a regular frame does not processes all consumable bytes,
+        //# then this operation MUST [construct a regular frame](#construct-a-frame)
+        //# using the consumable plaintext bytes.
+        if sequence_number == ENDFRAME_SEQUENCE_NUMBER {
+            //= spec/data-format/message-body.md#framed-data
+            //# - The number of frames in a single message MUST be less than or equal to `2^32 - 1`.
+            return Err(val_err("Too many frames"));
+        }
+
+        total_data_size += frame_length;
+        if total_data_size > MAX_DATA {
+            return Err(val_err("Plaintext too large"));
+        }
+        if let Some(max_plaintext_len) = max_plaintext_length {
+            if total_data_size > max_plaintext_len {
+                //= spec/client-apis/encrypt.md#plaintext-length-bound
+                //# If this input is provided, this operation MUST NOT encrypt a plaintext with length
+                //# greater than this value.
+                //
+                //= spec/client-apis/encrypt.md#construct-the-body
+                //# If [Plaintext Length Bound](#plaintext-length-bound) was specified on input
+                //# and this operation determines at any time that the plaintext being encrypted
+                //# has a length greater than this value,
+                //# this operation MUST immediately fail.
+                return Err(val_err(
+                    "Plaintext length exceeds specified Plaintext Length Bound",
+                ));
+            }
+        }
+
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //# Regular frame serialization MUST conform to the [Regular Frame](../data-format/message-body.md#regular-frame) specification.
+        //
+        //= spec/data-format/message-body.md#regular-frame
+        //# A regular frame MUST consist of, in order,
+        //# Sequence Number,
+        //# IV,
+        //# Encrypted Content,
+        //# and Authentication Tag.
+        construct_frame(
+            &ConstructFrameInput {
+                alg,
+                key,
+                //= spec/client-apis/encrypt.md#construct-a-frame
+                //= reason=plaintext_frame is exactly frame_length bytes (the full buffer read from input)
+                //# - For a regular frame the length of this plaintext MUST equal the frame length.
+                //
+                //= spec/client-apis/encrypt.md#construct-a-frame
+                //= reason=plaintext_frame is exactly frame_length bytes for a regular frame
+                //# - For a regular frame the length of this plaintext subsequence MUST equal the frame length.
+                //
+                //= spec/data-format/message-body.md#regular-frame-encrypted-content
+                //# The length of the encrypted content of a Regular Frame MUST be equal to the Frame Length.
+                plaintext: &plaintext_frame,
+                message_id: header.body.message_id(),
+                aad_content: BodyAADContent::RegularFrame,
+                sequence_number,
+                is_final: false,
+            },
+            &mut iv,
+            &mut aad,
+            &mut frame_buf,
+            ciphertext,
+            sig_digest,
+        )?;
+
+        //= spec/data-format/message-body.md#regular-frame-sequence-number
+        //# Subsequent frames MUST be in order and MUST contain an increment of 1 from the previous frame.
+        //
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //# Otherwise, the sequence number value MUST be 1 greater than the value of the sequence number
+        //# of the previous frame.
+        sequence_number += 1;
+    }
+
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //# When the end of the input is indicated,
+    //# this operation MUST perform the following until all consumable plaintext bytes are processed:
+    // Final frame
+    total_data_size += in_size;
+    if total_data_size > MAX_DATA {
+        return Err(val_err("Plaintext too large"));
+    }
+    if let Some(max_len) = max_plaintext_length {
+        if total_data_size > max_len {
+            return Err(val_err(
+                "Plaintext length exceeds specified Plaintext Length Bound",
+            ));
+        }
+    }
+
+    //= spec/data-format/message-body.md#final-frame
+    //= reason=in_size is the plaintext length for the final frame; this asserts it is <= frame_length
+    //# The length of the plaintext to be encrypted in the Final Frame MUST be
+    //# greater than or equal to 0 and less than or equal to the [Frame Length](message-header.md#frame-length).
+    debug_assert!(in_size <= frame_length);
+    debug_assert!(
+        in_size > 0 || sequence_number == START_SEQUENCE_NUMBER,
+        "empty final frame only allowed when entire plaintext is empty"
+    );
+
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //# If an end to the input has been indicated, there are no more consumable plaintext bytes to process,
+    //# and a final frame has not yet been constructed,
+    //# this operation MUST [construct an empty final frame](#construct-a-frame).
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# Final frame serialization MUST conform to the [Final Frame](../data-format/message-body.md#final-frame) specification.
+    construct_frame(
+        &ConstructFrameInput {
+            alg,
+            key,
+            //= spec/client-apis/encrypt.md#construct-a-frame
+            //= reason=plaintext_frame[0..in_size] is the remaining unencrypted bytes, where in_size <= frame_length
+            //# - For a final frame this MUST be the length of the remaining plaintext bytes
+            //# which have not yet been encrypted,
+            //# whose length MUST be equal to or less than the frame length.
+            //
+            //= spec/client-apis/encrypt.md#construct-a-frame
+            //= reason=plaintext_frame[0..in_size] is the remaining unencrypted bytes, where in_size <= frame_length
+            //# - For a final frame this MUST be the remaining plaintext bytes which have not yet been encrypted,
+            //# whose length MUST be equal to or less than the frame length.
+            plaintext: &plaintext_frame[0..in_size],
+            message_id: header.body.message_id(),
+            aad_content: BodyAADContent::FinalFrame,
+            //= spec/data-format/message-body.md#final-frame-sequence-number
+            //# The Final Frame Sequence number MUST be equal to the total number of frames in the Framed Data.
+            sequence_number,
+            is_final: true,
+        },
+        &mut iv,
+        &mut aad,
+        &mut frame_buf,
+        ciphertext,
+        sig_digest,
+    )?;
+
+    Ok(())
+}

--- a/esdk/src/message/body/body_encrypt.rs
+++ b/esdk/src/message/body/body_encrypt.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Frame encryption and body serialization.
 
-use super::{BodyAADContent, body_aad, get_encrypt, iv_seq};
+use super::{BodyAADContent, body_aad, get_aes_gcm, iv_seq};
 use crate::error::val_err;
 use crate::message::header::{ENDFRAME_SEQUENCE_NUMBER, HeaderInfo, START_SEQUENCE_NUMBER};
 use crate::message::serializable_types::{get_iv_length, get_tag_length};
@@ -16,7 +16,7 @@ const MAX_DATA: usize = (1usize << 36) - 32;
 
 /// Input for constructing a single frame (regular or final).
 pub(crate) struct ConstructFrameInput<'a> {
-    pub(crate) alg: AesGcm,
+    pub(crate) aes_gcm: AesGcm,
     pub(crate) key: &'a [u8],
     pub(crate) plaintext: &'a [u8],
     pub(crate) message_id: &'a [u8],
@@ -183,6 +183,11 @@ pub(crate) fn construct_frame(
         //
         //= spec/data-format/message-body.md#final-frame-encrypted-content-length
         //# The encrypted content length MUST be a UInt32.
+        // AES-GCM produces ciphertext of the same length as plaintext (the auth
+        // tag is a separate 16-byte field), so plaintext.len() is the value of
+        // the encrypted content length. The length must be written before the
+        // encrypted content on the wire, so we cannot measure the ciphertext
+        // post-encryption — we use this structural equivalence instead.
         let Ok(enc_content_len) = u32::try_from(input.plaintext.len()) else {
             return ser_err("Plaintext length exceeds u32");
         };
@@ -233,7 +238,7 @@ pub(crate) fn construct_frame(
     //= spec/client-apis/encrypt.md#construct-a-frame
     //# The value MUST be the authentication tag output when calculating the encrypted content for this frame.
     aes_encrypt(
-        input.alg,
+        input.aes_gcm,
         iv,
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= reason=input.key is set from the derived data key in encrypt_and_serialize_body
@@ -297,7 +302,7 @@ pub(crate) fn encrypt_and_serialize_body(
     //= reason=START_SEQUENCE_NUMBER is defined as 1
     //# If this is the first frame sequentially, the sequence number value MUST be 1.
     let mut sequence_number = START_SEQUENCE_NUMBER;
-    let alg = get_encrypt(&header.suite)?;
+    let aes_gcm = get_aes_gcm(&header.suite)?;
 
     let mut iv = vec![0; iv_len];
     let mut plaintext_frame = vec![0; frame_length];
@@ -366,7 +371,7 @@ pub(crate) fn encrypt_and_serialize_body(
                 //# has a length greater than this value,
                 //# this operation MUST immediately fail.
                 return Err(val_err(
-                    "Plaintext length exceeds specified Plaintext Length Bound",
+                    "Plaintext length exceeds configured Plaintext Length Bound",
                 ));
             }
         }
@@ -382,7 +387,7 @@ pub(crate) fn encrypt_and_serialize_body(
         //# and Authentication Tag.
         construct_frame(
             &ConstructFrameInput {
-                alg,
+                aes_gcm,
                 key,
                 //= spec/client-apis/encrypt.md#construct-a-frame
                 //= reason=plaintext_frame is exactly frame_length bytes (the full buffer read from input)
@@ -451,7 +456,7 @@ pub(crate) fn encrypt_and_serialize_body(
     //# Final frame serialization MUST conform to the [Final Frame](../data-format/message-body.md#final-frame) specification.
     construct_frame(
         &ConstructFrameInput {
-            alg,
+            aes_gcm,
             key,
             //= spec/client-apis/encrypt.md#construct-a-frame
             //= reason=plaintext_frame[0..in_size] is the remaining unencrypted bytes, where in_size <= frame_length

--- a/esdk/src/message/body/body_encrypt.rs
+++ b/esdk/src/message/body/body_encrypt.rs
@@ -35,9 +35,26 @@ pub(crate) fn construct_frame(
 ) -> Result<(), Error> {
     frame_buf.clear();
 
+    // AAD
+
     //= spec/client-apis/encrypt.md#construct-a-frame
     //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
     //# constructed according to the [Message Body AAD](../data-format/message-body-aad.md) specification, as follows:
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
+    //# equal to the length of the plaintext being encrypted.
+    //
+    //= spec/data-format/message-body-aad.md#content-length
+    //= reason=plaintext.len() is the length of the plaintext being encrypted in this frame
+    //# - For [framed data](message-body.md#framed-data), this value MUST equal the length, in bytes,
+    //# of the plaintext being encrypted in this frame.
+    let Ok(plaintext_len_u64) = u64::try_from(input.plaintext.len()) else {
+        return ser_err(&format!(
+            "Plaintext length {} exceeds u64::MAX",
+            input.plaintext.len()
+        ));
+    };
     body_aad(
         //= spec/client-apis/encrypt.md#construct-a-frame
         //# - The [message ID](../data-format/message-body-aad.md#message-id) MUST be the same as the
@@ -59,25 +76,11 @@ pub(crate) fn construct_frame(
         //= reason=The sequence_number parameter is the frame sequence number passed from encrypt_and_serialize_body
         //# For [framed data](message-body.md#framed-data), the value of this field MUST be the [frame sequence number](message-body.md#regular-frame-sequence-number).
         input.sequence_number,
-        //= spec/client-apis/encrypt.md#construct-a-frame
-        //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
-        //# equal to the length of the plaintext being encrypted.
-        //
-        //= spec/data-format/message-body-aad.md#content-length
-        //= reason=plaintext.len() is the length of the plaintext being encrypted in this frame
-        //# - For [framed data](message-body.md#framed-data), this value MUST equal the length, in bytes,
-        //# of the plaintext being encrypted in this frame.
-        {
-            let Ok(plaintext_len_u64) = u64::try_from(input.plaintext.len()) else {
-                return ser_err(&format!(
-                    "Plaintext length {} exceeds u64::MAX",
-                    input.plaintext.len()
-                ));
-            };
-            plaintext_len_u64
-        },
+        plaintext_len_u64,
         aad,
     );
+
+    // IV (computed; serialized below)
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //# - The IV MUST be the [sequence number](../data-format/message-body-aad.md#sequence-number)
@@ -100,6 +103,8 @@ pub(crate) fn construct_frame(
     //# Sequence Number End
     //# and Encrypted Content Length.
     if input.is_final {
+        // Sequence Number End
+
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= reason=The following lines serialize SeqNumEnd, SeqNum, IV, EncContentLen, EncContent, and AuthTag in order per the Final Frame spec
         //# For a final frame, each field MUST be serialized according to its specification:
@@ -120,6 +125,8 @@ pub(crate) fn construct_frame(
         //# The value MUST be encoded as the 4 bytes `FF FF FF FF` in hexadecimal notation.
         write_u32(frame_buf, ENDFRAME_SEQUENCE_NUMBER)?;
     }
+
+    // Sequence Number
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= reason=The following lines serialize SeqNum, IV, EncContent, and AuthTag in order per the Regular Frame spec
@@ -150,6 +157,8 @@ pub(crate) fn construct_frame(
     //# The value MUST be the sequence number of this frame.
     write_u32(frame_buf, input.sequence_number)?;
 
+    // IV
+
     //= spec/client-apis/encrypt.md#construct-a-frame
     //# - MUST serialize the [IV](../data-format/message-body.md#regular-frame-iv).
     //
@@ -166,6 +175,8 @@ pub(crate) fn construct_frame(
     write_bytes(frame_buf, iv)?;
 
     if input.is_final {
+        // Encrypted Content Length
+
         //= spec/client-apis/encrypt.md#construct-a-frame
         //# - MUST serialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
         //
@@ -184,27 +195,15 @@ pub(crate) fn construct_frame(
         write_u32(frame_buf, enc_content_len)?;
     }
 
+    // Encrypted Content + Authentication Tag
+
     //= spec/client-apis/encrypt.md#construct-a-frame
     //# To construct a regular or final frame that represents the next frame in the encrypted message's body,
     //# the Encrypt operation MUST calculate the encrypted content and an authentication tag using the
     //# [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
     //# specified by the [algorithm suite](../framework/algorithm-suites.md),
     //# with the following inputs:
-    aes_encrypt(
-        input.alg,
-        iv,
-        //= spec/client-apis/encrypt.md#construct-a-frame
-        //= reason=input.key is set from the derived data key in encrypt_and_serialize_body
-        //# - The cipherkey MUST be the derived data key
-        input.key,
-        //= spec/client-apis/encrypt.md#construct-a-frame
-        //# - The plaintext MUST be the next subsequence of consumable plaintext bytes that have not yet been encrypted.
-        input.plaintext,
-        aad,
-        frame_buf,
-    )?;
-
-    // aes_encrypt writes encrypted content followed by authentication tag to frame_buf
+    //
     //= spec/client-apis/encrypt.md#construct-a-frame
     //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#regular-frame-encrypted-content).
     //
@@ -232,6 +231,21 @@ pub(crate) fn construct_frame(
     //
     //= spec/client-apis/encrypt.md#construct-a-frame
     //# The value MUST be the authentication tag output when calculating the encrypted content for this frame.
+    aes_encrypt(
+        input.alg,
+        iv,
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //= reason=input.key is set from the derived data key in encrypt_and_serialize_body
+        //# - The cipherkey MUST be the derived data key
+        input.key,
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //# - The plaintext MUST be the next subsequence of consumable plaintext bytes that have not yet been encrypted.
+        input.plaintext,
+        aad,
+        frame_buf,
+    )?;
+
+    // Frame release
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= reason=Frame is fully serialized into frame_buf before being written to ciphertext; frame_buf.clear() at function start and write_bytes(ciphertext, frame_buf) here ensure atomic release

--- a/esdk/src/message/body/body_encrypt.rs
+++ b/esdk/src/message/body/body_encrypt.rs
@@ -80,7 +80,7 @@ pub(crate) fn construct_frame(
         aad,
     );
 
-    // IV (computed; serialized below)
+    // IV computation
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //# - The IV MUST be the [sequence number](../data-format/message-body-aad.md#sequence-number)

--- a/esdk/src/message/body/body_encrypt.rs
+++ b/esdk/src/message/body/body_encrypt.rs
@@ -67,7 +67,15 @@ pub(crate) fn construct_frame(
         //= reason=plaintext.len() is the length of the plaintext being encrypted in this frame
         //# - For [framed data](message-body.md#framed-data), this value MUST equal the length, in bytes,
         //# of the plaintext being encrypted in this frame.
-        input.plaintext.len() as u64,
+        {
+            let Ok(plaintext_len_u64) = u64::try_from(input.plaintext.len()) else {
+                return ser_err(&format!(
+                    "Plaintext length {} exceeds u64::MAX",
+                    input.plaintext.len()
+                ));
+            };
+            plaintext_len_u64
+        },
         aad,
     );
 
@@ -255,9 +263,14 @@ pub(crate) fn encrypt_and_serialize_body(
     max_plaintext_length: Option<usize>,
 ) -> Result<(), Error> {
     let mut total_data_size: usize = 0;
-    let frame_length = header.body.frame_length() as usize;
-    let iv_len = get_iv_length(&header.suite) as usize;
-    let auth_len = get_tag_length(&header.suite) as usize;
+    let Ok(frame_length) = usize::try_from(header.body.frame_length()) else {
+        return ser_err(&format!(
+            "Frame length {} exceeds usize::MAX",
+            header.body.frame_length()
+        ));
+    };
+    let iv_len = usize::from(get_iv_length(&header.suite));
+    let auth_len = usize::from(get_tag_length(&header.suite));
     let frame_len = frame_length + iv_len + auth_len + 4;
     let mut frame_buf = Vec::with_capacity(frame_len);
 

--- a/esdk/src/message/body/body_encrypt.rs
+++ b/esdk/src/message/body/body_encrypt.rs
@@ -11,6 +11,7 @@ use crate::message::{DigestWriter, Error, ser_err};
 use crate::types::{SafeRead, SafeWrite};
 use aws_mpl_legacy::primitives::{AesGcm, aes_encrypt};
 
+/// Maximum plaintext bytes per message: 2^36 - 32 (AES-GCM safety bound).
 const MAX_DATA: usize = (1usize << 36) - 32;
 
 /// Input for constructing a single frame (regular or final).

--- a/esdk/src/message/body/body_encrypt.rs
+++ b/esdk/src/message/body/body_encrypt.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Frame encryption and body serialization.
 
-use super::{BodyAADContent, body_aad, get_aes_gcm, iv_seq};
+use super::{BodyAADContent, body_aad, get_alg_suite, iv_seq};
 use crate::error::val_err;
 use crate::message::header::{ENDFRAME_SEQUENCE_NUMBER, HeaderInfo, START_SEQUENCE_NUMBER};
 use crate::message::serializable_types::{get_iv_length, get_tag_length};
@@ -16,7 +16,7 @@ const MAX_DATA: usize = (1usize << 36) - 32;
 
 /// Input for constructing a single frame (regular or final).
 pub(crate) struct ConstructFrameInput<'a> {
-    pub(crate) aes_gcm: AesGcm,
+    pub(crate) alg_suite: AesGcm,
     pub(crate) key: &'a [u8],
     pub(crate) plaintext: &'a [u8],
     pub(crate) message_id: &'a [u8],
@@ -183,11 +183,11 @@ pub(crate) fn construct_frame(
         //
         //= spec/data-format/message-body.md#final-frame-encrypted-content-length
         //# The encrypted content length MUST be a UInt32.
-        // AES-GCM produces ciphertext of the same length as plaintext (the auth
-        // tag is a separate 16-byte field), so plaintext.len() is the value of
-        // the encrypted content length. The length must be written before the
-        // encrypted content on the wire, so we cannot measure the ciphertext
-        // post-encryption — we use this structural equivalence instead.
+        // The wire layout puts this length field before the encrypted content,
+        // so we'd otherwise need to encrypt into a scratch buffer just to learn
+        // the ciphertext length. AES-GCM produces a ciphertext exactly the size
+        // of the plaintext (the auth tag is a separate field), so plaintext.len()
+        // *is* the encrypted content length and lets us skip that buffering.
         let Ok(enc_content_len) = u32::try_from(input.plaintext.len()) else {
             return ser_err("Plaintext length exceeds u32");
         };
@@ -238,7 +238,7 @@ pub(crate) fn construct_frame(
     //= spec/client-apis/encrypt.md#construct-a-frame
     //# The value MUST be the authentication tag output when calculating the encrypted content for this frame.
     aes_encrypt(
-        input.aes_gcm,
+        input.alg_suite,
         iv,
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= reason=input.key is set from the derived data key in encrypt_and_serialize_body
@@ -302,7 +302,7 @@ pub(crate) fn encrypt_and_serialize_body(
     //= reason=START_SEQUENCE_NUMBER is defined as 1
     //# If this is the first frame sequentially, the sequence number value MUST be 1.
     let mut sequence_number = START_SEQUENCE_NUMBER;
-    let aes_gcm = get_aes_gcm(&header.suite)?;
+    let alg_suite = get_alg_suite(&header.suite)?;
 
     let mut iv = vec![0; iv_len];
     let mut plaintext_frame = vec![0; frame_length];
@@ -387,7 +387,7 @@ pub(crate) fn encrypt_and_serialize_body(
         //# and Authentication Tag.
         construct_frame(
             &ConstructFrameInput {
-                aes_gcm,
+                alg_suite,
                 key,
                 //= spec/client-apis/encrypt.md#construct-a-frame
                 //= reason=plaintext_frame is exactly frame_length bytes (the full buffer read from input)
@@ -456,7 +456,7 @@ pub(crate) fn encrypt_and_serialize_body(
     //# Final frame serialization MUST conform to the [Final Frame](../data-format/message-body.md#final-frame) specification.
     construct_frame(
         &ConstructFrameInput {
-            aes_gcm,
+            alg_suite,
             key,
             //= spec/client-apis/encrypt.md#construct-a-frame
             //= reason=plaintext_frame[0..in_size] is the remaining unencrypted bytes, where in_size <= frame_length

--- a/esdk/src/message/body/mod.rs
+++ b/esdk/src/message/body/mod.rs
@@ -14,7 +14,7 @@ use crate::error::{Error, val_err};
 use aws_mpl_legacy::primitives::AesGcm;
 use aws_mpl_legacy::suites::AlgorithmSuite;
 
-pub(crate) fn get_aes_gcm(info: &AlgorithmSuite) -> Result<AesGcm, Error> {
+pub(crate) fn get_alg_suite(info: &AlgorithmSuite) -> Result<AesGcm, Error> {
     match &info.encrypt {
         aws_mpl_legacy::suites::Encrypt::AesGcm(aes_gcm) => Ok(*aes_gcm),
         _ => Err(val_err("Algorithm suite encrypt must be AES-GCM")),

--- a/esdk/src/message/body/mod.rs
+++ b/esdk/src/message/body/mod.rs
@@ -14,7 +14,7 @@ use crate::error::{Error, val_err};
 use aws_mpl_legacy::primitives::AesGcm;
 use aws_mpl_legacy::suites::AlgorithmSuite;
 
-pub(crate) fn get_encrypt(info: &AlgorithmSuite) -> Result<AesGcm, Error> {
+pub(crate) fn get_aes_gcm(info: &AlgorithmSuite) -> Result<AesGcm, Error> {
     match &info.encrypt {
         aws_mpl_legacy::suites::Encrypt::AesGcm(aes_gcm) => Ok(*aes_gcm),
         _ => Err(val_err("Algorithm suite encrypt must be AES-GCM")),

--- a/esdk/src/message/body/mod.rs
+++ b/esdk/src/message/body/mod.rs
@@ -1,0 +1,22 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//! Message body encryption and decryption.
+
+pub(crate) mod body_aad;
+mod body_decrypt;
+mod body_encrypt;
+
+pub(crate) use body_aad::*;
+pub(crate) use body_decrypt::*;
+pub(crate) use body_encrypt::*;
+
+use crate::error::{Error, val_err};
+use aws_mpl_legacy::primitives::AesGcm;
+use aws_mpl_legacy::suites::AlgorithmSuite;
+
+pub(crate) fn get_encrypt(info: &AlgorithmSuite) -> Result<AesGcm, Error> {
+    match &info.encrypt {
+        aws_mpl_legacy::suites::Encrypt::AesGcm(aes_gcm) => Ok(*aes_gcm),
+        _ => Err(val_err("Algorithm suite encrypt must be AES-GCM")),
+    }
+}

--- a/esdk/tests/test_authentication_tag.rs
+++ b/esdk/tests/test_authentication_tag.rs
@@ -3,6 +3,7 @@
 
 //! Tests for encrypt.md#authentication-tag
 
+mod fixtures;
 mod test_helpers;
 
 use aws_esdk::*;

--- a/esdk/tests/test_authentication_tag.rs
+++ b/esdk/tests/test_authentication_tag.rs
@@ -7,8 +7,6 @@ mod fixtures;
 mod test_helpers;
 
 use aws_esdk::*;
-use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
-use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
 use test_helpers::*;
 
 /// V1 header auth layout: IV(12) || Tag(16) immediately after the header body.
@@ -36,13 +34,7 @@ async fn test_v1_header_auth_has_iv_then_tag() {
     //# to the message header calculated in this step.
     let keyring = test_keyring().await;
     let pt = b"raw byte v1 auth tag";
-    let ct = encrypt_with_suite(
-        pt,
-        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
-        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
-        &keyring,
-    )
-    .await;
+    let ct = encrypt_with_version(pt, Version::V1, keyring.clone()).await;
     let (_, iv_offset, tag_offset) = v1_header_auth_offsets(&ct);
 
     //= spec/client-apis/encrypt.md#authentication-tag
@@ -68,9 +60,7 @@ async fn test_v1_header_auth_has_iv_then_tag() {
     );
 
     // Round-trip cross-check: decrypt the same ct whose bytes we inspected above.
-    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let result = decrypt(&dec_input).await.unwrap().plaintext;
+    let result = decrypt_v1_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt, "V1 round-trip with auth tag verification");
 }
 
@@ -83,13 +73,7 @@ async fn test_v2_header_auth_has_tag_only() {
     //# over the message header body.
     let keyring = test_keyring().await;
     let pt = b"raw byte v2 auth tag";
-    let ct = encrypt_with_suite(
-        pt,
-        EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey,
-        EsdkCommitmentPolicy::RequireEncryptRequireDecrypt,
-        &keyring,
-    )
-    .await;
+    let ct = encrypt_with_version(pt, Version::V2, keyring.clone()).await;
     let (header_body_end, tag_offset) = v2_header_auth_offsets(&ct);
 
     let tag_bytes = &ct[tag_offset..tag_offset + TAG_LEN];
@@ -113,8 +97,7 @@ async fn test_v2_header_auth_has_tag_only() {
     );
 
     // Round-trip cross-check: decrypt the same ct whose bytes we inspected above.
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    let result = decrypt(&dec_input).await.unwrap().plaintext;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt, "V2 round-trip with auth tag verification");
 }
 
@@ -131,11 +114,7 @@ async fn test_auth_tag_present_with_required_ec_v1() {
     ]);
     let keyring = test_keyring().await;
     let pt = b"v1 required ec with auth tag";
-    let mut enc_input =
-        EncryptInput::with_legacy_keyring(pt.as_slice(), ec.clone(), keyring.clone());
-    enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
-    enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let ct = encrypt_no_sign_ec_keyring(pt, ec.clone(), Version::V1, &keyring).await;
 
     // Raw-byte: auth tag is present at the expected offset with the expected length.
     let (_, _, tag_offset) = v1_header_auth_offsets(&ct);
@@ -147,9 +126,7 @@ async fn test_auth_tag_present_with_required_ec_v1() {
     );
 
     // Round-trip cross-check: decrypt the same ct with the same EC validates the AAD construction.
-    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, ec, keyring);
-    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let result = decrypt(&dec_input).await.unwrap().plaintext;
+    let result = decrypt_v1_with_keyring_ec(&ct, ec, &keyring).await;
     assert_eq!(result, pt, "V1 round-trip with non-empty EC");
 }
 
@@ -166,10 +143,7 @@ async fn test_auth_tag_present_with_required_ec_v2() {
     ]);
     let keyring = test_keyring().await;
     let pt = b"v2 required ec with auth tag";
-    let mut enc_input =
-        EncryptInput::with_legacy_keyring(pt.as_slice(), ec.clone(), keyring.clone());
-    enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey);
-    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let ct = encrypt_no_sign_ec_keyring(pt, ec.clone(), Version::V2, &keyring).await;
 
     // Raw-byte: auth tag is present at the expected offset with the expected length.
     let (_, tag_offset) = v2_header_auth_offsets(&ct);
@@ -181,8 +155,7 @@ async fn test_auth_tag_present_with_required_ec_v2() {
     );
 
     // Round-trip cross-check: decrypt the same ct with the same EC validates the AAD construction.
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, ec, keyring);
-    let result = decrypt(&dec_input).await.unwrap().plaintext;
+    let result = decrypt_with_keyring_ec(&ct, ec, &keyring).await;
     assert_eq!(result, pt, "V2 round-trip with non-empty EC");
 }
 
@@ -192,19 +165,11 @@ async fn test_auth_tag_tampered_header_fails_decrypt_v1() {
     //= type=test
     //# If this tag verification fails, this operation MUST immediately halt and fail.
     let keyring = test_keyring().await;
-    let mut ct = encrypt_with_suite(
-        b"v1 tamper test",
-        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
-        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
-        &keyring,
-    )
-    .await;
+    let mut ct = encrypt_with_version(b"v1 tamper test", Version::V1, keyring.clone()).await;
     // Tamper with a byte in the header body area (after version byte).
     assert!(ct.len() > 10, "ciphertext must be long enough to tamper");
     ct[5] ^= 0xFF;
-    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let err = decrypt(&dec_input)
+    let err = try_decrypt_v1_with_keyring(&ct, &keyring)
         .await
         .expect_err("V1 tampered header must fail decryption");
     assert!(
@@ -220,18 +185,11 @@ async fn test_auth_tag_tampered_header_fails_decrypt_v2() {
     //= type=test
     //# If this tag verification fails, this operation MUST immediately halt and fail.
     let keyring = test_keyring().await;
-    let mut ct = encrypt_with_suite(
-        b"v2 tamper test",
-        EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey,
-        EsdkCommitmentPolicy::RequireEncryptRequireDecrypt,
-        &keyring,
-    )
-    .await;
+    let mut ct = encrypt_with_version(b"v2 tamper test", Version::V2, keyring.clone()).await;
     // Tamper with a byte in the header body area (after version byte).
     assert!(ct.len() > 10, "ciphertext must be long enough to tamper");
     ct[5] ^= 0xFF;
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    let err = decrypt(&dec_input)
+    let err = try_decrypt_with_keyring(&ct, &keyring)
         .await
         .expect_err("V2 tampered header must fail decryption");
     assert!(

--- a/esdk/tests/test_authentication_tag.rs
+++ b/esdk/tests/test_authentication_tag.rs
@@ -8,211 +8,150 @@ mod test_helpers;
 use aws_esdk::*;
 use test_helpers::*;
 
+/// V1 header auth layout: IV(12) || Tag(16) immediately after the header body.
+/// Returns (header_body_end, iv_offset, tag_offset).
+fn v1_header_auth_offsets(ct: &[u8]) -> (usize, usize, usize) {
+    assert_eq!(ct[0], 0x01, "must be V1 message");
+    let (_, _, _, frame_length_offset) = parse_v1_trailing_offsets(ct);
+    let header_body_end = frame_length_offset + 4;
+    (header_body_end, header_body_end, header_body_end + IV_LEN)
+}
+
+/// V2 header auth layout: Tag(16) immediately after the header body (no IV on wire).
+/// Returns (header_body_end, tag_offset).
+fn v2_header_auth_offsets(ct: &[u8]) -> (usize, usize) {
+    let fields = parse_v2_header_field_offsets(ct);
+    let header_body_end = fields.last().expect("must have header fields").2;
+    (header_body_end, header_body_end)
+}
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_calculated_over_header_body_v1() {
+async fn test_v1_header_auth_has_iv_then_tag() {
     //= spec/client-apis/encrypt.md#authentication-tag
     //= type=test
-    //= reason=decrypt independently recomputes the auth tag over the header body and rejects mismatches, so a successful round-trip proves the auth tag was calculated over the header body
+    //# The encrypted message output by the Encrypt operation MUST have a message header equal
+    //# to the message header calculated in this step.
+    let pt = b"raw byte v1 auth tag";
+    let ct = encrypt_v1(pt).await;
+    let (_, iv_offset, tag_offset) = v1_header_auth_offsets(&ct);
+
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //# - The IV MUST have a value of 0.
+    let iv_bytes = &ct[iv_offset..iv_offset + IV_LEN];
+    assert_eq!(iv_bytes.len(), IV_LEN, "V1 header auth IV must be {IV_LEN} bytes");
+    assert!(
+        iv_bytes.iter().all(|&b| b == 0),
+        "V1 header auth IV must be all zeros (IV=0 padded to IV length)"
+    );
+
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
     //# After serializing the message header body,
     //# this operation MUST calculate an [authentication tag](../data-format/message-header.md#authentication-tag)
     //# over the message header body.
-    let pt = b"v1 auth tag over header body";
+    let tag_bytes = &ct[tag_offset..tag_offset + TAG_LEN];
+    assert_eq!(tag_bytes.len(), TAG_LEN, "V1 header auth tag must be {TAG_LEN} bytes");
+    assert!(
+        tag_bytes.iter().any(|&b| b != 0),
+        "V1 header auth tag must not be all zeros"
+    );
+
+    // Round-trip cross-check: independent decrypt validates the same tag.
     let result = round_trip_v1(pt, EncryptionContext::new()).await;
     assert_eq!(result, pt, "V1 round-trip with auth tag verification");
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_calculated_over_header_body_v2() {
+async fn test_v2_header_auth_has_tag_only() {
     //= spec/client-apis/encrypt.md#authentication-tag
     //= type=test
-    //= reason=decrypt independently recomputes the auth tag over the header body and rejects mismatches, so a successful round-trip proves the auth tag was calculated over the header body
     //# After serializing the message header body,
     //# this operation MUST calculate an [authentication tag](../data-format/message-header.md#authentication-tag)
     //# over the message header body.
-    let pt = b"v2 auth tag over header body";
+    let pt = b"raw byte v2 auth tag";
+    let ct = encrypt_v2(pt).await;
+    let (header_body_end, tag_offset) = v2_header_auth_offsets(&ct);
+
+    let tag_bytes = &ct[tag_offset..tag_offset + TAG_LEN];
+    assert_eq!(tag_bytes.len(), TAG_LEN, "V2 header auth tag must be {TAG_LEN} bytes");
+    assert!(
+        tag_bytes.iter().any(|&b| b != 0),
+        "V2 header auth tag must not be all zeros"
+    );
+
+    // V2 has NO IV on the wire — body starts right after the tag.
+    let after_tag = header_body_end + TAG_LEN;
+    let next_4 = u32::from_be_bytes([
+        ct[after_tag],
+        ct[after_tag + 1],
+        ct[after_tag + 2],
+        ct[after_tag + 3],
+    ]);
+    assert!(
+        next_4 == 1 || next_4 == 0xFFFF_FFFF,
+        "V2: bytes after auth tag must be body start (seq=1 or endframe), got {next_4:#010X}"
+    );
+
+    // Round-trip cross-check: independent decrypt validates the same tag.
     let result = round_trip_v2(pt, EncryptionContext::new()).await;
     assert_eq!(result, pt, "V2 round-trip with auth tag verification");
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_uses_authenticated_encryption_algorithm_v1() {
+async fn test_auth_tag_present_with_required_ec_v1() {
     //= spec/client-apis/encrypt.md#authentication-tag
     //= type=test
-    //= reason=decrypt uses the algorithm suite's authenticated encryption algorithm to verify the tag; a successful round-trip proves the correct algorithm was used
-    //# The value of this MUST be the output of the [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
-    //# specified by the [algorithm suite](../framework/algorithm-suites.md), with the following inputs:
-    let pt = b"v1 encryption algorithm";
-    let result = round_trip_v1(pt, EncryptionContext::new()).await;
-    assert_eq!(result, pt, "V1 round-trip with algorithm verification");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_uses_authenticated_encryption_algorithm_v2() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=decrypt uses the algorithm suite's authenticated encryption algorithm to verify the tag; a successful round-trip proves the correct algorithm was used
-    //# The value of this MUST be the output of the [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
-    //# specified by the [algorithm suite](../framework/algorithm-suites.md), with the following inputs:
-    let pt = b"v2 encryption algorithm";
-    let result = round_trip_v2(pt, EncryptionContext::new()).await;
-    assert_eq!(result, pt, "V2 round-trip with algorithm verification");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_aad_is_header_body_concat_required_ec_v1() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=decrypt recomputes the AAD as header body + required EC serialization and verifies the tag; a successful round-trip with non-empty EC proves the AAD was correctly constructed
+    //= reason=with a non-empty required EC the encryption-context-to-only-authenticate is non-empty, exercising the AAD-concatenation and required-EC-filtering code paths; the tag bytes prove an AEAD output was produced for this scenario and the round-trip proves encrypt and decrypt agree on the AAD construction
     //# - The AAD MUST be the concatenation of the serialized [message header body](../data-format/message-header.md#header-body)
     //# and the serialization of encryption context to only authenticate.
-    let ec = std::collections::HashMap::from([("key".to_string(), "val".to_string())]);
-    let pt = b"v1 aad concatenation";
-    let result = round_trip_v1(pt, ec).await;
-    assert_eq!(result, pt, "V1 round-trip with EC proves AAD construction");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_aad_is_header_body_concat_required_ec_v2() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=decrypt recomputes the AAD as header body + required EC serialization and verifies the tag; a successful round-trip with non-empty EC proves the AAD was correctly constructed
-    //# - The AAD MUST be the concatenation of the serialized [message header body](../data-format/message-header.md#header-body)
-    //# and the serialization of encryption context to only authenticate.
-    let ec = std::collections::HashMap::from([("key".to_string(), "val".to_string())]);
-    let pt = b"v2 aad concatenation";
-    let result = round_trip_v2(pt, ec).await;
-    assert_eq!(result, pt, "V2 round-trip with EC proves AAD construction");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_required_ec_filtering_v1() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=decrypt recomputes the required EC filtering and uses it in AAD verification; a successful round-trip with non-empty EC proves the filtering was applied correctly
-    //# The encryption context to only authenticate MUST be the [encryption context](../framework/structures.md#encryption-context)
-    //# in the [encryption materials](../framework/structures.md#encryption-materials)
-    //# filtered to only contain key value pairs listed in
-    //# the [encryption material's](../framework/structures.md#encryption-materials)
-    //# [required encryption context keys](../framework/structures.md#required-encryption-context-keys)
-    //# serialized according to the [encryption context serialization specification](../framework/structures.md#serialization).
     let ec = std::collections::HashMap::from([
         ("test-public-key".to_string(), "testval".to_string()),
         ("user-key".to_string(), "user-val".to_string()),
     ]);
-    let pt = b"v1 required ec filtering";
+    let pt = b"v1 required ec with auth tag";
+    let ct = encrypt_v1_with_ec(pt, ec.clone()).await;
+
+    // Raw-byte: auth tag is present at the expected offset with the expected length.
+    let (_, _, tag_offset) = v1_header_auth_offsets(&ct);
+    let tag_bytes = &ct[tag_offset..tag_offset + TAG_LEN];
+    assert_eq!(tag_bytes.len(), TAG_LEN, "V1 auth tag must be {TAG_LEN} bytes");
+    assert!(
+        tag_bytes.iter().any(|&b| b != 0),
+        "V1 auth tag must be a real AEAD output (not all zeros)"
+    );
+
+    // Round-trip cross-check: decrypt with the same EC validates the AAD construction.
     let result = round_trip_v1(pt, ec).await;
-    assert_eq!(result, pt, "V1 round-trip with non-empty EC proves filtering");
+    assert_eq!(result, pt, "V1 round-trip with non-empty EC");
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_required_ec_filtering_v2() {
+async fn test_auth_tag_present_with_required_ec_v2() {
     //= spec/client-apis/encrypt.md#authentication-tag
     //= type=test
-    //= reason=decrypt recomputes the required EC filtering and uses it in AAD verification; a successful round-trip with non-empty EC proves the filtering was applied correctly
-    //# The encryption context to only authenticate MUST be the [encryption context](../framework/structures.md#encryption-context)
-    //# in the [encryption materials](../framework/structures.md#encryption-materials)
-    //# filtered to only contain key value pairs listed in
-    //# the [encryption material's](../framework/structures.md#encryption-materials)
-    //# [required encryption context keys](../framework/structures.md#required-encryption-context-keys)
-    //# serialized according to the [encryption context serialization specification](../framework/structures.md#serialization).
+    //= reason=with a non-empty required EC the encryption-context-to-only-authenticate is non-empty, exercising the AAD-concatenation and required-EC-filtering code paths; the tag bytes prove an AEAD output was produced for this scenario and the round-trip proves encrypt and decrypt agree on the AAD construction
+    //# - The AAD MUST be the concatenation of the serialized [message header body](../data-format/message-header.md#header-body)
+    //# and the serialization of encryption context to only authenticate.
     let ec = std::collections::HashMap::from([
         ("test-public-key".to_string(), "testval".to_string()),
         ("user-key".to_string(), "user-val".to_string()),
     ]);
-    let pt = b"v2 required ec filtering";
+    let pt = b"v2 required ec with auth tag";
+    let ct = encrypt_no_sign_with_ec(pt, ec.clone(), Version::V2).await;
+
+    // Raw-byte: auth tag is present at the expected offset with the expected length.
+    let (_, tag_offset) = v2_header_auth_offsets(&ct);
+    let tag_bytes = &ct[tag_offset..tag_offset + TAG_LEN];
+    assert_eq!(tag_bytes.len(), TAG_LEN, "V2 auth tag must be {TAG_LEN} bytes");
+    assert!(
+        tag_bytes.iter().any(|&b| b != 0),
+        "V2 auth tag must be a real AEAD output (not all zeros)"
+    );
+
+    // Round-trip cross-check: decrypt with the same EC validates the AAD construction.
     let result = round_trip_v2(pt, ec).await;
-    assert_eq!(result, pt, "V2 round-trip with non-empty EC proves filtering");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_iv_is_zero_v1() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=decrypt recomputes the auth tag with IV=0; if encrypt used a different IV the tag would not match and round-trip would fail
-    //# - The IV MUST have a value of 0.
-    let pt = b"v1 iv zero";
-    let result = round_trip_v1(pt, EncryptionContext::new()).await;
-    assert_eq!(result, pt, "V1 round-trip proves IV=0 was used for auth tag");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_iv_is_zero_v2() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=decrypt recomputes the auth tag with IV=0; if encrypt used a different IV the tag would not match and round-trip would fail
-    //# - The IV MUST have a value of 0.
-    let pt = b"v2 iv zero";
-    let result = round_trip_v2(pt, EncryptionContext::new()).await;
-    assert_eq!(result, pt, "V2 round-trip proves IV=0 was used for auth tag");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_cipherkey_is_derived_data_key_v1() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=decrypt recomputes the auth tag using the derived data key; if encrypt used a different key the tag would not match and round-trip would fail
-    //# - The cipherkey MUST be the derived data key
-    let pt = b"v1 cipherkey";
-    let result = round_trip_v1(pt, EncryptionContext::new()).await;
-    assert_eq!(result, pt, "V1 round-trip proves derived data key was used as cipherkey");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_cipherkey_is_derived_data_key_v2() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=decrypt recomputes the auth tag using the derived data key; if encrypt used a different key the tag would not match and round-trip would fail
-    //# - The cipherkey MUST be the derived data key
-    let pt = b"v2 cipherkey";
-    let result = round_trip_v2(pt, EncryptionContext::new()).await;
-    assert_eq!(result, pt, "V2 round-trip proves derived data key was used as cipherkey");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_plaintext_is_empty_v1() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=decrypt recomputes the auth tag with empty plaintext; if encrypt used non-empty plaintext the tag would not match and round-trip would fail
-    //# - The plaintext MUST be an empty byte array
-    let pt = b"v1 empty plaintext for auth tag";
-    let result = round_trip_v1(pt, EncryptionContext::new()).await;
-    assert_eq!(result, pt, "V1 round-trip proves auth tag was computed with empty plaintext");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_plaintext_is_empty_v2() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=decrypt recomputes the auth tag with empty plaintext; if encrypt used non-empty plaintext the tag would not match and round-trip would fail
-    //# - The plaintext MUST be an empty byte array
-    let pt = b"v2 empty plaintext for auth tag";
-    let result = round_trip_v2(pt, EncryptionContext::new()).await;
-    assert_eq!(result, pt, "V2 round-trip proves auth tag was computed with empty plaintext");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_header_equality_v1() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=a successful round-trip confirms the serialized header matches the calculated header because decrypt authenticates the header and would fail if they differed
-    //# The encrypted message output by the Encrypt operation MUST have a message header equal
-    //# to the message header calculated in this step.
-    let pt = b"v1 header equality";
-    let result = round_trip_v1(pt, EncryptionContext::new()).await;
-    assert_eq!(result, pt, "V1 round-trip proves output header equals calculated header");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_header_equality_v2() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //= reason=a successful round-trip confirms the serialized header matches the calculated header because decrypt authenticates the header and would fail if they differed
-    //# The encrypted message output by the Encrypt operation MUST have a message header equal
-    //# to the message header calculated in this step.
-    let pt = b"v2 header equality";
-    let result = round_trip_v2(pt, EncryptionContext::new()).await;
-    assert_eq!(result, pt, "V2 round-trip proves output header equals calculated header");
+    assert_eq!(result, pt, "V2 round-trip with non-empty EC");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -221,18 +160,20 @@ async fn test_auth_tag_tampered_header_fails_decrypt_v1() {
     //= type=test
     //# If this tag verification fails, this operation MUST immediately halt and fail.
     let mut ct = encrypt_v1(b"v1 tamper test").await;
-    // Tamper with a byte in the header body area (after version byte)
-    if ct.len() > 10 {
-        ct[5] ^= 0xFF;
-    }
+    // Tamper with a byte in the header body area (after version byte).
+    assert!(ct.len() > 10, "ciphertext must be long enough to tamper");
+    ct[5] ^= 0xFF;
     let keyring = test_keyring().await;
     let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
     dec_input.commitment_policy =
         aws_mpl_legacy::commitment::EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let err = decrypt(&dec_input).await.expect_err("V1 tampered header must fail decryption");
+    let err = decrypt(&dec_input)
+        .await
+        .expect_err("V1 tampered header must fail decryption");
     assert!(
         matches!(err.kind, ErrorKind::CryptographicError),
-        "V1: expected CryptographicError, got {:?}", err.kind
+        "V1: expected CryptographicError, got {:?}",
+        err.kind
     );
 }
 
@@ -242,16 +183,34 @@ async fn test_auth_tag_tampered_header_fails_decrypt_v2() {
     //= type=test
     //# If this tag verification fails, this operation MUST immediately halt and fail.
     let mut ct = encrypt_v2(b"v2 tamper test").await;
-    // Tamper with a byte in the header body area (after version byte)
-    if ct.len() > 10 {
-        ct[5] ^= 0xFF;
-    }
+    // Tamper with a byte in the header body area (after version byte).
+    assert!(ct.len() > 10, "ciphertext must be long enough to tamper");
+    ct[5] ^= 0xFF;
     let keyring = test_keyring().await;
     let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    let err = decrypt(&dec_input).await.expect_err("V2 tampered header must fail decryption");
+    let err = decrypt(&dec_input)
+        .await
+        .expect_err("V2 tampered header must fail decryption");
     assert!(
         matches!(err.kind, ErrorKind::ValidationError),
-        "V2: expected ValidationError, got {:?}", err.kind
+        "V2: expected ValidationError, got {:?}",
+        err.kind
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_serialized_bytes_not_released_until_complete_v1() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //# The serialized bytes MUST NOT be released until the entire message header has been serialized.
+    // Encrypt returns the full ciphertext only after the header (body + IV + auth tag) is complete.
+    // Verify the auth tag is present at the expected position, proving the header was fully serialized.
+    let ct = encrypt_v1(b"v1 serialization release test").await;
+    let (_, _, tag_offset) = v1_header_auth_offsets(&ct);
+    let tag_bytes = &ct[tag_offset..tag_offset + TAG_LEN];
+    assert!(
+        tag_bytes.iter().any(|&b| b != 0),
+        "V1 header auth tag must be present (not all zeros) — proves full header was serialized before release"
     );
 }
 
@@ -262,105 +221,11 @@ async fn test_auth_tag_serialized_bytes_not_released_until_complete_v2() {
     //# The serialized bytes MUST NOT be released until the entire message header has been serialized.
     // Encrypt returns the full ciphertext only after the header (body + auth tag) is complete.
     // Verify the auth tag is present at the expected position, proving the header was fully serialized.
-    let ct = encrypt_v2(b"serialization release test").await;
-    let fields = parse_v2_header_field_offsets(&ct);
-    let header_body_end = fields.last().expect("must have header fields").2;
-    let auth_tag_bytes = &ct[header_body_end..header_body_end + TAG_LEN];
+    let ct = encrypt_v2(b"v2 serialization release test").await;
+    let (_, tag_offset) = v2_header_auth_offsets(&ct);
+    let tag_bytes = &ct[tag_offset..tag_offset + TAG_LEN];
     assert!(
-        auth_tag_bytes.iter().any(|&b| b != 0),
+        tag_bytes.iter().any(|&b| b != 0),
         "V2 header auth tag must be present (not all zeros) — proves full header was serialized before release"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_v2_header_auth_tag_is_16_bytes_after_header_body() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //# After serializing the message header body,
-    //# this operation MUST calculate an [authentication tag](../data-format/message-header.md#authentication-tag)
-    //# over the message header body.
-    let ct = encrypt_v2(b"raw byte v2 auth tag").await;
-    let fields = parse_v2_header_field_offsets(&ct);
-    // The last field in the V2 header body is "Algorithm Suite Data" (32 bytes).
-    // The header auth tag (16 bytes) immediately follows the header body.
-    let last_field = fields.last().expect("must have header fields");
-    let header_body_end = last_field.2;
-    let auth_tag_bytes = &ct[header_body_end..header_body_end + TAG_LEN];
-    assert_eq!(
-        auth_tag_bytes.len(),
-        TAG_LEN,
-        "V2 header auth tag must be exactly {} bytes",
-        TAG_LEN
-    );
-    // Auth tag must not be all zeros (it's a real AEAD output)
-    assert!(
-        auth_tag_bytes.iter().any(|&b| b != 0),
-        "V2 header auth tag must not be all zeros"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_v1_header_auth_has_iv_then_tag() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //# The encrypted message output by the Encrypt operation MUST have a message header equal
-    //# to the message header calculated in this step.
-    let ct = encrypt_v1(b"raw byte v1 auth tag").await;
-    // V1 header: Version(1) + AlgSuiteID(2) + MessageID(16) + AAD(variable) + EDKs(variable)
-    //            + ContentType(1) + Reserved(4) + IVLength(1) + FrameLength(4)
-    // Then header auth: IV(12) + Tag(16)
-    // Find header body end by parsing. V1 version byte is 0x01.
-    assert_eq!(ct[0], 0x01, "must be V1 message");
-    let (_, _, _, frame_length_offset) = parse_v1_trailing_offsets(&ct);
-    let header_body_end = frame_length_offset + 4;
-    // V1 header auth: IV (12 bytes) then Tag (16 bytes)
-    let iv_bytes = &ct[header_body_end..header_body_end + IV_LEN];
-    let tag_bytes = &ct[header_body_end + IV_LEN..header_body_end + IV_LEN + TAG_LEN];
-
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //# - The IV MUST have a value of 0.
-    assert_eq!(iv_bytes.len(), IV_LEN, "V1 header auth IV must be {} bytes", IV_LEN);
-    assert!(
-        iv_bytes.iter().all(|&b| b == 0),
-        "V1 header auth IV must be all zeros (IV=0 padded to IV length)"
-    );
-
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //# - The plaintext MUST be an empty byte array
-    assert_eq!(tag_bytes.len(), TAG_LEN, "V1 header auth tag must be {} bytes", TAG_LEN);
-    assert!(
-        tag_bytes.iter().any(|&b| b != 0),
-        "V1 header auth tag must not be all zeros"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_v2_header_auth_has_tag_only() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //# If the message headers are not equal, the Encrypt operation MUST fail.
-    let ct = encrypt_v2(b"raw byte v2 tag only").await;
-    let fields = parse_v2_header_field_offsets(&ct);
-    let header_body_end = fields.last().expect("must have header fields").2;
-
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //# - The cipherkey MUST be the derived data key
-    let tag_bytes = &ct[header_body_end..header_body_end + TAG_LEN];
-    assert_eq!(tag_bytes.len(), TAG_LEN, "V2 header auth tag must be {} bytes", TAG_LEN);
-    assert!(
-        tag_bytes.iter().any(|&b| b != 0),
-        "V2 header auth tag must not be all zeros"
-    );
-    // V2 has NO IV in header auth — the body starts right after the tag.
-    // Verify the next bytes are the start of the body (first frame seq num or endframe marker).
-    let after_tag = header_body_end + TAG_LEN;
-    let next_4 = u32::from_be_bytes([ct[after_tag], ct[after_tag + 1], ct[after_tag + 2], ct[after_tag + 3]]);
-    assert!(
-        next_4 == 1 || next_4 == 0xFFFF_FFFF,
-        "V2: bytes after auth tag must be body start (seq=1 or endframe), got {:#010X}",
-        next_4
     );
 }

--- a/esdk/tests/test_authentication_tag.rs
+++ b/esdk/tests/test_authentication_tag.rs
@@ -197,35 +197,3 @@ async fn test_auth_tag_tampered_header_fails_decrypt_v2() {
         err.kind
     );
 }
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_serialized_bytes_not_released_until_complete_v1() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //# The serialized bytes MUST NOT be released until the entire message header has been serialized.
-    // Encrypt returns the full ciphertext only after the header (body + IV + auth tag) is complete.
-    // Verify the auth tag is present at the expected position, proving the header was fully serialized.
-    let ct = encrypt_v1(b"v1 serialization release test").await;
-    let (_, _, tag_offset) = v1_header_auth_offsets(&ct);
-    let tag_bytes = &ct[tag_offset..tag_offset + TAG_LEN];
-    assert!(
-        tag_bytes.iter().any(|&b| b != 0),
-        "V1 header auth tag must be present (not all zeros) — proves full header was serialized before release"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_auth_tag_serialized_bytes_not_released_until_complete_v2() {
-    //= spec/client-apis/encrypt.md#authentication-tag
-    //= type=test
-    //# The serialized bytes MUST NOT be released until the entire message header has been serialized.
-    // Encrypt returns the full ciphertext only after the header (body + auth tag) is complete.
-    // Verify the auth tag is present at the expected position, proving the header was fully serialized.
-    let ct = encrypt_v2(b"v2 serialization release test").await;
-    let (_, tag_offset) = v2_header_auth_offsets(&ct);
-    let tag_bytes = &ct[tag_offset..tag_offset + TAG_LEN];
-    assert!(
-        tag_bytes.iter().any(|&b| b != 0),
-        "V2 header auth tag must be present (not all zeros) — proves full header was serialized before release"
-    );
-}

--- a/esdk/tests/test_authentication_tag.rs
+++ b/esdk/tests/test_authentication_tag.rs
@@ -58,8 +58,12 @@ async fn test_v1_header_auth_has_iv_then_tag() {
         "V1 header auth tag must not be all zeros"
     );
 
-    // Round-trip cross-check: independent decrypt validates the same tag.
-    let result = round_trip_v1(pt, EncryptionContext::new()).await;
+    // Round-trip cross-check: decrypt the same ct whose bytes we inspected above.
+    let keyring = test_keyring().await;
+    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    dec_input.commitment_policy =
+        aws_mpl_legacy::commitment::EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let result = decrypt(&dec_input).await.unwrap().plaintext;
     assert_eq!(result, pt, "V1 round-trip with auth tag verification");
 }
 
@@ -94,8 +98,10 @@ async fn test_v2_header_auth_has_tag_only() {
         "V2: bytes after auth tag must be body start (seq=1 or endframe), got {next_4:#010X}"
     );
 
-    // Round-trip cross-check: independent decrypt validates the same tag.
-    let result = round_trip_v2(pt, EncryptionContext::new()).await;
+    // Round-trip cross-check: decrypt the same ct whose bytes we inspected above.
+    let keyring = test_keyring().await;
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let result = decrypt(&dec_input).await.unwrap().plaintext;
     assert_eq!(result, pt, "V2 round-trip with auth tag verification");
 }
 
@@ -122,8 +128,12 @@ async fn test_auth_tag_present_with_required_ec_v1() {
         "V1 auth tag must be a real AEAD output (not all zeros)"
     );
 
-    // Round-trip cross-check: decrypt with the same EC validates the AAD construction.
-    let result = round_trip_v1(pt, ec).await;
+    // Round-trip cross-check: decrypt the same ct with the same EC validates the AAD construction.
+    let keyring = test_keyring().await;
+    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, ec, keyring);
+    dec_input.commitment_policy =
+        aws_mpl_legacy::commitment::EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let result = decrypt(&dec_input).await.unwrap().plaintext;
     assert_eq!(result, pt, "V1 round-trip with non-empty EC");
 }
 
@@ -150,8 +160,10 @@ async fn test_auth_tag_present_with_required_ec_v2() {
         "V2 auth tag must be a real AEAD output (not all zeros)"
     );
 
-    // Round-trip cross-check: decrypt with the same EC validates the AAD construction.
-    let result = round_trip_v2(pt, ec).await;
+    // Round-trip cross-check: decrypt the same ct with the same EC validates the AAD construction.
+    let keyring = test_keyring().await;
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, ec, keyring);
+    let result = decrypt(&dec_input).await.unwrap().plaintext;
     assert_eq!(result, pt, "V2 round-trip with non-empty EC");
 }
 

--- a/esdk/tests/test_authentication_tag.rs
+++ b/esdk/tests/test_authentication_tag.rs
@@ -1,0 +1,366 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for encrypt.md#authentication-tag
+
+mod test_helpers;
+
+use aws_esdk::*;
+use test_helpers::*;
+
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_calculated_over_header_body_v1() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt independently recomputes the auth tag over the header body and rejects mismatches, so a successful round-trip proves the auth tag was calculated over the header body
+    //# After serializing the message header body,
+    //# this operation MUST calculate an [authentication tag](../data-format/message-header.md#authentication-tag)
+    //# over the message header body.
+    let pt = b"v1 auth tag over header body";
+    let result = round_trip_v1(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V1 round-trip with auth tag verification");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_calculated_over_header_body_v2() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt independently recomputes the auth tag over the header body and rejects mismatches, so a successful round-trip proves the auth tag was calculated over the header body
+    //# After serializing the message header body,
+    //# this operation MUST calculate an [authentication tag](../data-format/message-header.md#authentication-tag)
+    //# over the message header body.
+    let pt = b"v2 auth tag over header body";
+    let result = round_trip_v2(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V2 round-trip with auth tag verification");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_uses_authenticated_encryption_algorithm_v1() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt uses the algorithm suite's authenticated encryption algorithm to verify the tag; a successful round-trip proves the correct algorithm was used
+    //# The value of this MUST be the output of the [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
+    //# specified by the [algorithm suite](../framework/algorithm-suites.md), with the following inputs:
+    let pt = b"v1 encryption algorithm";
+    let result = round_trip_v1(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V1 round-trip with algorithm verification");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_uses_authenticated_encryption_algorithm_v2() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt uses the algorithm suite's authenticated encryption algorithm to verify the tag; a successful round-trip proves the correct algorithm was used
+    //# The value of this MUST be the output of the [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
+    //# specified by the [algorithm suite](../framework/algorithm-suites.md), with the following inputs:
+    let pt = b"v2 encryption algorithm";
+    let result = round_trip_v2(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V2 round-trip with algorithm verification");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_aad_is_header_body_concat_required_ec_v1() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt recomputes the AAD as header body + required EC serialization and verifies the tag; a successful round-trip with non-empty EC proves the AAD was correctly constructed
+    //# - The AAD MUST be the concatenation of the serialized [message header body](../data-format/message-header.md#header-body)
+    //# and the serialization of encryption context to only authenticate.
+    let ec = std::collections::HashMap::from([("key".to_string(), "val".to_string())]);
+    let pt = b"v1 aad concatenation";
+    let result = round_trip_v1(pt, ec).await;
+    assert_eq!(result, pt, "V1 round-trip with EC proves AAD construction");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_aad_is_header_body_concat_required_ec_v2() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt recomputes the AAD as header body + required EC serialization and verifies the tag; a successful round-trip with non-empty EC proves the AAD was correctly constructed
+    //# - The AAD MUST be the concatenation of the serialized [message header body](../data-format/message-header.md#header-body)
+    //# and the serialization of encryption context to only authenticate.
+    let ec = std::collections::HashMap::from([("key".to_string(), "val".to_string())]);
+    let pt = b"v2 aad concatenation";
+    let result = round_trip_v2(pt, ec).await;
+    assert_eq!(result, pt, "V2 round-trip with EC proves AAD construction");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_required_ec_filtering_v1() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt recomputes the required EC filtering and uses it in AAD verification; a successful round-trip with non-empty EC proves the filtering was applied correctly
+    //# The encryption context to only authenticate MUST be the [encryption context](../framework/structures.md#encryption-context)
+    //# in the [encryption materials](../framework/structures.md#encryption-materials)
+    //# filtered to only contain key value pairs listed in
+    //# the [encryption material's](../framework/structures.md#encryption-materials)
+    //# [required encryption context keys](../framework/structures.md#required-encryption-context-keys)
+    //# serialized according to the [encryption context serialization specification](../framework/structures.md#serialization).
+    let ec = std::collections::HashMap::from([
+        ("test-public-key".to_string(), "testval".to_string()),
+        ("user-key".to_string(), "user-val".to_string()),
+    ]);
+    let pt = b"v1 required ec filtering";
+    let result = round_trip_v1(pt, ec).await;
+    assert_eq!(result, pt, "V1 round-trip with non-empty EC proves filtering");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_required_ec_filtering_v2() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt recomputes the required EC filtering and uses it in AAD verification; a successful round-trip with non-empty EC proves the filtering was applied correctly
+    //# The encryption context to only authenticate MUST be the [encryption context](../framework/structures.md#encryption-context)
+    //# in the [encryption materials](../framework/structures.md#encryption-materials)
+    //# filtered to only contain key value pairs listed in
+    //# the [encryption material's](../framework/structures.md#encryption-materials)
+    //# [required encryption context keys](../framework/structures.md#required-encryption-context-keys)
+    //# serialized according to the [encryption context serialization specification](../framework/structures.md#serialization).
+    let ec = std::collections::HashMap::from([
+        ("test-public-key".to_string(), "testval".to_string()),
+        ("user-key".to_string(), "user-val".to_string()),
+    ]);
+    let pt = b"v2 required ec filtering";
+    let result = round_trip_v2(pt, ec).await;
+    assert_eq!(result, pt, "V2 round-trip with non-empty EC proves filtering");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_iv_is_zero_v1() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt recomputes the auth tag with IV=0; if encrypt used a different IV the tag would not match and round-trip would fail
+    //# - The IV MUST have a value of 0.
+    let pt = b"v1 iv zero";
+    let result = round_trip_v1(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V1 round-trip proves IV=0 was used for auth tag");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_iv_is_zero_v2() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt recomputes the auth tag with IV=0; if encrypt used a different IV the tag would not match and round-trip would fail
+    //# - The IV MUST have a value of 0.
+    let pt = b"v2 iv zero";
+    let result = round_trip_v2(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V2 round-trip proves IV=0 was used for auth tag");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_cipherkey_is_derived_data_key_v1() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt recomputes the auth tag using the derived data key; if encrypt used a different key the tag would not match and round-trip would fail
+    //# - The cipherkey MUST be the derived data key
+    let pt = b"v1 cipherkey";
+    let result = round_trip_v1(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V1 round-trip proves derived data key was used as cipherkey");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_cipherkey_is_derived_data_key_v2() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt recomputes the auth tag using the derived data key; if encrypt used a different key the tag would not match and round-trip would fail
+    //# - The cipherkey MUST be the derived data key
+    let pt = b"v2 cipherkey";
+    let result = round_trip_v2(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V2 round-trip proves derived data key was used as cipherkey");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_plaintext_is_empty_v1() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt recomputes the auth tag with empty plaintext; if encrypt used non-empty plaintext the tag would not match and round-trip would fail
+    //# - The plaintext MUST be an empty byte array
+    let pt = b"v1 empty plaintext for auth tag";
+    let result = round_trip_v1(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V1 round-trip proves auth tag was computed with empty plaintext");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_plaintext_is_empty_v2() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=decrypt recomputes the auth tag with empty plaintext; if encrypt used non-empty plaintext the tag would not match and round-trip would fail
+    //# - The plaintext MUST be an empty byte array
+    let pt = b"v2 empty plaintext for auth tag";
+    let result = round_trip_v2(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V2 round-trip proves auth tag was computed with empty plaintext");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_header_equality_v1() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=a successful round-trip confirms the serialized header matches the calculated header because decrypt authenticates the header and would fail if they differed
+    //# The encrypted message output by the Encrypt operation MUST have a message header equal
+    //# to the message header calculated in this step.
+    let pt = b"v1 header equality";
+    let result = round_trip_v1(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V1 round-trip proves output header equals calculated header");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_header_equality_v2() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //= reason=a successful round-trip confirms the serialized header matches the calculated header because decrypt authenticates the header and would fail if they differed
+    //# The encrypted message output by the Encrypt operation MUST have a message header equal
+    //# to the message header calculated in this step.
+    let pt = b"v2 header equality";
+    let result = round_trip_v2(pt, EncryptionContext::new()).await;
+    assert_eq!(result, pt, "V2 round-trip proves output header equals calculated header");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_tampered_header_fails_decrypt_v1() {
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //# If this tag verification fails, this operation MUST immediately halt and fail.
+    let mut ct = encrypt_v1(b"v1 tamper test").await;
+    // Tamper with a byte in the header body area (after version byte)
+    if ct.len() > 10 {
+        ct[5] ^= 0xFF;
+    }
+    let keyring = test_keyring().await;
+    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    dec_input.commitment_policy =
+        aws_mpl_legacy::commitment::EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let err = decrypt(&dec_input).await.expect_err("V1 tampered header must fail decryption");
+    assert!(
+        matches!(err.kind, ErrorKind::CryptographicError),
+        "V1: expected CryptographicError, got {:?}", err.kind
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_tampered_header_fails_decrypt_v2() {
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //# If this tag verification fails, this operation MUST immediately halt and fail.
+    let mut ct = encrypt_v2(b"v2 tamper test").await;
+    // Tamper with a byte in the header body area (after version byte)
+    if ct.len() > 10 {
+        ct[5] ^= 0xFF;
+    }
+    let keyring = test_keyring().await;
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let err = decrypt(&dec_input).await.expect_err("V2 tampered header must fail decryption");
+    assert!(
+        matches!(err.kind, ErrorKind::ValidationError),
+        "V2: expected ValidationError, got {:?}", err.kind
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_tag_serialized_bytes_not_released_until_complete_v2() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //# The serialized bytes MUST NOT be released until the entire message header has been serialized.
+    // Encrypt returns the full ciphertext only after the header (body + auth tag) is complete.
+    // Verify the auth tag is present at the expected position, proving the header was fully serialized.
+    let ct = encrypt_v2(b"serialization release test").await;
+    let fields = parse_v2_header_field_offsets(&ct);
+    let header_body_end = fields.last().expect("must have header fields").2;
+    let auth_tag_bytes = &ct[header_body_end..header_body_end + TAG_LEN];
+    assert!(
+        auth_tag_bytes.iter().any(|&b| b != 0),
+        "V2 header auth tag must be present (not all zeros) — proves full header was serialized before release"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v2_header_auth_tag_is_16_bytes_after_header_body() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //# After serializing the message header body,
+    //# this operation MUST calculate an [authentication tag](../data-format/message-header.md#authentication-tag)
+    //# over the message header body.
+    let ct = encrypt_v2(b"raw byte v2 auth tag").await;
+    let fields = parse_v2_header_field_offsets(&ct);
+    // The last field in the V2 header body is "Algorithm Suite Data" (32 bytes).
+    // The header auth tag (16 bytes) immediately follows the header body.
+    let last_field = fields.last().expect("must have header fields");
+    let header_body_end = last_field.2;
+    let auth_tag_bytes = &ct[header_body_end..header_body_end + TAG_LEN];
+    assert_eq!(
+        auth_tag_bytes.len(),
+        TAG_LEN,
+        "V2 header auth tag must be exactly {} bytes",
+        TAG_LEN
+    );
+    // Auth tag must not be all zeros (it's a real AEAD output)
+    assert!(
+        auth_tag_bytes.iter().any(|&b| b != 0),
+        "V2 header auth tag must not be all zeros"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_header_auth_has_iv_then_tag() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //# The encrypted message output by the Encrypt operation MUST have a message header equal
+    //# to the message header calculated in this step.
+    let ct = encrypt_v1(b"raw byte v1 auth tag").await;
+    // V1 header: Version(1) + AlgSuiteID(2) + MessageID(16) + AAD(variable) + EDKs(variable)
+    //            + ContentType(1) + Reserved(4) + IVLength(1) + FrameLength(4)
+    // Then header auth: IV(12) + Tag(16)
+    // Find header body end by parsing. V1 version byte is 0x01.
+    assert_eq!(ct[0], 0x01, "must be V1 message");
+    let (_, _, _, frame_length_offset) = parse_v1_trailing_offsets(&ct);
+    let header_body_end = frame_length_offset + 4;
+    // V1 header auth: IV (12 bytes) then Tag (16 bytes)
+    let iv_bytes = &ct[header_body_end..header_body_end + IV_LEN];
+    let tag_bytes = &ct[header_body_end + IV_LEN..header_body_end + IV_LEN + TAG_LEN];
+
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //# - The IV MUST have a value of 0.
+    assert_eq!(iv_bytes.len(), IV_LEN, "V1 header auth IV must be {} bytes", IV_LEN);
+    assert!(
+        iv_bytes.iter().all(|&b| b == 0),
+        "V1 header auth IV must be all zeros (IV=0 padded to IV length)"
+    );
+
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //# - The plaintext MUST be an empty byte array
+    assert_eq!(tag_bytes.len(), TAG_LEN, "V1 header auth tag must be {} bytes", TAG_LEN);
+    assert!(
+        tag_bytes.iter().any(|&b| b != 0),
+        "V1 header auth tag must not be all zeros"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v2_header_auth_has_tag_only() {
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //# If the message headers are not equal, the Encrypt operation MUST fail.
+    let ct = encrypt_v2(b"raw byte v2 tag only").await;
+    let fields = parse_v2_header_field_offsets(&ct);
+    let header_body_end = fields.last().expect("must have header fields").2;
+
+    //= spec/client-apis/encrypt.md#authentication-tag
+    //= type=test
+    //# - The cipherkey MUST be the derived data key
+    let tag_bytes = &ct[header_body_end..header_body_end + TAG_LEN];
+    assert_eq!(tag_bytes.len(), TAG_LEN, "V2 header auth tag must be {} bytes", TAG_LEN);
+    assert!(
+        tag_bytes.iter().any(|&b| b != 0),
+        "V2 header auth tag must not be all zeros"
+    );
+    // V2 has NO IV in header auth — the body starts right after the tag.
+    // Verify the next bytes are the start of the body (first frame seq num or endframe marker).
+    let after_tag = header_body_end + TAG_LEN;
+    let next_4 = u32::from_be_bytes([ct[after_tag], ct[after_tag + 1], ct[after_tag + 2], ct[after_tag + 3]]);
+    assert!(
+        next_4 == 1 || next_4 == 0xFFFF_FFFF,
+        "V2: bytes after auth tag must be body start (seq=1 or endframe), got {:#010X}",
+        next_4
+    );
+}

--- a/esdk/tests/test_authentication_tag.rs
+++ b/esdk/tests/test_authentication_tag.rs
@@ -7,6 +7,8 @@ mod fixtures;
 mod test_helpers;
 
 use aws_esdk::*;
+use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
+use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
 use test_helpers::*;
 
 /// V1 header auth layout: IV(12) || Tag(16) immediately after the header body.
@@ -32,8 +34,15 @@ async fn test_v1_header_auth_has_iv_then_tag() {
     //= type=test
     //# The encrypted message output by the Encrypt operation MUST have a message header equal
     //# to the message header calculated in this step.
+    let keyring = test_keyring().await;
     let pt = b"raw byte v1 auth tag";
-    let ct = encrypt_v1(pt).await;
+    let ct = encrypt_with_suite(
+        pt,
+        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
+        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
+        &keyring,
+    )
+    .await;
     let (_, iv_offset, tag_offset) = v1_header_auth_offsets(&ct);
 
     //= spec/client-apis/encrypt.md#authentication-tag
@@ -59,10 +68,8 @@ async fn test_v1_header_auth_has_iv_then_tag() {
     );
 
     // Round-trip cross-check: decrypt the same ct whose bytes we inspected above.
-    let keyring = test_keyring().await;
     let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    dec_input.commitment_policy =
-        aws_mpl_legacy::commitment::EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
     let result = decrypt(&dec_input).await.unwrap().plaintext;
     assert_eq!(result, pt, "V1 round-trip with auth tag verification");
 }
@@ -74,8 +81,15 @@ async fn test_v2_header_auth_has_tag_only() {
     //# After serializing the message header body,
     //# this operation MUST calculate an [authentication tag](../data-format/message-header.md#authentication-tag)
     //# over the message header body.
+    let keyring = test_keyring().await;
     let pt = b"raw byte v2 auth tag";
-    let ct = encrypt_v2(pt).await;
+    let ct = encrypt_with_suite(
+        pt,
+        EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey,
+        EsdkCommitmentPolicy::RequireEncryptRequireDecrypt,
+        &keyring,
+    )
+    .await;
     let (header_body_end, tag_offset) = v2_header_auth_offsets(&ct);
 
     let tag_bytes = &ct[tag_offset..tag_offset + TAG_LEN];
@@ -99,7 +113,6 @@ async fn test_v2_header_auth_has_tag_only() {
     );
 
     // Round-trip cross-check: decrypt the same ct whose bytes we inspected above.
-    let keyring = test_keyring().await;
     let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
     let result = decrypt(&dec_input).await.unwrap().plaintext;
     assert_eq!(result, pt, "V2 round-trip with auth tag verification");
@@ -116,8 +129,13 @@ async fn test_auth_tag_present_with_required_ec_v1() {
         ("test-public-key".to_string(), "testval".to_string()),
         ("user-key".to_string(), "user-val".to_string()),
     ]);
+    let keyring = test_keyring().await;
     let pt = b"v1 required ec with auth tag";
-    let ct = encrypt_v1_with_ec(pt, ec.clone()).await;
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(pt.as_slice(), ec.clone(), keyring.clone());
+    enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
+    enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     // Raw-byte: auth tag is present at the expected offset with the expected length.
     let (_, _, tag_offset) = v1_header_auth_offsets(&ct);
@@ -129,10 +147,8 @@ async fn test_auth_tag_present_with_required_ec_v1() {
     );
 
     // Round-trip cross-check: decrypt the same ct with the same EC validates the AAD construction.
-    let keyring = test_keyring().await;
     let mut dec_input = DecryptInput::with_legacy_keyring(&ct, ec, keyring);
-    dec_input.commitment_policy =
-        aws_mpl_legacy::commitment::EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
     let result = decrypt(&dec_input).await.unwrap().plaintext;
     assert_eq!(result, pt, "V1 round-trip with non-empty EC");
 }
@@ -148,8 +164,12 @@ async fn test_auth_tag_present_with_required_ec_v2() {
         ("test-public-key".to_string(), "testval".to_string()),
         ("user-key".to_string(), "user-val".to_string()),
     ]);
+    let keyring = test_keyring().await;
     let pt = b"v2 required ec with auth tag";
-    let ct = encrypt_no_sign_with_ec(pt, ec.clone(), Version::V2).await;
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(pt.as_slice(), ec.clone(), keyring.clone());
+    enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey);
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     // Raw-byte: auth tag is present at the expected offset with the expected length.
     let (_, tag_offset) = v2_header_auth_offsets(&ct);
@@ -161,7 +181,6 @@ async fn test_auth_tag_present_with_required_ec_v2() {
     );
 
     // Round-trip cross-check: decrypt the same ct with the same EC validates the AAD construction.
-    let keyring = test_keyring().await;
     let dec_input = DecryptInput::with_legacy_keyring(&ct, ec, keyring);
     let result = decrypt(&dec_input).await.unwrap().plaintext;
     assert_eq!(result, pt, "V2 round-trip with non-empty EC");
@@ -172,14 +191,19 @@ async fn test_auth_tag_tampered_header_fails_decrypt_v1() {
     //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
     //# If this tag verification fails, this operation MUST immediately halt and fail.
-    let mut ct = encrypt_v1(b"v1 tamper test").await;
+    let keyring = test_keyring().await;
+    let mut ct = encrypt_with_suite(
+        b"v1 tamper test",
+        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
+        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
+        &keyring,
+    )
+    .await;
     // Tamper with a byte in the header body area (after version byte).
     assert!(ct.len() > 10, "ciphertext must be long enough to tamper");
     ct[5] ^= 0xFF;
-    let keyring = test_keyring().await;
     let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    dec_input.commitment_policy =
-        aws_mpl_legacy::commitment::EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
     let err = decrypt(&dec_input)
         .await
         .expect_err("V1 tampered header must fail decryption");
@@ -195,11 +219,17 @@ async fn test_auth_tag_tampered_header_fails_decrypt_v2() {
     //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
     //# If this tag verification fails, this operation MUST immediately halt and fail.
-    let mut ct = encrypt_v2(b"v2 tamper test").await;
+    let keyring = test_keyring().await;
+    let mut ct = encrypt_with_suite(
+        b"v2 tamper test",
+        EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey,
+        EsdkCommitmentPolicy::RequireEncryptRequireDecrypt,
+        &keyring,
+    )
+    .await;
     // Tamper with a byte in the header body area (after version byte).
     assert!(ct.len() > 10, "ciphertext must be long enough to tamper");
     ct[5] ^= 0xFF;
-    let keyring = test_keyring().await;
     let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
     let err = decrypt(&dec_input)
         .await

--- a/esdk/tests/test_construct_a_frame.rs
+++ b/esdk/tests/test_construct_a_frame.rs
@@ -79,20 +79,6 @@ async fn test_construct_frame_sequence_number_starts_at_one_and_increments() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_sequence_number_in_aad_matches_wire() {
-    // AAD seq is not on the wire; multi-frame round-trip is the cross-module check.
-    let pt = vec![0xABu8; 100];
-    let result = round_trip_framed(&pt, 10).await;
-
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //= reason=decrypt rebuilds AAD from the wire seq num; round-trip pins encrypt to it
-    //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be the sequence
-    //# number of the frame being encrypted.
-    assert_eq!(result, pt);
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_regular_frame_plaintext_equals_frame_length() {
     // 25 bytes / frame_length=10 → 2 regular (10) + 1 final (5).
     let pt = vec![0xBBu8; 25];
@@ -141,20 +127,6 @@ async fn test_construct_frame_final_frame_plaintext_at_most_frame_length() {
         assert_eq!(final_len, expected_final_len, "{label}");
         assert!(final_len <= frame_length, "{label}");
     }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_content_length_in_aad_matches_plaintext() {
-    // 50 bytes / frame_length=20 mixes regular and final frames.
-    let pt = vec![0xCDu8; 50];
-    let result = round_trip_framed(&pt, 20).await;
-
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //= reason=decrypt rebuilds AAD from the wire content length; round-trip pins encrypt to it
-    //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
-    //# equal to the length of the plaintext being encrypted.
-    assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_construct_a_frame.rs
+++ b/esdk/tests/test_construct_a_frame.rs
@@ -2,17 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tests for spec/client-apis/encrypt.md#construct-a-frame
-//!
-//! These tests pin the encrypt-side construction contract: the VALUES that the
-//! Encrypt operation puts in each frame field. The on-wire shape of those
-//! fields (lengths, byte order) is covered in test_message_body_format.rs.
-//!
-//! For value-selection requirements where the value is not directly observable
-//! on the wire (the AAD's sequence number, the body AAD content tag, the
-//! message ID inside the AAD), a successful decrypt of a multi-frame ciphertext
-//! is the cross-module check: the decryptor independently reconstructs the AAD
-//! from the on-wire sequence number and the header's message ID, so an encrypt
-//! that put the wrong value in the AAD would fail authentication on decrypt.
 
 mod fixtures;
 mod test_helpers;
@@ -22,29 +11,25 @@ use test_helpers::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_aead_inputs_authenticate_via_round_trip() {
-    // The cipherkey, the AAD's body-aad-content tag, and the message ID inside
-    // the AAD are not directly observable on the wire. The decryptor
-    // independently re-derives each from the header and the per-frame on-wire
-    // sequence number, then runs AES-GCM authenticated decryption. Round-trip
-    // success on a multi-frame ciphertext therefore proves all three values
-    // were correct on encrypt — any disagreement would fail authentication.
+    // Cipherkey, message ID in AAD, and body-AAD-content tag are not on the wire;
+    // round-trip across multiple frames is the cross-module check.
     let pt: Vec<u8> = (0u8..=200).collect();
     let result = round_trip_framed(&pt, 50).await;
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
-    //= reason=decrypt independently re-derives the data key from EDKs; round-trip success proves encrypt used the same derived data key
+    //= reason=decrypt re-derives the data key from EDKs; round-trip success proves agreement
     //# - The cipherkey MUST be the derived data key
     //
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
-    //= reason=decrypt reads message ID from the header and inserts it into the AAD; round-trip success proves encrypt put the same ID in the AAD
+    //= reason=decrypt reads the header message ID and inserts it into the AAD
     //# - The [message ID](../data-format/message-body-aad.md#message-id) MUST be the same as the
     //# [message ID](../data-format/message-header.md#message-id) serialized in the header of this message.
     //
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
-    //= reason=regular vs final body-AAD content strings are baked into decrypt; round-trip success proves encrypt used the right tag for each frame type (multi-frame ciphertext exercises both)
+    //= reason=multi-frame ciphertext exercises both regular and final body-AAD content tags
     //# - The [Body AAD Content](../data-format/message-body-aad.md#body-aad-content) MUST be the structure defined in
     //# [Message Body AAD](../data-format/message-body-aad.md).
     assert_eq!(result, pt);
@@ -52,13 +37,11 @@ async fn test_construct_frame_aead_inputs_authenticate_via_round_trip() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_iv_is_padded_sequence_number() {
-    // 35 bytes / frame_length=10 → seq 1, 2, 3 (regular) + 4 (final, 5 bytes).
-    // Three regular frames lets us verify the seq→IV mapping for multiple
-    // distinct values (per the rust-conventions ordering rule: ≥3 items needed).
+    // 35 bytes / frame_length=10 → 3 regular + 1 final (≥3 distinct seq nums).
     let pt = vec![0xAAu8; 35];
     let ct = encrypt_with_frame_length(&pt, 10).await;
     let frames = parse_frames(&ct, 10);
-    assert_eq!(frames.len(), 4, "35 bytes / 10-byte frames → 3 regular + 1 final");
+    assert_eq!(frames.len(), 4);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
@@ -66,25 +49,16 @@ async fn test_construct_frame_iv_is_padded_sequence_number() {
     //# used in the message body AAD for this frame,
     //# padded to the [IV length](../data-format/message-header.md#iv-length).
     for (i, (seq, iv, _, _, _)) in frames.iter().enumerate() {
-        assert_eq!(iv.len(), IV_LEN, "frame {i}: IV must be IV_LEN bytes");
+        assert_eq!(iv.len(), IV_LEN, "frame {i}");
         let iv_seq = u32::from_be_bytes([iv[8], iv[9], iv[10], iv[11]]);
-        assert_eq!(
-            iv_seq, *seq,
-            "frame {i}: low 4 bytes of IV must equal the wire sequence number {seq}"
-        );
-        assert_eq!(
-            &iv[0..8],
-            &[0u8; 8],
-            "frame {i}: high 8 bytes of IV must be the zero pad"
-        );
+        assert_eq!(iv_seq, *seq, "frame {i}: IV low 4 bytes != seq {seq}");
+        assert_eq!(&iv[0..8], &[0u8; 8], "frame {i}: IV high 8 bytes != zero pad");
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_sequence_number_starts_at_one_and_increments() {
-    // 40 bytes / frame_length=10 → seq 1, 2, 3, 4 (3 regular + 1 final). Four
-    // frames exceeds the ≥3-items minimum for ordering tests and disambiguates
-    // monotonic-but-wrong mappings (e.g., 2*i+1).
+    // 40 bytes / frame_length=10 → 4 frames at seq 1..=4.
     let pt = vec![0xCCu8; 40];
     let ct = encrypt_with_frame_length(&pt, 10).await;
     let frames = parse_frames(&ct, 10);
@@ -93,33 +67,26 @@ async fn test_construct_frame_sequence_number_starts_at_one_and_increments() {
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# If this is the first frame sequentially, the sequence number value MUST be 1.
-    assert_eq!(frames[0].0, 1, "first frame sequence number must be 1");
+    assert_eq!(frames[0].0, 1);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# Otherwise, the sequence number value MUST be 1 greater than the value of the sequence number
     //# of the previous frame.
     for i in 1..frames.len() {
-        assert_eq!(
-            frames[i].0,
-            frames[i - 1].0 + 1,
-            "frame {i}: sequence number must be 1 greater than previous"
-        );
+        assert_eq!(frames[i].0, frames[i - 1].0 + 1, "frame {i}");
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_sequence_number_in_aad_matches_wire() {
-    // The AAD's sequence-number field is not directly visible on the wire, but
-    // the decryptor reconstructs it from the wire sequence number; round-trip
-    // success across multiple frames proves the encrypt-side AAD seq matched
-    // the wire seq for every frame.
+    // AAD seq is not on the wire; multi-frame round-trip is the cross-module check.
     let pt = vec![0xABu8; 100];
     let result = round_trip_framed(&pt, 10).await;
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
-    //= reason=decrypt re-builds the AAD using the wire seq num; round-trip success proves encrypt put the wire seq num into the AAD
+    //= reason=decrypt rebuilds AAD from the wire seq num; round-trip pins encrypt to it
     //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be the sequence
     //# number of the frame being encrypted.
     assert_eq!(result, pt);
@@ -127,7 +94,7 @@ async fn test_construct_frame_sequence_number_in_aad_matches_wire() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_regular_frame_plaintext_equals_frame_length() {
-    // 25 bytes / frame_length=10 → 2 regular (10 each) + 1 final (5).
+    // 25 bytes / frame_length=10 → 2 regular (10) + 1 final (5).
     let pt = vec![0xBBu8; 25];
     let frame_length = 10u32;
     let ct = encrypt_with_frame_length(&pt, frame_length).await;
@@ -146,18 +113,15 @@ async fn test_construct_frame_regular_frame_plaintext_equals_frame_length() {
         assert_eq!(
             u32::try_from(enc_content.len()).unwrap(),
             frame_length,
-            "regular frame {i}: encrypted content length (= plaintext length) must equal frame length"
+            "regular frame {i}"
         );
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_final_frame_plaintext_at_most_frame_length() {
-    // Three boundary cases for the final frame's remaining-plaintext rule:
-    // pt_len < frame_length → final = pt_len
-    // pt_len == frame_length → final = frame_length
-    // pt_len > frame_length, pt_len % frame_length != 0 → final = pt_len % frame_length
     let frame_length = 10u32;
+    // (label, pt_len, expected_final_len): less-than, equal, greater-with-partial.
     for (label, pt_len, expected_final_len) in [
         ("less", 7usize, 7u32),
         ("equal", 10usize, 10u32),
@@ -166,38 +130,29 @@ async fn test_construct_frame_final_frame_plaintext_at_most_frame_length() {
         let pt = vec![0xDDu8; pt_len];
         let ct = encrypt_with_frame_length(&pt, frame_length).await;
         let frames = parse_frames(&ct, frame_length);
-        let (_, _, enc_content, _, is_final) = frames.last().expect("must have a final frame");
-        assert!(*is_final, "{label}: last frame must be final");
+        let (_, _, enc_content, _, is_final) = frames.last().expect("final frame");
+        assert!(*is_final, "{label}");
 
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= type=test
         //# - For a final frame this MUST be the length of the remaining plaintext bytes
         //# which have not yet been encrypted,
         //# whose length MUST be equal to or less than the frame length.
-        assert_eq!(
-            u32::try_from(enc_content.len()).unwrap(),
-            expected_final_len,
-            "{label}: final frame content length must equal remaining plaintext"
-        );
-        assert!(
-            u32::try_from(enc_content.len()).unwrap() <= frame_length,
-            "{label}: final frame content length must be <= frame length"
-        );
+        let final_len = u32::try_from(enc_content.len()).unwrap();
+        assert_eq!(final_len, expected_final_len, "{label}");
+        assert!(final_len <= frame_length, "{label}");
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_content_length_in_aad_matches_plaintext() {
-    // Mixed-size frames cover both regular (== frame_length) and final
-    // (< frame_length) cases. Round-trip across multiple frames proves the
-    // encrypt-side AAD content length matched the actual plaintext length per
-    // frame, since otherwise auth would fail on at least one frame.
+    // 50 bytes / frame_length=20 mixes regular and final frames.
     let pt = vec![0xCDu8; 50];
     let result = round_trip_framed(&pt, 20).await;
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
-    //= reason=decrypt re-derives the AAD content length from the wire content length per frame; round-trip success proves encrypt put the actual plaintext length into the AAD
+    //= reason=decrypt rebuilds AAD from the wire content length; round-trip pins encrypt to it
     //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
     //# equal to the length of the plaintext being encrypted.
     assert_eq!(result, pt);
@@ -205,23 +160,19 @@ async fn test_construct_frame_content_length_in_aad_matches_plaintext() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_plaintext_subsequence_consumed_in_order() {
-    // Use a plaintext of all distinct bytes so any reordering, skip, or
-    // duplication of plaintext between frames would fail the equality check.
+    // All-distinct bytes: any reorder, skip, or duplication breaks equality.
     let pt: Vec<u8> = (0..=255).collect();
     let result = round_trip_framed(&pt, 50).await;
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
-    //= reason=plaintext bytes are all distinct; reordering, skipping, or duplicating any subsequence between frames would fail the round-trip equality
     //# - The plaintext MUST be the next subsequence of consumable plaintext bytes that have not yet been encrypted.
     assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_regular_frame_field_serialization() {
-    // Verify each on-wire field of a regular frame has the spec-required value.
-    // A 25-byte plaintext with frame_length=10 produces 2 regular frames at
-    // sequence numbers 1 and 2 — the first regular and a subsequent regular.
+    // 25 bytes / frame_length=10 → 2 regular frames at seq 1 and 2.
     let pt = vec![0xEEu8; 25];
     let frame_length = 10u32;
     let ct = encrypt_with_frame_length(&pt, frame_length).await;
@@ -236,13 +187,13 @@ async fn test_construct_frame_regular_frame_field_serialization() {
         //= type=test
         //# - MUST serialize the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number).
         //# The value MUST be the sequence number of this frame.
-        assert_eq!(*seq, expected_seq, "regular frame {i}: serialized sequence number");
+        assert_eq!(*seq, expected_seq, "frame {i}");
 
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= type=test
         //# - MUST serialize the [IV](../data-format/message-body.md#regular-frame-iv).
         //# The value MUST be the IV used when calculating the encrypted content for this frame.
-        assert_eq!(iv.len(), IV_LEN, "regular frame {i}: serialized IV length");
+        assert_eq!(iv.len(), IV_LEN, "frame {i}");
 
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= type=test
@@ -251,78 +202,63 @@ async fn test_construct_frame_regular_frame_field_serialization() {
         assert_eq!(
             u32::try_from(enc_content.len()).unwrap(),
             frame_length,
-            "regular frame {i}: serialized encrypted content length"
+            "frame {i}"
         );
 
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= type=test
         //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#regular-frame-authentication-tag).
         //# The value MUST be the authentication tag output when calculating the encrypted content for this frame.
-        assert_eq!(tag.len(), TAG_LEN, "regular frame {i}: serialized auth tag length");
+        assert_eq!(tag.len(), TAG_LEN, "frame {i}");
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_final_frame_field_serialization() {
-    // 13 bytes / frame_length=10 → 1 regular (seq 1) + 1 final (seq 2, content_len 3).
+    // 13 bytes / frame_length=10 → 1 regular (seq 1) + 1 final (seq 2, len 3).
     let pt = vec![0x42u8; 13];
     let frame_length = 10u32;
     let ct = encrypt_with_frame_length(&pt, frame_length).await;
     let frames = parse_frames(&ct, frame_length);
     let (seq, iv, enc_content, tag, is_final) =
-        frames.last().expect("must have a final frame").clone();
+        frames.last().expect("final frame").clone();
     assert!(is_final);
 
-    // Sequence Number End is the 4-byte 0xFFFFFFFF marker that prefixes the
-    // final frame on the wire. parse_frames consumes that marker before
-    // recording fields, so we re-locate it on the raw bytes.
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [Sequence Number End](../data-format/message-body.md#sequence-number-end).
     let endframe_count = ct.windows(4).filter(|w| *w == ENDFRAME_MARKER).count();
-    assert_eq!(
-        endframe_count, 1,
-        "exactly one Sequence Number End marker must appear"
-    );
+    assert_eq!(endframe_count, 1);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [Sequence Number](../data-format/message-body.md#final-frame-sequence-number).
     //# The value MUST be the sequence number of this frame.
-    assert_eq!(seq, 2, "final frame sequence number");
+    assert_eq!(seq, 2);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [IV](../data-format/message-body.md#final-frame-iv).
-    assert_eq!(iv.len(), IV_LEN, "final frame IV length");
+    assert_eq!(iv.len(), IV_LEN);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
-    assert_eq!(
-        u32::try_from(enc_content.len()).unwrap(),
-        3,
-        "final frame Encrypted Content Length"
-    );
+    assert_eq!(u32::try_from(enc_content.len()).unwrap(), 3);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#final-frame-encrypted-content).
-    assert_eq!(enc_content.len(), 3, "final frame encrypted content");
+    assert_eq!(enc_content.len(), 3);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#final-frame-authentication-tag).
-    assert_eq!(tag.len(), TAG_LEN, "final frame auth tag length");
+    assert_eq!(tag.len(), TAG_LEN);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_streaming_frame_released() {
-    // Streaming case: provide enough plaintext for multiple frames and verify
-    // the writer received bytes that decrypt to the original plaintext. This
-    // also exercises the "MUST NOT be released until entire frame serialized"
-    // invariant — premature release of a partial frame would leave the
-    // resulting ciphertext unparseable or its tag invalid.
     let keyring = test_keyring().await;
     let mut stream_input =
         EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
@@ -332,11 +268,11 @@ async fn test_construct_frame_streaming_frame_released() {
     let mut output = Vec::new();
     encrypt_stream(&mut reader, &mut output, &stream_input)
         .await
-        .expect("streaming encrypt must succeed");
+        .expect("streaming encrypt");
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
-    //= reason=successful round-trip of streamed bytes proves each frame was completely serialized before being released to the writer
+    //= reason=premature release of a partial frame would leave the ciphertext unparseable
     //# The serialized frame bytes MUST NOT be released until the entire frame has been serialized.
     //
     //= spec/client-apis/encrypt.md#construct-a-frame
@@ -344,7 +280,7 @@ async fn test_construct_frame_streaming_frame_released() {
     //# If the Encrypt operation is streaming the encrypted message and
     //# the entire frame has been serialized,
     //# the serialized frame MUST be released.
-    assert!(!output.is_empty(), "streaming output must contain released frame bytes");
+    assert!(!output.is_empty());
 
     let dec_keyring = test_keyring().await;
     let dec_input =

--- a/esdk/tests/test_construct_a_frame.rs
+++ b/esdk/tests/test_construct_a_frame.rs
@@ -268,7 +268,7 @@ async fn test_construct_frame_final_frame_field_serialization() {
 async fn test_construct_frame_streaming_frame_released() {
     let keyring = test_keyring().await;
     let mut stream_input =
-        EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
+        EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring.clone());
     stream_input.frame_length = FrameLength::new(10).unwrap();
     let plaintext = vec![0xAAu8; 50];
     let mut reader = std::io::Cursor::new(&plaintext);
@@ -289,9 +289,8 @@ async fn test_construct_frame_streaming_frame_released() {
     //# the serialized frame MUST be released.
     assert!(!output.is_empty());
 
-    let dec_keyring = test_keyring().await;
     let dec_input =
-        DecryptInput::with_legacy_keyring(&output, EncryptionContext::new(), dec_keyring);
+        DecryptInput::with_legacy_keyring(&output, EncryptionContext::new(), keyring);
     let decrypted = decrypt(&dec_input).await.unwrap();
     assert_eq!(decrypted.plaintext, plaintext);
 }

--- a/esdk/tests/test_construct_a_frame.rs
+++ b/esdk/tests/test_construct_a_frame.rs
@@ -1,0 +1,401 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/client-apis/encrypt.md#construct-a-frame
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use test_helpers::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_cipherkey_and_plaintext() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - The cipherkey MUST be the derived data key
+    let pt = b"hello world construct frame";
+    let result = round_trip_framed(pt, 4096).await;
+    assert_eq!(result, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_aad_and_iv() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# To construct a regular or final frame that represents the next frame in the encrypted message's body,
+    //# the Encrypt operation MUST calculate the encrypted content and an authentication tag using the
+    //# [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
+    //# specified by the [algorithm suite](../framework/algorithm-suites.md),
+    //# with the following inputs:
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
+    //# constructed according to the [Message Body AAD](../data-format/message-body-aad.md) specification, as follows:
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - The IV MUST be the [sequence number](../data-format/message-body-aad.md#sequence-number)
+    //# used in the message body AAD for this frame,
+    //# padded to the [IV length](../data-format/message-header.md#iv-length).
+    let pt = b"test aad and iv";
+    let result = round_trip_framed(pt, 4096).await;
+    assert_eq!(result, pt, "round-trip proves AAD and IV were correct");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_message_id_in_aad() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - The [message ID](../data-format/message-body-aad.md#message-id) MUST be the same as the
+    //# [message ID](../data-format/message-header.md#message-id) serialized in the header of this message.
+    let pt = b"message id in aad";
+    let result = round_trip_framed(pt, 4096).await;
+    assert_eq!(result, pt, "decryption success proves message ID in AAD matches header");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_body_aad_content() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - The [Body AAD Content](../data-format/message-body-aad.md#body-aad-content) MUST be the structure defined in
+    //# [Message Body AAD](../data-format/message-body-aad.md).
+    let pt = b"body aad content test";
+    let result = round_trip_framed(pt, 4096).await;
+    assert_eq!(result, pt, "decryption success proves body AAD content type is correct");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_sequence_number_in_aad() {
+    // Multi-frame: each frame's AAD must have the correct sequence number
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be the sequence
+    //# number of the frame being encrypted.
+    let pt = vec![0xABu8; 100];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt, "multi-frame round-trip proves per-frame sequence numbers in AAD are correct");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_content_length_in_aad() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
+    //# equal to the length of the plaintext being encrypted.
+    let pt = vec![0xCDu8; 50];
+    let result = round_trip_framed(&pt, 20).await;
+    assert_eq!(result, pt, "round-trip proves content length in AAD is correct for each frame");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_sequence_number_starts_at_one() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# If this is the first frame sequentially, the sequence number value MUST be 1.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Sequence Number](../data-format/message-body.md#final-frame-sequence-number).
+    let ct = encrypt_with_frame_length(b"seq num test", 4096).await;
+    // Find the body: after the header. The first frame's sequence number
+    // is the first 4 bytes of the body. For a single final frame, the body
+    // starts with ENDFRAME marker (0xFFFFFFFF) then the sequence number.
+    // Search for the ENDFRAME marker followed by sequence number 1.
+    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
+    let seq_one = 1u32.to_be_bytes();
+    let mut found = false;
+    for i in 0..ct.len().saturating_sub(8) {
+        if ct[i..i + 4] == endframe && ct[i + 4..i + 8] == seq_one {
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "first frame sequence number must be 1 (after ENDFRAME marker for single-frame message)");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_sequence_number_increments() {
+    // Create a multi-frame message: 30 bytes with frame_length=10 → 3 regular frames + 1 final (empty or 10-byte)
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# Otherwise, the sequence number value MUST be 1 greater than the value of the sequence number
+    //# of the previous frame.
+    let pt = vec![0xAAu8; 30];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    // Regular frames start with sequence number (4 bytes).
+    // Look for sequence numbers 1, 2, 3 in order.
+    let seq1 = 1u32.to_be_bytes();
+    let seq2 = 2u32.to_be_bytes();
+    let seq3 = 3u32.to_be_bytes();
+    let ct_str = ct.iter().map(|b| format!("{b:02x}")).collect::<String>();
+    // Verify round-trip to confirm correctness
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt, "multi-frame round-trip must succeed, proving sequence numbers increment correctly");
+    // Also verify the raw bytes contain the expected sequence numbers
+    let has_seq1 = ct.windows(4).any(|w| w == seq1);
+    let has_seq2 = ct.windows(4).any(|w| w == seq2);
+    let has_seq3 = ct.windows(4).any(|w| w == seq3);
+    assert!(has_seq1, "ciphertext must contain sequence number 1: {ct_str}");
+    assert!(has_seq2, "ciphertext must contain sequence number 2: {ct_str}");
+    assert!(has_seq3, "ciphertext must contain sequence number 3: {ct_str}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_regular_frame_plaintext_equals_frame_length() {
+    // 20 bytes with frame_length=10 → 1 regular frame (10 bytes) + 1 final frame (10 bytes)
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - For a regular frame the length of this plaintext MUST equal the frame length.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - For a regular frame the length of this plaintext subsequence MUST equal the frame length.
+    let pt = vec![0xBBu8; 20];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt, "regular frame must encrypt exactly frame_length bytes");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_final_frame_remaining_plaintext() {
+    // 15 bytes with frame_length=10 → 1 regular (10) + 1 final (5, which is < frame_length)
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - For a final frame this MUST be the length of the remaining plaintext bytes
+    //# which have not yet been encrypted,
+    //# whose length MUST be equal to or less than the frame length.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - For a final frame this MUST be the remaining plaintext bytes which have not yet been encrypted,
+    //# whose length MUST be equal to or less than the frame length.
+    let pt = vec![0xCCu8; 15];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt, "final frame must encrypt remaining bytes (less than frame length)");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_regular_frame_plaintext_subsequence() {
+    // Verify that multi-frame encryption preserves the full plaintext in order
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - The plaintext MUST be the next subsequence of consumable plaintext bytes that have not yet been encrypted.
+    let pt: Vec<u8> = (0..=255).collect();
+    let result = round_trip_framed(&pt, 50).await;
+    assert_eq!(result, pt, "each frame must encrypt the next unconsumed subsequence");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_serialization_regular_and_final() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# The Encrypt operation MUST serialize a regular frame or final frame with the following specifics:
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# Regular frame serialization MUST conform to the [Regular Frame](../data-format/message-body.md#regular-frame) specification.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# For a regular frame, each field MUST be serialized according to its specification:
+    let pt = vec![0xDDu8; 25];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt, "successful decrypt proves both regular and final frames are correctly serialized");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_sequence_number_serialized() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number).
+    //# The value MUST be the sequence number of this frame.
+    let pt = vec![0xEEu8; 30];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt, "decrypt success proves sequence numbers are correctly serialized");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_iv_serialized() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [IV](../data-format/message-body.md#regular-frame-iv).
+    //# The value MUST be the IV used when calculating the encrypted content for this frame.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [IV](../data-format/message-body.md#final-frame-iv).
+    let pt = b"iv serialization test";
+    let result = round_trip_framed(pt, 4096).await;
+    assert_eq!(result, pt.to_vec(), "decrypt success proves IV is correctly serialized");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_final_frame_has_endframe_marker() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# Final frame serialization MUST conform to the [Final Frame](../data-format/message-body.md#final-frame) specification.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# For a final frame, each field MUST be serialized according to its specification:
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Sequence Number End](../data-format/message-body.md#sequence-number-end).
+    // The final frame includes the Sequence Number End marker per the final frame specification
+    let ct = encrypt_with_frame_length(b"endframe marker", 4096).await;
+    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
+    let count = ct.windows(4).filter(|w| *w == endframe).count();
+    assert!(count >= 1, "final frame must contain ENDFRAME marker (0xFFFFFFFF)");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_final_frame_content_length_serialized() {
+    // 7 bytes with frame_length=10 → single final frame with content length 7
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - For a final frame this MUST be the length of the remaining plaintext bytes
+    //# which have not yet been encrypted,
+    //# whose length MUST be equal to or less than the frame length.
+    let pt = b"1234567";
+    let ct = encrypt_with_frame_length(pt, 10).await;
+    // The final frame has: ENDFRAME(4) + SeqNum(4) + IV(12) + ContentLength(4) + EncContent + AuthTag
+    // Content length should be 7 (0x00000007)
+    let content_len_bytes = 7u32.to_be_bytes();
+    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
+    // Find ENDFRAME marker, then skip seq_num(4) + IV(12) to find content length
+    let mut found = false;
+    for i in 0..ct.len().saturating_sub(24) {
+        if ct[i..i + 4] == endframe {
+            // seq_num at i+4, IV at i+8 (12 bytes), content_length at i+20
+            if i + 24 <= ct.len() && ct[i + 20..i + 24] == content_len_bytes {
+                found = true;
+                break;
+            }
+        }
+    }
+    assert!(found, "final frame must contain encrypted content length field");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_auth_tag_serialized() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#regular-frame-encrypted-content).
+    //# The value MUST be the encrypted content calculated for this frame.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#regular-frame-authentication-tag).
+    //# The value MUST be the authentication tag output when calculating the encrypted content for this frame.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#final-frame-encrypted-content).
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#final-frame-authentication-tag).
+    let pt = b"encrypted content and auth tag test";
+    let result = round_trip_framed(pt, 4096).await;
+    assert_eq!(result, pt.to_vec(), "decrypt success proves encrypted content and auth tag are correctly serialized");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_bytes_not_released_until_complete() {
+    // If bytes were released prematurely (partial frame), decryption would fail
+    // because the auth tag wouldn't be present. A successful round-trip proves
+    // the entire frame was serialized before release.
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# The serialized frame bytes MUST NOT be released until the entire frame has been serialized.
+    let pt = vec![0xFFu8; 100];
+    let result = round_trip_framed(&pt, 20).await;
+    assert_eq!(result, pt, "successful multi-frame decrypt proves frames are fully serialized before release");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_empty_plaintext() {
+    // Empty plaintext produces a single final frame with 0-length encrypted content.
+    // The encrypt side correctly produces this; verify it doesn't error.
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - For a final frame this MUST be the length of the remaining plaintext bytes
+    //# which have not yet been encrypted,
+    //# whose length MUST be equal to or less than the frame length.
+    // Empty plaintext (0 bytes remaining) is <= frame length, proving the final frame handles the zero-length case
+    let pt = b"";
+    let ct = encrypt_with_frame_length(pt, 4096).await;
+    // Verify the ciphertext contains an ENDFRAME marker (final frame was produced)
+    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
+    assert!(ct.windows(4).any(|w| w == endframe), "empty plaintext must produce a final frame with ENDFRAME marker");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_single_final_frame() {
+    // Plaintext smaller than frame length → single final frame only
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - For a final frame this MUST be the remaining plaintext bytes which have not yet been encrypted,
+    //# whose length MUST be equal to or less than the frame length.
+    let pt = b"short";
+    let result = round_trip_framed(pt, 4096).await;
+    assert_eq!(result, pt.to_vec(), "single final frame must correctly encrypt short plaintext");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_final_frame_content_length_less_than_frame_length() {
+    // 13 bytes with frame_length=10 → 1 regular (10) + 1 final (3)
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - For a final frame this MUST be the length of the remaining plaintext bytes
+    //# which have not yet been encrypted,
+    //# whose length MUST be equal to or less than the frame length.
+    let pt = vec![0x42u8; 13];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    // Find the final frame's content length field (should be 3)
+    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
+    let expected_len = 3u32.to_be_bytes();
+    let mut found = false;
+    for i in 0..ct.len().saturating_sub(24) {
+        if ct[i..i + 4] == endframe && i + 24 <= ct.len() && ct[i + 20..i + 24] == expected_len {
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "final frame content length must be 3 (remaining bytes after regular frame)");
+    // Also verify round-trip
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_streaming_frame_released() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# If the Encrypt operation is streaming the encrypted message and
+    //# the entire frame has been serialized,
+    //# the serialized frame MUST be released.
+    let keyring = test_keyring().await;
+    let mut stream_input = EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
+    stream_input.frame_length = FrameLength::new(10).unwrap();
+    // Provide enough plaintext for multiple frames
+    let plaintext = vec![0xAAu8; 50];
+    let mut reader = std::io::Cursor::new(&plaintext);
+    let mut output = Vec::new();
+    let result = encrypt_stream(&mut reader, &mut output, &stream_input).await;
+    assert!(result.is_ok(), "streaming encrypt must succeed");
+    // The output must contain bytes — frames were released (written) to the output writer
+    // as they were serialized. If frames were not released, output would be empty.
+    assert!(!output.is_empty(), "streaming output must contain released frame bytes");
+    // Verify the output is a valid encrypted message by decrypting it
+    let dec_keyring = test_keyring().await;
+    let dec_input = DecryptInput::with_legacy_keyring(&output, EncryptionContext::new(), dec_keyring);
+    let decrypted = decrypt(&dec_input).await.unwrap();
+    assert_eq!(decrypted.plaintext, plaintext, "decrypted plaintext must match original");
+}

--- a/esdk/tests/test_construct_a_frame.rs
+++ b/esdk/tests/test_construct_a_frame.rs
@@ -11,8 +11,11 @@ use test_helpers::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_aead_inputs_authenticate_via_round_trip() {
-    // Cipherkey, message ID in AAD, and body-AAD-content tag are not on the wire;
-    // round-trip across multiple frames is the cross-module check.
+    // Cipherkey, message ID, body-AAD-content tag, sequence number, and content
+    // length are all AAD inputs to AES-GCM (not on the wire); round-trip across
+    // multiple frames is the cross-module check that encrypt and decrypt agree.
+    // Use a multi-frame plaintext so both regular and final body-AAD content
+    // tags are exercised, and so seq num + content length vary across frames.
     let pt: Vec<u8> = (0u8..=200).collect();
     let result = round_trip_framed(&pt, 50).await;
 
@@ -32,6 +35,18 @@ async fn test_construct_frame_aead_inputs_authenticate_via_round_trip() {
     //= reason=multi-frame ciphertext exercises both regular and final body-AAD content tags
     //# - The [Body AAD Content](../data-format/message-body-aad.md#body-aad-content) MUST be the structure defined in
     //# [Message Body AAD](../data-format/message-body-aad.md).
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //= reason=decrypt rebuilds AAD from the wire seq num; round-trip pins encrypt to use that same seq num for the AAD
+    //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be the sequence
+    //# number of the frame being encrypted.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //= reason=decrypt rebuilds AAD from the wire content length; round-trip pins encrypt to use that same length for the AAD
+    //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
+    //# equal to the length of the plaintext being encrypted.
     assert_eq!(result, pt);
 }
 

--- a/esdk/tests/test_construct_a_frame.rs
+++ b/esdk/tests/test_construct_a_frame.rs
@@ -2,6 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tests for spec/client-apis/encrypt.md#construct-a-frame
+//!
+//! These tests pin the encrypt-side construction contract: the VALUES that the
+//! Encrypt operation puts in each frame field. The on-wire shape of those
+//! fields (lengths, byte order) is covered in test_message_body_format.rs.
+//!
+//! For value-selection requirements where the value is not directly observable
+//! on the wire (the AAD's sequence number, the body AAD content tag, the
+//! message ID inside the AAD), a successful decrypt of a multi-frame ciphertext
+//! is the cross-module check: the decryptor independently reconstructs the AAD
+//! from the on-wire sequence number and the header's message ID, so an encrypt
+//! that put the wrong value in the AAD would fail authentication on decrypt.
 
 mod fixtures;
 mod test_helpers;
@@ -10,141 +21,120 @@ use aws_esdk::*;
 use test_helpers::*;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_cipherkey_and_plaintext() {
+async fn test_construct_frame_aead_inputs_authenticate_via_round_trip() {
+    // The cipherkey, the AAD's body-aad-content tag, and the message ID inside
+    // the AAD are not directly observable on the wire. The decryptor
+    // independently re-derives each from the header and the per-frame on-wire
+    // sequence number, then runs AES-GCM authenticated decryption. Round-trip
+    // success on a multi-frame ciphertext therefore proves all three values
+    // were correct on encrypt — any disagreement would fail authentication.
+    let pt: Vec<u8> = (0u8..=200).collect();
+    let result = round_trip_framed(&pt, 50).await;
+
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
+    //= reason=decrypt independently re-derives the data key from EDKs; round-trip success proves encrypt used the same derived data key
     //# - The cipherkey MUST be the derived data key
-    let pt = b"hello world construct frame";
-    let result = round_trip_framed(pt, 4096).await;
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //= reason=decrypt reads message ID from the header and inserts it into the AAD; round-trip success proves encrypt put the same ID in the AAD
+    //# - The [message ID](../data-format/message-body-aad.md#message-id) MUST be the same as the
+    //# [message ID](../data-format/message-header.md#message-id) serialized in the header of this message.
+    //
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //= reason=regular vs final body-AAD content strings are baked into decrypt; round-trip success proves encrypt used the right tag for each frame type (multi-frame ciphertext exercises both)
+    //# - The [Body AAD Content](../data-format/message-body-aad.md#body-aad-content) MUST be the structure defined in
+    //# [Message Body AAD](../data-format/message-body-aad.md).
     assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_aad_and_iv() {
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# To construct a regular or final frame that represents the next frame in the encrypted message's body,
-    //# the Encrypt operation MUST calculate the encrypted content and an authentication tag using the
-    //# [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
-    //# specified by the [algorithm suite](../framework/algorithm-suites.md),
-    //# with the following inputs:
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - The AAD MUST be the serialized [message body AAD](../data-format/message-body-aad.md),
-    //# constructed according to the [Message Body AAD](../data-format/message-body-aad.md) specification, as follows:
-    //
+async fn test_construct_frame_iv_is_padded_sequence_number() {
+    // 35 bytes / frame_length=10 → seq 1, 2, 3 (regular) + 4 (final, 5 bytes).
+    // Three regular frames lets us verify the seq→IV mapping for multiple
+    // distinct values (per the rust-conventions ordering rule: ≥3 items needed).
+    let pt = vec![0xAAu8; 35];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_frames(&ct, 10);
+    assert_eq!(frames.len(), 4, "35 bytes / 10-byte frames → 3 regular + 1 final");
+
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - The IV MUST be the [sequence number](../data-format/message-body-aad.md#sequence-number)
     //# used in the message body AAD for this frame,
     //# padded to the [IV length](../data-format/message-header.md#iv-length).
-    let pt = b"test aad and iv";
-    let result = round_trip_framed(pt, 4096).await;
-    assert_eq!(result, pt, "round-trip proves AAD and IV were correct");
+    for (i, (seq, iv, _, _, _)) in frames.iter().enumerate() {
+        assert_eq!(iv.len(), IV_LEN, "frame {i}: IV must be IV_LEN bytes");
+        let iv_seq = u32::from_be_bytes([iv[8], iv[9], iv[10], iv[11]]);
+        assert_eq!(
+            iv_seq, *seq,
+            "frame {i}: low 4 bytes of IV must equal the wire sequence number {seq}"
+        );
+        assert_eq!(
+            &iv[0..8],
+            &[0u8; 8],
+            "frame {i}: high 8 bytes of IV must be the zero pad"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_message_id_in_aad() {
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - The [message ID](../data-format/message-body-aad.md#message-id) MUST be the same as the
-    //# [message ID](../data-format/message-header.md#message-id) serialized in the header of this message.
-    let pt = b"message id in aad";
-    let result = round_trip_framed(pt, 4096).await;
-    assert_eq!(result, pt, "decryption success proves message ID in AAD matches header");
-}
+async fn test_construct_frame_sequence_number_starts_at_one_and_increments() {
+    // 40 bytes / frame_length=10 → seq 1, 2, 3, 4 (3 regular + 1 final). Four
+    // frames exceeds the ≥3-items minimum for ordering tests and disambiguates
+    // monotonic-but-wrong mappings (e.g., 2*i+1).
+    let pt = vec![0xCCu8; 40];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_frames(&ct, 10);
+    assert_eq!(frames.len(), 4);
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_body_aad_content() {
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - The [Body AAD Content](../data-format/message-body-aad.md#body-aad-content) MUST be the structure defined in
-    //# [Message Body AAD](../data-format/message-body-aad.md).
-    let pt = b"body aad content test";
-    let result = round_trip_framed(pt, 4096).await;
-    assert_eq!(result, pt, "decryption success proves body AAD content type is correct");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_sequence_number_in_aad() {
-    // Multi-frame: each frame's AAD must have the correct sequence number
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be the sequence
-    //# number of the frame being encrypted.
-    let pt = vec![0xABu8; 100];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(result, pt, "multi-frame round-trip proves per-frame sequence numbers in AAD are correct");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_content_length_in_aad() {
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
-    //# equal to the length of the plaintext being encrypted.
-    let pt = vec![0xCDu8; 50];
-    let result = round_trip_framed(&pt, 20).await;
-    assert_eq!(result, pt, "round-trip proves content length in AAD is correct for each frame");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_sequence_number_starts_at_one() {
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# If this is the first frame sequentially, the sequence number value MUST be 1.
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - MUST serialize the [Sequence Number](../data-format/message-body.md#final-frame-sequence-number).
-    let ct = encrypt_with_frame_length(b"seq num test", 4096).await;
-    // Find the body: after the header. The first frame's sequence number
-    // is the first 4 bytes of the body. For a single final frame, the body
-    // starts with ENDFRAME marker (0xFFFFFFFF) then the sequence number.
-    // Search for the ENDFRAME marker followed by sequence number 1.
-    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
-    let seq_one = 1u32.to_be_bytes();
-    let mut found = false;
-    for i in 0..ct.len().saturating_sub(8) {
-        if ct[i..i + 4] == endframe && ct[i + 4..i + 8] == seq_one {
-            found = true;
-            break;
-        }
-    }
-    assert!(found, "first frame sequence number must be 1 (after ENDFRAME marker for single-frame message)");
-}
+    assert_eq!(frames[0].0, 1, "first frame sequence number must be 1");
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_sequence_number_increments() {
-    // Create a multi-frame message: 30 bytes with frame_length=10 → 3 regular frames + 1 final (empty or 10-byte)
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# Otherwise, the sequence number value MUST be 1 greater than the value of the sequence number
     //# of the previous frame.
-    let pt = vec![0xAAu8; 30];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    // Regular frames start with sequence number (4 bytes).
-    // Look for sequence numbers 1, 2, 3 in order.
-    let seq1 = 1u32.to_be_bytes();
-    let seq2 = 2u32.to_be_bytes();
-    let seq3 = 3u32.to_be_bytes();
-    let ct_str = ct.iter().map(|b| format!("{b:02x}")).collect::<String>();
-    // Verify round-trip to confirm correctness
+    for i in 1..frames.len() {
+        assert_eq!(
+            frames[i].0,
+            frames[i - 1].0 + 1,
+            "frame {i}: sequence number must be 1 greater than previous"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_sequence_number_in_aad_matches_wire() {
+    // The AAD's sequence-number field is not directly visible on the wire, but
+    // the decryptor reconstructs it from the wire sequence number; round-trip
+    // success across multiple frames proves the encrypt-side AAD seq matched
+    // the wire seq for every frame.
+    let pt = vec![0xABu8; 100];
     let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(result, pt, "multi-frame round-trip must succeed, proving sequence numbers increment correctly");
-    // Also verify the raw bytes contain the expected sequence numbers
-    let has_seq1 = ct.windows(4).any(|w| w == seq1);
-    let has_seq2 = ct.windows(4).any(|w| w == seq2);
-    let has_seq3 = ct.windows(4).any(|w| w == seq3);
-    assert!(has_seq1, "ciphertext must contain sequence number 1: {ct_str}");
-    assert!(has_seq2, "ciphertext must contain sequence number 2: {ct_str}");
-    assert!(has_seq3, "ciphertext must contain sequence number 3: {ct_str}");
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //= reason=decrypt re-builds the AAD using the wire seq num; round-trip success proves encrypt put the wire seq num into the AAD
+    //# - The [sequence number](../data-format/message-body-aad.md#sequence-number) MUST be the sequence
+    //# number of the frame being encrypted.
+    assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_regular_frame_plaintext_equals_frame_length() {
-    // 20 bytes with frame_length=10 → 1 regular frame (10 bytes) + 1 final frame (10 bytes)
+    // 25 bytes / frame_length=10 → 2 regular (10 each) + 1 final (5).
+    let pt = vec![0xBBu8; 25];
+    let frame_length = 10u32;
+    let ct = encrypt_with_frame_length(&pt, frame_length).await;
+    let frames = parse_frames(&ct, frame_length);
+    let regular: Vec<_> = frames.iter().filter(|f| !f.4).collect();
+    assert_eq!(regular.len(), 2);
+
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - For a regular frame the length of this plaintext MUST equal the frame length.
@@ -152,250 +142,213 @@ async fn test_construct_frame_regular_frame_plaintext_equals_frame_length() {
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - For a regular frame the length of this plaintext subsequence MUST equal the frame length.
-    let pt = vec![0xBBu8; 20];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(result, pt, "regular frame must encrypt exactly frame_length bytes");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_final_frame_remaining_plaintext() {
-    // 15 bytes with frame_length=10 → 1 regular (10) + 1 final (5, which is < frame_length)
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - For a final frame this MUST be the length of the remaining plaintext bytes
-    //# which have not yet been encrypted,
-    //# whose length MUST be equal to or less than the frame length.
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - For a final frame this MUST be the remaining plaintext bytes which have not yet been encrypted,
-    //# whose length MUST be equal to or less than the frame length.
-    let pt = vec![0xCCu8; 15];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(result, pt, "final frame must encrypt remaining bytes (less than frame length)");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_regular_frame_plaintext_subsequence() {
-    // Verify that multi-frame encryption preserves the full plaintext in order
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - The plaintext MUST be the next subsequence of consumable plaintext bytes that have not yet been encrypted.
-    let pt: Vec<u8> = (0..=255).collect();
-    let result = round_trip_framed(&pt, 50).await;
-    assert_eq!(result, pt, "each frame must encrypt the next unconsumed subsequence");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_serialization_regular_and_final() {
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# The Encrypt operation MUST serialize a regular frame or final frame with the following specifics:
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# Regular frame serialization MUST conform to the [Regular Frame](../data-format/message-body.md#regular-frame) specification.
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# For a regular frame, each field MUST be serialized according to its specification:
-    let pt = vec![0xDDu8; 25];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(result, pt, "successful decrypt proves both regular and final frames are correctly serialized");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_sequence_number_serialized() {
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - MUST serialize the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number).
-    //# The value MUST be the sequence number of this frame.
-    let pt = vec![0xEEu8; 30];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(result, pt, "decrypt success proves sequence numbers are correctly serialized");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_iv_serialized() {
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - MUST serialize the [IV](../data-format/message-body.md#regular-frame-iv).
-    //# The value MUST be the IV used when calculating the encrypted content for this frame.
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - MUST serialize the [IV](../data-format/message-body.md#final-frame-iv).
-    let pt = b"iv serialization test";
-    let result = round_trip_framed(pt, 4096).await;
-    assert_eq!(result, pt.to_vec(), "decrypt success proves IV is correctly serialized");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_final_frame_has_endframe_marker() {
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# Final frame serialization MUST conform to the [Final Frame](../data-format/message-body.md#final-frame) specification.
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# For a final frame, each field MUST be serialized according to its specification:
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - MUST serialize the [Sequence Number End](../data-format/message-body.md#sequence-number-end).
-    // The final frame includes the Sequence Number End marker per the final frame specification
-    let ct = encrypt_with_frame_length(b"endframe marker", 4096).await;
-    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
-    let count = ct.windows(4).filter(|w| *w == endframe).count();
-    assert!(count >= 1, "final frame must contain ENDFRAME marker (0xFFFFFFFF)");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_final_frame_content_length_serialized() {
-    // 7 bytes with frame_length=10 → single final frame with content length 7
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - MUST serialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - For a final frame this MUST be the length of the remaining plaintext bytes
-    //# which have not yet been encrypted,
-    //# whose length MUST be equal to or less than the frame length.
-    let pt = b"1234567";
-    let ct = encrypt_with_frame_length(pt, 10).await;
-    // The final frame has: ENDFRAME(4) + SeqNum(4) + IV(12) + ContentLength(4) + EncContent + AuthTag
-    // Content length should be 7 (0x00000007)
-    let content_len_bytes = 7u32.to_be_bytes();
-    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
-    // Find ENDFRAME marker, then skip seq_num(4) + IV(12) to find content length
-    let mut found = false;
-    for i in 0..ct.len().saturating_sub(24) {
-        if ct[i..i + 4] == endframe {
-            // seq_num at i+4, IV at i+8 (12 bytes), content_length at i+20
-            if i + 24 <= ct.len() && ct[i + 20..i + 24] == content_len_bytes {
-                found = true;
-                break;
-            }
-        }
+    for (i, (_, _, enc_content, _, _)) in regular.iter().enumerate() {
+        assert_eq!(
+            u32::try_from(enc_content.len()).unwrap(),
+            frame_length,
+            "regular frame {i}: encrypted content length (= plaintext length) must equal frame length"
+        );
     }
-    assert!(found, "final frame must contain encrypted content length field");
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_auth_tag_serialized() {
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#regular-frame-encrypted-content).
-    //# The value MUST be the encrypted content calculated for this frame.
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#regular-frame-authentication-tag).
-    //# The value MUST be the authentication tag output when calculating the encrypted content for this frame.
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#final-frame-encrypted-content).
-    //
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#final-frame-authentication-tag).
-    let pt = b"encrypted content and auth tag test";
-    let result = round_trip_framed(pt, 4096).await;
-    assert_eq!(result, pt.to_vec(), "decrypt success proves encrypted content and auth tag are correctly serialized");
+async fn test_construct_frame_final_frame_plaintext_at_most_frame_length() {
+    // Three boundary cases for the final frame's remaining-plaintext rule:
+    // pt_len < frame_length → final = pt_len
+    // pt_len == frame_length → final = frame_length
+    // pt_len > frame_length, pt_len % frame_length != 0 → final = pt_len % frame_length
+    let frame_length = 10u32;
+    for (label, pt_len, expected_final_len) in [
+        ("less", 7usize, 7u32),
+        ("equal", 10usize, 10u32),
+        ("greater_partial", 13usize, 3u32),
+    ] {
+        let pt = vec![0xDDu8; pt_len];
+        let ct = encrypt_with_frame_length(&pt, frame_length).await;
+        let frames = parse_frames(&ct, frame_length);
+        let (_, _, enc_content, _, is_final) = frames.last().expect("must have a final frame");
+        assert!(*is_final, "{label}: last frame must be final");
+
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //= type=test
+        //# - For a final frame this MUST be the length of the remaining plaintext bytes
+        //# which have not yet been encrypted,
+        //# whose length MUST be equal to or less than the frame length.
+        assert_eq!(
+            u32::try_from(enc_content.len()).unwrap(),
+            expected_final_len,
+            "{label}: final frame content length must equal remaining plaintext"
+        );
+        assert!(
+            u32::try_from(enc_content.len()).unwrap() <= frame_length,
+            "{label}: final frame content length must be <= frame length"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_bytes_not_released_until_complete() {
-    // If bytes were released prematurely (partial frame), decryption would fail
-    // because the auth tag wouldn't be present. A successful round-trip proves
-    // the entire frame was serialized before release.
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# The serialized frame bytes MUST NOT be released until the entire frame has been serialized.
-    let pt = vec![0xFFu8; 100];
+async fn test_construct_frame_content_length_in_aad_matches_plaintext() {
+    // Mixed-size frames cover both regular (== frame_length) and final
+    // (< frame_length) cases. Round-trip across multiple frames proves the
+    // encrypt-side AAD content length matched the actual plaintext length per
+    // frame, since otherwise auth would fail on at least one frame.
+    let pt = vec![0xCDu8; 50];
     let result = round_trip_framed(&pt, 20).await;
-    assert_eq!(result, pt, "successful multi-frame decrypt proves frames are fully serialized before release");
-}
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_empty_plaintext() {
-    // Empty plaintext produces a single final frame with 0-length encrypted content.
-    // The encrypt side correctly produces this; verify it doesn't error.
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
-    //# - For a final frame this MUST be the length of the remaining plaintext bytes
-    //# which have not yet been encrypted,
-    //# whose length MUST be equal to or less than the frame length.
-    // Empty plaintext (0 bytes remaining) is <= frame length, proving the final frame handles the zero-length case
-    let pt = b"";
-    let ct = encrypt_with_frame_length(pt, 4096).await;
-    // Verify the ciphertext contains an ENDFRAME marker (final frame was produced)
-    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
-    assert!(ct.windows(4).any(|w| w == endframe), "empty plaintext must produce a final frame with ENDFRAME marker");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_single_final_frame() {
-    // Plaintext smaller than frame length → single final frame only
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - For a final frame this MUST be the remaining plaintext bytes which have not yet been encrypted,
-    //# whose length MUST be equal to or less than the frame length.
-    let pt = b"short";
-    let result = round_trip_framed(pt, 4096).await;
-    assert_eq!(result, pt.to_vec(), "single final frame must correctly encrypt short plaintext");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_construct_frame_final_frame_content_length_less_than_frame_length() {
-    // 13 bytes with frame_length=10 → 1 regular (10) + 1 final (3)
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# - For a final frame this MUST be the length of the remaining plaintext bytes
-    //# which have not yet been encrypted,
-    //# whose length MUST be equal to or less than the frame length.
-    let pt = vec![0x42u8; 13];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    // Find the final frame's content length field (should be 3)
-    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
-    let expected_len = 3u32.to_be_bytes();
-    let mut found = false;
-    for i in 0..ct.len().saturating_sub(24) {
-        if ct[i..i + 4] == endframe && i + 24 <= ct.len() && ct[i + 20..i + 24] == expected_len {
-            found = true;
-            break;
-        }
-    }
-    assert!(found, "final frame content length must be 3 (remaining bytes after regular frame)");
-    // Also verify round-trip
-    let result = round_trip_framed(&pt, 10).await;
+    //= reason=decrypt re-derives the AAD content length from the wire content length per frame; round-trip success proves encrypt put the actual plaintext length into the AAD
+    //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
+    //# equal to the length of the plaintext being encrypted.
     assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_plaintext_subsequence_consumed_in_order() {
+    // Use a plaintext of all distinct bytes so any reordering, skip, or
+    // duplication of plaintext between frames would fail the equality check.
+    let pt: Vec<u8> = (0..=255).collect();
+    let result = round_trip_framed(&pt, 50).await;
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //= reason=plaintext bytes are all distinct; reordering, skipping, or duplicating any subsequence between frames would fail the round-trip equality
+    //# - The plaintext MUST be the next subsequence of consumable plaintext bytes that have not yet been encrypted.
+    assert_eq!(result, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_regular_frame_field_serialization() {
+    // Verify each on-wire field of a regular frame has the spec-required value.
+    // A 25-byte plaintext with frame_length=10 produces 2 regular frames at
+    // sequence numbers 1 and 2 — the first regular and a subsequent regular.
+    let pt = vec![0xEEu8; 25];
+    let frame_length = 10u32;
+    let ct = encrypt_with_frame_length(&pt, frame_length).await;
+    let frames = parse_frames(&ct, frame_length);
+    let regular: Vec<_> = frames.iter().filter(|f| !f.4).collect();
+    assert_eq!(regular.len(), 2);
+
+    for (i, (seq, iv, enc_content, tag, _)) in regular.iter().enumerate() {
+        let expected_seq = u32::try_from(i).unwrap() + 1;
+
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //= type=test
+        //# - MUST serialize the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number).
+        //# The value MUST be the sequence number of this frame.
+        assert_eq!(*seq, expected_seq, "regular frame {i}: serialized sequence number");
+
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //= type=test
+        //# - MUST serialize the [IV](../data-format/message-body.md#regular-frame-iv).
+        //# The value MUST be the IV used when calculating the encrypted content for this frame.
+        assert_eq!(iv.len(), IV_LEN, "regular frame {i}: serialized IV length");
+
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //= type=test
+        //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#regular-frame-encrypted-content).
+        //# The value MUST be the encrypted content calculated for this frame.
+        assert_eq!(
+            u32::try_from(enc_content.len()).unwrap(),
+            frame_length,
+            "regular frame {i}: serialized encrypted content length"
+        );
+
+        //= spec/client-apis/encrypt.md#construct-a-frame
+        //= type=test
+        //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#regular-frame-authentication-tag).
+        //# The value MUST be the authentication tag output when calculating the encrypted content for this frame.
+        assert_eq!(tag.len(), TAG_LEN, "regular frame {i}: serialized auth tag length");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_frame_final_frame_field_serialization() {
+    // 13 bytes / frame_length=10 → 1 regular (seq 1) + 1 final (seq 2, content_len 3).
+    let pt = vec![0x42u8; 13];
+    let frame_length = 10u32;
+    let ct = encrypt_with_frame_length(&pt, frame_length).await;
+    let frames = parse_frames(&ct, frame_length);
+    let (seq, iv, enc_content, tag, is_final) =
+        frames.last().expect("must have a final frame").clone();
+    assert!(is_final);
+
+    // Sequence Number End is the 4-byte 0xFFFFFFFF marker that prefixes the
+    // final frame on the wire. parse_frames consumes that marker before
+    // recording fields, so we re-locate it on the raw bytes.
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Sequence Number End](../data-format/message-body.md#sequence-number-end).
+    let endframe_count = ct.windows(4).filter(|w| *w == ENDFRAME_MARKER).count();
+    assert_eq!(
+        endframe_count, 1,
+        "exactly one Sequence Number End marker must appear"
+    );
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Sequence Number](../data-format/message-body.md#final-frame-sequence-number).
+    //# The value MUST be the sequence number of this frame.
+    assert_eq!(seq, 2, "final frame sequence number");
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [IV](../data-format/message-body.md#final-frame-iv).
+    assert_eq!(iv.len(), IV_LEN, "final frame IV length");
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
+    assert_eq!(
+        u32::try_from(enc_content.len()).unwrap(),
+        3,
+        "final frame Encrypted Content Length"
+    );
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#final-frame-encrypted-content).
+    assert_eq!(enc_content.len(), 3, "final frame encrypted content");
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#final-frame-authentication-tag).
+    assert_eq!(tag.len(), TAG_LEN, "final frame auth tag length");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_streaming_frame_released() {
+    // Streaming case: provide enough plaintext for multiple frames and verify
+    // the writer received bytes that decrypt to the original plaintext. This
+    // also exercises the "MUST NOT be released until entire frame serialized"
+    // invariant — premature release of a partial frame would leave the
+    // resulting ciphertext unparseable or its tag invalid.
+    let keyring = test_keyring().await;
+    let mut stream_input =
+        EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
+    stream_input.frame_length = FrameLength::new(10).unwrap();
+    let plaintext = vec![0xAAu8; 50];
+    let mut reader = std::io::Cursor::new(&plaintext);
+    let mut output = Vec::new();
+    encrypt_stream(&mut reader, &mut output, &stream_input)
+        .await
+        .expect("streaming encrypt must succeed");
+
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //= reason=successful round-trip of streamed bytes proves each frame was completely serialized before being released to the writer
+    //# The serialized frame bytes MUST NOT be released until the entire frame has been serialized.
+    //
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# If the Encrypt operation is streaming the encrypted message and
     //# the entire frame has been serialized,
     //# the serialized frame MUST be released.
-    let keyring = test_keyring().await;
-    let mut stream_input = EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
-    stream_input.frame_length = FrameLength::new(10).unwrap();
-    // Provide enough plaintext for multiple frames
-    let plaintext = vec![0xAAu8; 50];
-    let mut reader = std::io::Cursor::new(&plaintext);
-    let mut output = Vec::new();
-    let result = encrypt_stream(&mut reader, &mut output, &stream_input).await;
-    assert!(result.is_ok(), "streaming encrypt must succeed");
-    // The output must contain bytes — frames were released (written) to the output writer
-    // as they were serialized. If frames were not released, output would be empty.
     assert!(!output.is_empty(), "streaming output must contain released frame bytes");
-    // Verify the output is a valid encrypted message by decrypting it
+
     let dec_keyring = test_keyring().await;
-    let dec_input = DecryptInput::with_legacy_keyring(&output, EncryptionContext::new(), dec_keyring);
+    let dec_input =
+        DecryptInput::with_legacy_keyring(&output, EncryptionContext::new(), dec_keyring);
     let decrypted = decrypt(&dec_input).await.unwrap();
-    assert_eq!(decrypted.plaintext, plaintext, "decrypted plaintext must match original");
+    assert_eq!(decrypted.plaintext, plaintext);
 }

--- a/esdk/tests/test_construct_a_frame.rs
+++ b/esdk/tests/test_construct_a_frame.rs
@@ -40,7 +40,7 @@ async fn test_construct_frame_iv_is_padded_sequence_number() {
     // 35 bytes / frame_length=10 → 3 regular + 1 final (≥3 distinct seq nums).
     let pt = vec![0xAAu8; 35];
     let ct = encrypt_with_frame_length(&pt, 10).await;
-    let frames = parse_frames(&ct, 10);
+    let frames = parse_all_frames(&ct, 10);
     assert_eq!(frames.len(), 4);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
@@ -48,11 +48,11 @@ async fn test_construct_frame_iv_is_padded_sequence_number() {
     //# - The IV MUST be the [sequence number](../data-format/message-body-aad.md#sequence-number)
     //# used in the message body AAD for this frame,
     //# padded to the [IV length](../data-format/message-header.md#iv-length).
-    for (i, (seq, iv, _, _, _)) in frames.iter().enumerate() {
-        assert_eq!(iv.len(), IV_LEN, "frame {i}");
-        let iv_seq = u32::from_be_bytes([iv[8], iv[9], iv[10], iv[11]]);
-        assert_eq!(iv_seq, *seq, "frame {i}: IV low 4 bytes != seq {seq}");
-        assert_eq!(&iv[0..8], &[0u8; 8], "frame {i}: IV high 8 bytes != zero pad");
+    for (i, f) in frames.iter().enumerate() {
+        assert_eq!(f.iv.len(), IV_LEN, "frame {i}");
+        let iv_seq = u32::from_be_bytes([f.iv[8], f.iv[9], f.iv[10], f.iv[11]]);
+        assert_eq!(iv_seq, f.seq_num, "frame {i}: IV low 4 bytes != seq {}", f.seq_num);
+        assert_eq!(&f.iv[0..8], &[0u8; 8], "frame {i}: IV high 8 bytes != zero pad");
     }
 }
 
@@ -61,20 +61,20 @@ async fn test_construct_frame_sequence_number_starts_at_one_and_increments() {
     // 40 bytes / frame_length=10 → 4 frames at seq 1..=4.
     let pt = vec![0xCCu8; 40];
     let ct = encrypt_with_frame_length(&pt, 10).await;
-    let frames = parse_frames(&ct, 10);
+    let frames = parse_all_frames(&ct, 10);
     assert_eq!(frames.len(), 4);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# If this is the first frame sequentially, the sequence number value MUST be 1.
-    assert_eq!(frames[0].0, 1);
+    assert_eq!(frames[0].seq_num, 1);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# Otherwise, the sequence number value MUST be 1 greater than the value of the sequence number
     //# of the previous frame.
     for i in 1..frames.len() {
-        assert_eq!(frames[i].0, frames[i - 1].0 + 1, "frame {i}");
+        assert_eq!(frames[i].seq_num, frames[i - 1].seq_num + 1, "frame {i}");
     }
 }
 
@@ -98,8 +98,8 @@ async fn test_construct_frame_regular_frame_plaintext_equals_frame_length() {
     let pt = vec![0xBBu8; 25];
     let frame_length = 10u32;
     let ct = encrypt_with_frame_length(&pt, frame_length).await;
-    let frames = parse_frames(&ct, frame_length);
-    let regular: Vec<_> = frames.iter().filter(|f| !f.4).collect();
+    let frames = parse_all_frames(&ct, frame_length);
+    let regular: Vec<_> = frames.iter().filter(|f| !f.is_final).collect();
     assert_eq!(regular.len(), 2);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
@@ -109,12 +109,11 @@ async fn test_construct_frame_regular_frame_plaintext_equals_frame_length() {
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - For a regular frame the length of this plaintext subsequence MUST equal the frame length.
-    for (i, (_, _, enc_content, _, _)) in regular.iter().enumerate() {
-        assert_eq!(
-            u32::try_from(enc_content.len()).unwrap(),
-            frame_length,
-            "regular frame {i}"
-        );
+    for (i, f) in regular.iter().enumerate() {
+        let Ok(content_len) = u32::try_from(f.content.len()) else {
+            panic!("content length exceeds u32::MAX");
+        };
+        assert_eq!(content_len, frame_length, "regular frame {i}");
     }
 }
 
@@ -129,16 +128,16 @@ async fn test_construct_frame_final_frame_plaintext_at_most_frame_length() {
     ] {
         let pt = vec![0xDDu8; pt_len];
         let ct = encrypt_with_frame_length(&pt, frame_length).await;
-        let frames = parse_frames(&ct, frame_length);
-        let (_, _, enc_content, _, is_final) = frames.last().expect("final frame");
-        assert!(*is_final, "{label}");
+        let final_frame = parse_final_frame(&ct, frame_length);
 
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= type=test
         //# - For a final frame this MUST be the length of the remaining plaintext bytes
         //# which have not yet been encrypted,
         //# whose length MUST be equal to or less than the frame length.
-        let final_len = u32::try_from(enc_content.len()).unwrap();
+        let Ok(final_len) = u32::try_from(final_frame.content.len()) else {
+            panic!("content length exceeds u32::MAX");
+        };
         assert_eq!(final_len, expected_final_len, "{label}");
         assert!(final_len <= frame_length, "{label}");
     }
@@ -176,85 +175,94 @@ async fn test_construct_frame_regular_frame_field_serialization() {
     let pt = vec![0xEEu8; 25];
     let frame_length = 10u32;
     let ct = encrypt_with_frame_length(&pt, frame_length).await;
-    let frames = parse_frames(&ct, frame_length);
-    let regular: Vec<_> = frames.iter().filter(|f| !f.4).collect();
+    let frames = parse_all_frames(&ct, frame_length);
+    let regular: Vec<_> = frames.iter().filter(|f| !f.is_final).collect();
     assert_eq!(regular.len(), 2);
 
-    for (i, (seq, iv, enc_content, tag, _)) in regular.iter().enumerate() {
-        let expected_seq = u32::try_from(i).unwrap() + 1;
+    for (i, f) in regular.iter().enumerate() {
+        let Ok(idx_u32) = u32::try_from(i) else {
+            panic!("index exceeds u32::MAX");
+        };
+        let expected_seq = idx_u32 + 1;
 
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= type=test
         //# - MUST serialize the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number).
         //# The value MUST be the sequence number of this frame.
-        assert_eq!(*seq, expected_seq, "frame {i}");
+        assert_eq!(f.seq_num, expected_seq, "frame {i}");
 
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= type=test
         //# - MUST serialize the [IV](../data-format/message-body.md#regular-frame-iv).
         //# The value MUST be the IV used when calculating the encrypted content for this frame.
-        assert_eq!(iv.len(), IV_LEN, "frame {i}");
+        assert_eq!(f.iv.len(), IV_LEN, "frame {i}");
 
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= type=test
         //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#regular-frame-encrypted-content).
         //# The value MUST be the encrypted content calculated for this frame.
-        assert_eq!(
-            u32::try_from(enc_content.len()).unwrap(),
-            frame_length,
-            "frame {i}"
-        );
+        let Ok(content_len) = u32::try_from(f.content.len()) else {
+            panic!("content length exceeds u32::MAX");
+        };
+        assert_eq!(content_len, frame_length, "frame {i}");
 
         //= spec/client-apis/encrypt.md#construct-a-frame
         //= type=test
         //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#regular-frame-authentication-tag).
         //# The value MUST be the authentication tag output when calculating the encrypted content for this frame.
-        assert_eq!(tag.len(), TAG_LEN, "frame {i}");
+        assert_eq!(f.tag.len(), TAG_LEN, "frame {i}");
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_final_frame_field_serialization() {
     // 13 bytes / frame_length=10 → 1 regular (seq 1) + 1 final (seq 2, len 3).
-    let pt = vec![0x42u8; 13];
-    let frame_length = 10u32;
-    let ct = encrypt_with_frame_length(&pt, frame_length).await;
-    let frames = parse_frames(&ct, frame_length);
-    let (seq, iv, enc_content, tag, is_final) =
-        frames.last().expect("final frame").clone();
-    assert!(is_final);
+    const PT_LEN: usize = 13;
+    const FRAME_LEN: u32 = 10;
+    const FINAL_CONTENT_LEN: u32 = (PT_LEN as u32) - FRAME_LEN; // 3
+
+    let pt = vec![0x42u8; PT_LEN];
+    let ct = encrypt_with_frame_length(&pt, FRAME_LEN).await;
+    let final_frame = parse_final_frame(&ct, FRAME_LEN);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [Sequence Number End](../data-format/message-body.md#sequence-number-end).
-    let endframe_count = ct.windows(4).filter(|w| *w == ENDFRAME_MARKER).count();
-    assert_eq!(endframe_count, 1);
+    assert_eq!(
+        final_frame.endframe_marker_bytes.expect("final frame has marker"),
+        &ENDFRAME_MARKER
+    );
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [Sequence Number](../data-format/message-body.md#final-frame-sequence-number).
     //# The value MUST be the sequence number of this frame.
-    assert_eq!(seq, 2);
+    assert_eq!(final_frame.seq_num, 2);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [IV](../data-format/message-body.md#final-frame-iv).
-    assert_eq!(iv.len(), IV_LEN);
+    assert_eq!(final_frame.iv.len(), IV_LEN);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
-    assert_eq!(u32::try_from(enc_content.len()).unwrap(), 3);
+    // The on-wire content-length field decodes to FINAL_CONTENT_LEN.
+    assert_eq!(final_frame.content_length, FINAL_CONTENT_LEN);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [Encrypted Content](../data-format/message-body.md#final-frame-encrypted-content).
-    assert_eq!(enc_content.len(), 3);
+    // The on-wire content slice is FINAL_CONTENT_LEN bytes long.
+    let Ok(content_len) = u32::try_from(final_frame.content.len()) else {
+        panic!("content length exceeds u32::MAX");
+    };
+    assert_eq!(content_len, FINAL_CONTENT_LEN);
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - MUST serialize the [Authentication Tag](../data-format/message-body.md#final-frame-authentication-tag).
-    assert_eq!(tag.len(), TAG_LEN);
+    assert_eq!(final_frame.tag.len(), TAG_LEN);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_construct_a_frame.rs
+++ b/esdk/tests/test_construct_a_frame.rs
@@ -16,8 +16,12 @@ async fn test_construct_frame_aead_inputs_authenticate_via_round_trip() {
     // multiple frames is the cross-module check that encrypt and decrypt agree.
     // Use a multi-frame plaintext so both regular and final body-AAD content
     // tags are exercised, and so seq num + content length vary across frames.
+    let keyring = test_keyring().await;
     let pt: Vec<u8> = (0u8..=200).collect();
-    let result = round_trip_framed(&pt, 50).await;
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(&pt, EncryptionContext::new(), keyring.clone());
+    enc_input.frame_length = FrameLength::new(50).unwrap();
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
@@ -47,6 +51,8 @@ async fn test_construct_frame_aead_inputs_authenticate_via_round_trip() {
     //= reason=decrypt rebuilds AAD from the wire content length; round-trip pins encrypt to use that same length for the AAD
     //# - The [content length](../data-format/message-body-aad.md#content-length) MUST have a value
     //# equal to the length of the plaintext being encrypted.
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let result = decrypt(&dec_input).await.unwrap().plaintext;
     assert_eq!(result, pt);
 }
 
@@ -147,12 +153,18 @@ async fn test_construct_frame_final_frame_plaintext_at_most_frame_length() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_frame_plaintext_subsequence_consumed_in_order() {
     // All-distinct bytes: any reorder, skip, or duplication breaks equality.
+    let keyring = test_keyring().await;
     let pt: Vec<u8> = (0..=255).collect();
-    let result = round_trip_framed(&pt, 50).await;
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(&pt, EncryptionContext::new(), keyring.clone());
+    enc_input.frame_length = FrameLength::new(50).unwrap();
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     //= spec/client-apis/encrypt.md#construct-a-frame
     //= type=test
     //# - The plaintext MUST be the next subsequence of consumable plaintext bytes that have not yet been encrypted.
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let result = decrypt(&dec_input).await.unwrap().plaintext;
     assert_eq!(result, pt);
 }
 

--- a/esdk/tests/test_construct_the_body.rs
+++ b/esdk/tests/test_construct_the_body.rs
@@ -125,6 +125,12 @@ async fn test_empty_plaintext_constructs_empty_final_frame() {
     assert_eq!(regular, 0);
     assert_eq!(final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 0);
+
+    // Round-trip cross-check: empty plaintext must decrypt back to empty.
+    // Regression: the decrypt path's preallocated `result` buffer would otherwise
+    // be returned unchanged, leaking frame_length zero bytes.
+    let result = round_trip_framed(b"", 4096).await;
+    assert_eq!(result, b"", "empty plaintext must round-trip to empty");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -167,20 +173,6 @@ async fn test_construct_body_plaintext_length_bound_runtime_enforcement() {
     //# this operation MUST immediately fail.
     let err = result.expect_err("must fail mid-stream");
     assert!(matches!(err.kind, ErrorKind::ValidationError), "got {:?}", err.kind);
-}
-
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_empty_plaintext_round_trip_returns_empty() {
-    //= spec/client-apis/encrypt.md#construct-the-body
-    //= type=test
-    //= reason=encrypt of empty plaintext produces a single empty final frame; decrypt of that ciphertext must round-trip to an empty plaintext (regression test for the case where the decrypt path's preallocated `result` buffer would otherwise be returned unchanged, leaking frame_length zero bytes)
-    //# If an end to the input has been indicated, there are no more consumable plaintext bytes to process,
-    //# and a final frame has not yet been constructed,
-    //# this operation MUST [construct an empty final frame](#construct-a-frame).
-    let pt: &[u8] = b"";
-    let result = round_trip_framed(pt, 4096).await;
-    assert_eq!(result, pt, "empty plaintext must round-trip to empty");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_construct_the_body.rs
+++ b/esdk/tests/test_construct_the_body.rs
@@ -175,19 +175,3 @@ async fn test_construct_body_plaintext_length_bound_runtime_enforcement() {
     assert!(matches!(err.kind, ErrorKind::ValidationError), "got {:?}", err.kind);
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_exact_multiple_round_trip_preserves_last_frame() {
-    //= spec/client-apis/encrypt.md#construct-the-body
-    //= type=test
-    //= reason=when plaintext length is an exact multiple of frame length, encrypt may emit an empty final frame after the last regular frame; the decrypt path returns the last regular frame's plaintext for the empty-final-frame case, so a round trip of an exact-multiple plaintext must preserve every byte
-    //# - If there are exactly enough consumable plaintext bytes to create one regular frame,
-    //# such that creating a regular frame processes all consumable bytes,
-    //# then this operation MUST [construct either a final frame or regular frame](#construct-a-frame)
-    //# with the remaining plaintext.
-    // 20 bytes / frame_length=10 → either (1 regular + 1 final-of-10) or
-    // (2 regular + 1 final-of-0). Either way, all 20 bytes must round-trip.
-    let pt: Vec<u8> = (0u8..20).collect();
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(result, pt, "exact-multiple plaintext must round-trip");
-}
-

--- a/esdk/tests/test_construct_the_body.rs
+++ b/esdk/tests/test_construct_the_body.rs
@@ -168,3 +168,34 @@ async fn test_construct_body_plaintext_length_bound_runtime_enforcement() {
     let err = result.expect_err("must fail mid-stream");
     assert!(matches!(err.kind, ErrorKind::ValidationError), "got {:?}", err.kind);
 }
+
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_empty_plaintext_round_trip_returns_empty() {
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //= reason=encrypt of empty plaintext produces a single empty final frame; decrypt of that ciphertext must round-trip to an empty plaintext (regression test for the case where the decrypt path's preallocated `result` buffer would otherwise be returned unchanged, leaking frame_length zero bytes)
+    //# If an end to the input has been indicated, there are no more consumable plaintext bytes to process,
+    //# and a final frame has not yet been constructed,
+    //# this operation MUST [construct an empty final frame](#construct-a-frame).
+    let pt: &[u8] = b"";
+    let result = round_trip_framed(pt, 4096).await;
+    assert_eq!(result, pt, "empty plaintext must round-trip to empty");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_exact_multiple_round_trip_preserves_last_frame() {
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //= reason=when plaintext length is an exact multiple of frame length, encrypt may emit an empty final frame after the last regular frame; the decrypt path returns the last regular frame's plaintext for the empty-final-frame case, so a round trip of an exact-multiple plaintext must preserve every byte
+    //# - If there are exactly enough consumable plaintext bytes to create one regular frame,
+    //# such that creating a regular frame processes all consumable bytes,
+    //# then this operation MUST [construct either a final frame or regular frame](#construct-a-frame)
+    //# with the remaining plaintext.
+    // 20 bytes / frame_length=10 → either (1 regular + 1 final-of-10) or
+    // (2 regular + 1 final-of-0). Either way, all 20 bytes must round-trip.
+    let pt: Vec<u8> = (0u8..20).collect();
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt, "exact-multiple plaintext must round-trip");
+}
+

--- a/esdk/tests/test_construct_the_body.rs
+++ b/esdk/tests/test_construct_the_body.rs
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tests for spec/client-apis/encrypt.md#construct-the-body
-//!
-//! Each test pins one bullet of the construct-the-body flow. The on-wire
-//! shape of frames is covered separately in test_message_body_format.rs and
-//! the per-frame construction details in test_construct_a_frame.rs.
 
 mod fixtures;
 mod test_helpers;
@@ -15,7 +11,7 @@ use test_helpers::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_process_consumable_bytes_as_regular_frames() {
-    // 50 bytes with frame_length=10 → 4 regular frames + 1 final (10 bytes).
+    // 50 bytes / frame_length=10 → 4 regular + 1 final (10).
     let pt = vec![0xBBu8; 50];
     let ct = encrypt_with_frame_length(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
@@ -25,12 +21,12 @@ async fn test_process_consumable_bytes_as_regular_frames() {
     //# Before the end of the input is indicated,
     //# this operation MUST process as much of the consumable bytes as possible
     //# by [constructing regular frames](#construct-a-frame).
-    assert_eq!(regular, 4, "50 bytes / 10-byte frames → 4 regular frames");
-    assert_eq!(final_count, 1, "must have exactly 1 final frame");
+    assert_eq!(regular, 4);
+    assert_eq!(final_count, 1);
 
     //= spec/client-apis/encrypt.md#construct-the-body
     //= type=test
-    //= reason=round-trip proves the body bytes serialized by encrypt are the bytes decrypt consumes
+    //= reason=round-trip proves encrypt and decrypt agree on the body bytes
     //# The encrypted message output by the Encrypt operation MUST have a message body equal
     //# to the message body calculated in this step.
     let result = round_trip_framed(&pt, 10).await;
@@ -39,7 +35,7 @@ async fn test_process_consumable_bytes_as_regular_frames() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_end_of_input_processing() {
-    // 15 bytes with frame_length=10 → 1 regular (10) + 1 final (5).
+    // 15 bytes / frame_length=10 → 1 regular (10) + 1 final (5).
     let pt = vec![0xCCu8; 15];
     let ct = encrypt_with_frame_length(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
@@ -48,13 +44,9 @@ async fn test_end_of_input_processing() {
     //= type=test
     //# When the end of the input is indicated,
     //# this operation MUST perform the following until all consumable plaintext bytes are processed:
-    assert_eq!(regular, 1, "15 bytes → 1 regular frame (10 bytes)");
-    assert_eq!(final_count, 1, "must have exactly 1 final frame");
-    assert_eq!(
-        final_frame_content_length(&ct).unwrap(),
-        5,
-        "final frame content length must be 5 (remaining bytes)"
-    );
+    assert_eq!(regular, 1);
+    assert_eq!(final_count, 1);
+    assert_eq!(final_frame_content_length(&ct).unwrap(), 5);
 
     let result = round_trip_framed(&pt, 10).await;
     assert_eq!(result, pt);
@@ -62,8 +54,7 @@ async fn test_end_of_input_processing() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_exact_frame_length_constructs_final_or_regular() {
-    // 10 bytes plaintext with frame_length=10 → exactly enough for one regular
-    // frame, and the implementation chooses to emit a final frame for this case.
+    // 10 bytes / frame_length=10 → exactly one frame (final, in this impl).
     let pt = vec![0xDDu8; 10];
     let ct = encrypt_with_frame_length(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
@@ -74,12 +65,8 @@ async fn test_exact_frame_length_constructs_final_or_regular() {
     //# such that creating a regular frame processes all consumable bytes,
     //# then this operation MUST [construct either a final frame or regular frame](#construct-a-frame)
     //# with the remaining plaintext.
-    assert_eq!(regular + final_count, 1, "exact-match must produce one frame total");
-    assert_eq!(
-        final_frame_content_length(&ct).unwrap(),
-        10,
-        "final frame content length must equal frame length"
-    );
+    assert_eq!(regular + final_count, 1);
+    assert_eq!(final_frame_content_length(&ct).unwrap(), 10);
 
     let result = round_trip_framed(&pt, 10).await;
     assert_eq!(result, pt);
@@ -87,7 +74,7 @@ async fn test_exact_frame_length_constructs_final_or_regular() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_enough_bytes_constructs_regular_frame() {
-    // 25 bytes with frame_length=10 → 2 regular (10+10) + 1 final (5).
+    // 25 bytes / frame_length=10 → 2 regular + 1 final (5).
     let pt = vec![0xEEu8; 25];
     let ct = encrypt_with_frame_length(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
@@ -98,7 +85,7 @@ async fn test_enough_bytes_constructs_regular_frame() {
     //# such that creating a regular frame does not processes all consumable bytes,
     //# then this operation MUST [construct a regular frame](#construct-a-frame)
     //# using the consumable plaintext bytes.
-    assert_eq!(regular, 2, "25 bytes → 2 regular frames (10+10)");
+    assert_eq!(regular, 2);
     assert_eq!(final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 5);
 
@@ -108,7 +95,7 @@ async fn test_enough_bytes_constructs_regular_frame() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_not_enough_bytes_constructs_final_frame() {
-    // 7 bytes with frame_length=10 → single final frame (7 bytes < frame_length).
+    // 7 bytes / frame_length=10 → single final frame.
     let pt = vec![0xFFu8; 7];
     let ct = encrypt_with_frame_length(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
@@ -117,7 +104,7 @@ async fn test_not_enough_bytes_constructs_final_frame() {
     //= type=test
     //# - If there are not enough input consumable plaintext bytes to create a new regular frame,
     //# then this operation MUST [construct a final frame](#construct-a-frame)
-    assert_eq!(regular, 0, "7 bytes < frame_length → no regular frames");
+    assert_eq!(regular, 0);
     assert_eq!(final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 7);
 
@@ -135,13 +122,9 @@ async fn test_empty_plaintext_constructs_empty_final_frame() {
     //# If an end to the input has been indicated, there are no more consumable plaintext bytes to process,
     //# and a final frame has not yet been constructed,
     //# this operation MUST [construct an empty final frame](#construct-a-frame).
-    assert_eq!(regular, 0, "empty plaintext → no regular frames");
+    assert_eq!(regular, 0);
     assert_eq!(final_count, 1);
-    assert_eq!(
-        final_frame_content_length(&ct).unwrap(),
-        0,
-        "empty final frame content length must be 0"
-    );
+    assert_eq!(final_frame_content_length(&ct).unwrap(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -159,18 +142,13 @@ async fn test_plaintext_length_bound_must_not_encrypt_longer() {
     //= type=test
     //# If this input is provided, this operation MUST NOT encrypt a plaintext with length
     //# greater than this value.
-    let err = result.expect_err("must reject plaintext exceeding the bound");
-    assert!(
-        matches!(err.kind, ErrorKind::ValidationError),
-        "expected ValidationError, got {:?}",
-        err.kind
-    );
+    let err = result.expect_err("must reject");
+    assert!(matches!(err.kind, ErrorKind::ValidationError), "got {:?}", err.kind);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_body_plaintext_length_bound_runtime_enforcement() {
-    // Bound = 10, plaintext = 50, frame = 10. The streaming encoder must fail
-    // mid-stream once it sees more than 10 bytes — not silently truncate.
+    // Bound 10, plaintext 50, frame 10: encoder must fail mid-stream.
     let keyring = test_keyring().await;
     let mut stream_input =
         EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
@@ -187,10 +165,6 @@ async fn test_construct_body_plaintext_length_bound_runtime_enforcement() {
     //# and this operation determines at any time that the plaintext being encrypted
     //# has a length greater than this value,
     //# this operation MUST immediately fail.
-    let err = result.expect_err("must fail when plaintext exceeds bound during body construction");
-    assert!(
-        matches!(err.kind, ErrorKind::ValidationError),
-        "expected ValidationError, got {:?}",
-        err.kind
-    );
+    let err = result.expect_err("must fail mid-stream");
+    assert!(matches!(err.kind, ErrorKind::ValidationError), "got {:?}", err.kind);
 }

--- a/esdk/tests/test_construct_the_body.rs
+++ b/esdk/tests/test_construct_the_body.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tests for spec/client-apis/encrypt.md#construct-the-body
+//!
+//! Each test pins one bullet of the construct-the-body flow. The on-wire
+//! shape of frames is covered separately in test_message_body_format.rs and
+//! the per-frame construction details in test_construct_a_frame.rs.
 
 mod fixtures;
 mod test_helpers;
@@ -10,230 +14,152 @@ use aws_esdk::*;
 use test_helpers::*;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_regular_frame_serialization_conforms_to_spec() {
-    //= spec/client-apis/encrypt.md#construct-a-frame
-    //= type=test
-    //# The Encrypt operation MUST serialize a regular frame or final frame with the following specifics:
-    // 30 bytes with frame_length=10 → 2 regular frames + 1 final frame (10 bytes)
-    let pt = vec![0xAAu8; 30];
+async fn test_process_consumable_bytes_as_regular_frames() {
+    // 50 bytes with frame_length=10 → 4 regular frames + 1 final (10 bytes).
+    let pt = vec![0xBBu8; 50];
     let ct = encrypt_with_frame_length(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
-    assert_eq!(regular, 2, "30 bytes / 10-byte frames → 2 regular frames");
 
-    //= spec/data-format/message-body.md#final-frame
-    //= type=test
-    //# Framed data MUST contain exactly one final frame.
-    assert_eq!(final_count, 1, "must have exactly 1 final frame");
-
-    // count_frames walks regular frames sequentially then finds the final frame,
-    // proving the final frame is last.
-    //= spec/data-format/message-body.md#final-frame
-    //= type=test
-    //# The final frame MUST be the last frame.
-    assert_eq!(regular + final_count, 3, "2 regular + 1 final = 3 total frames in order");
-
-    //= spec/client-apis/encrypt.md#construct-the-body
-    //= type=test
-    //# The encrypted message output by the Encrypt operation MUST have a message body equal
-    //# to the message body calculated in this step.
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves body in output equals calculated body"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_process_consumable_bytes_as_regular_frames() {
     //= spec/client-apis/encrypt.md#construct-the-body
     //= type=test
     //# Before the end of the input is indicated,
     //# this operation MUST process as much of the consumable bytes as possible
     //# by [constructing regular frames](#construct-a-frame).
-    // 50 bytes with frame_length=10 → 4 regular frames + 1 final frame (10 bytes)
-    let pt = vec![0xBBu8; 50];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    let (regular, final_count) = count_frames(&ct, 10);
     assert_eq!(regular, 4, "50 bytes / 10-byte frames → 4 regular frames");
     assert_eq!(final_count, 1, "must have exactly 1 final frame");
+
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //= reason=round-trip proves the body bytes serialized by encrypt are the bytes decrypt consumes
+    //# The encrypted message output by the Encrypt operation MUST have a message body equal
+    //# to the message body calculated in this step.
     let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "all consumable bytes processed as regular frames before final"
-    );
+    assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_end_of_input_processing() {
+    // 15 bytes with frame_length=10 → 1 regular (10) + 1 final (5).
+    let pt = vec![0xCCu8; 15];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (regular, final_count) = count_frames(&ct, 10);
+
     //= spec/client-apis/encrypt.md#construct-the-body
     //= type=test
     //# When the end of the input is indicated,
     //# this operation MUST perform the following until all consumable plaintext bytes are processed:
-    // 15 bytes with frame_length=10 → 1 regular (10) + 1 final (5)
-    let pt = vec![0xCCu8; 15];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    let (regular, final_count) = count_frames(&ct, 10);
     assert_eq!(regular, 1, "15 bytes → 1 regular frame (10 bytes)");
     assert_eq!(final_count, 1, "must have exactly 1 final frame");
-    let content_len = final_frame_content_length(&ct).unwrap();
     assert_eq!(
-        content_len, 5,
+        final_frame_content_length(&ct).unwrap(),
+        5,
         "final frame content length must be 5 (remaining bytes)"
     );
 
-    //= spec/data-format/message-body.md#final-frame
-    //= type=test
-    //# The length of the plaintext to be encrypted in the Final Frame MUST be
-    //# greater than or equal to 0 and less than or equal to the [Frame Length](message-header.md#frame-length).
-    assert!(
-        content_len <= 10,
-        "final frame content length must be <= frame length"
-    );
     let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "end-of-input processing produces correct output"
-    );
+    assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_exact_frame_length_constructs_final_or_regular() {
+    // 10 bytes plaintext with frame_length=10 → exactly enough for one regular
+    // frame, and the implementation chooses to emit a final frame for this case.
+    let pt = vec![0xDDu8; 10];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (regular, final_count) = count_frames(&ct, 10);
+
     //= spec/client-apis/encrypt.md#construct-the-body
     //= type=test
     //# - If there are exactly enough consumable plaintext bytes to create one regular frame,
     //# such that creating a regular frame processes all consumable bytes,
     //# then this operation MUST [construct either a final frame or regular frame](#construct-a-frame)
     //# with the remaining plaintext.
-    //
-    //= spec/data-format/message-body.md#final-frame
-    //= type=test
-    //# - When the length of the Plaintext is an exact multiple of the Frame Length
-    //# (including if it is equal to the frame length),
-    //# the Final Frame encrypted content length SHOULD be equal to the frame length but MAY be 0.
-    // 10 bytes with frame_length=10 → exactly one frame's worth
-    // The implementation constructs a final frame for the exact-match case.
-    let pt = vec![0xDDu8; 10];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    let (regular, final_count) = count_frames(&ct, 10);
-    assert_eq!(regular, 0, "exact-match case: no regular frames");
-    assert_eq!(final_count, 1, "exact-match case: exactly 1 final frame");
-    let content_len = final_frame_content_length(&ct).unwrap();
+    assert_eq!(regular + final_count, 1, "exact-match must produce one frame total");
     assert_eq!(
-        content_len, 10,
+        final_frame_content_length(&ct).unwrap(),
+        10,
         "final frame content length must equal frame length"
     );
+
     let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(result, pt, "exact frame-length plaintext handled correctly");
+    assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_enough_bytes_constructs_regular_frame() {
+    // 25 bytes with frame_length=10 → 2 regular (10+10) + 1 final (5).
+    let pt = vec![0xEEu8; 25];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (regular, final_count) = count_frames(&ct, 10);
+
     //= spec/client-apis/encrypt.md#construct-the-body
     //= type=test
     //# - If there are enough input plaintext bytes consumable to create a new regular frame,
     //# such that creating a regular frame does not processes all consumable bytes,
     //# then this operation MUST [construct a regular frame](#construct-a-frame)
     //# using the consumable plaintext bytes.
-    // 25 bytes with frame_length=10 → 2 regular frames (10+10) + 1 final (5)
-    let pt = vec![0xEEu8; 25];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    let (regular, final_count) = count_frames(&ct, 10);
     assert_eq!(regular, 2, "25 bytes → 2 regular frames (10+10)");
-    assert_eq!(final_count, 1, "must have exactly 1 final frame");
-    let content_len = final_frame_content_length(&ct).unwrap();
-    assert_eq!(content_len, 5, "final frame content length must be 5");
+    assert_eq!(final_count, 1);
+    assert_eq!(final_frame_content_length(&ct).unwrap(), 5);
+
     let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "regular frames constructed when more bytes remain"
-    );
+    assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_not_enough_bytes_constructs_final_frame() {
-    //= spec/client-apis/encrypt.md#construct-the-body
-    //= type=test
-    //# - If there are not enough input consumable plaintext bytes to create a new regular frame,
-    //# then this operation MUST [construct a final frame](#construct-a-frame)
-    // 7 bytes with frame_length=10 → single final frame (7 bytes < frame_length)
+    // 7 bytes with frame_length=10 → single final frame (7 bytes < frame_length).
     let pt = vec![0xFFu8; 7];
     let ct = encrypt_with_frame_length(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
-    //= spec/data-format/message-body.md#final-frame
+    //= spec/client-apis/encrypt.md#construct-the-body
     //= type=test
-    //# - When the length of the Plaintext is less than the Frame Length,
-    //# the body MUST contain exactly one frame and that frame MUST be a Final Frame.
+    //# - If there are not enough input consumable plaintext bytes to create a new regular frame,
+    //# then this operation MUST [construct a final frame](#construct-a-frame)
     assert_eq!(regular, 0, "7 bytes < frame_length → no regular frames");
-    assert_eq!(final_count, 1, "must have exactly 1 final frame");
-    let content_len = final_frame_content_length(&ct).unwrap();
-    assert_eq!(content_len, 7, "final frame content length must be 7");
+    assert_eq!(final_count, 1);
+    assert_eq!(final_frame_content_length(&ct).unwrap(), 7);
 
     let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "short plaintext produces final frame with correct serialization"
-    );
+    assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_empty_plaintext_constructs_empty_final_frame() {
+    let ct = encrypt_with_frame_length(b"", 4096).await;
+    let (regular, final_count) = count_frames(&ct, 4096);
+
     //= spec/client-apis/encrypt.md#construct-the-body
     //= type=test
     //# If an end to the input has been indicated, there are no more consumable plaintext bytes to process,
     //# and a final frame has not yet been constructed,
     //# this operation MUST [construct an empty final frame](#construct-a-frame).
-    let ct = encrypt_with_frame_length(b"", 4096).await;
-    let (regular, final_count) = count_frames(&ct, 4096);
     assert_eq!(regular, 0, "empty plaintext → no regular frames");
-    assert_eq!(final_count, 1, "must have exactly 1 final frame");
-    let content_len = final_frame_content_length(&ct).unwrap();
-    assert_eq!(content_len, 0, "empty final frame content length must be 0");
-
-    // Parse the final frame structure from raw bytes to verify field ordering.
-    // Final frame: ENDFRAME(4) + SeqNum(4) + IV(12) + ContentLen(4) + Content(0) + Tag(16) = 36 bytes
-    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
-    let seq_one = 1u32.to_be_bytes();
-    let final_frame_offset = ct
-        .windows(8)
-        .position(|w| w[..4] == endframe && w[4..8] == seq_one)
-        .expect("final frame must have Sequence Number End followed by Sequence Number");
-
-    // Verify the final frame field ordering from raw bytes:
-    // Sequence Number End (4) + Sequence Number (4) + IV (12) + Content Length (4) + Content (0) + Tag (16)
-    let ff = &ct[final_frame_offset..];
-    assert_eq!(&ff[0..4], &endframe, "Sequence Number End");
-    assert_eq!(&ff[4..8], &seq_one, "Sequence Number = 1");
-    // IV at offset 8..20, ContentLen at offset 20..24, Content (0 bytes), Tag at offset 24..40
-    let ff_content_len = u32::from_be_bytes([ff[20], ff[21], ff[22], ff[23]]);
-    assert_eq!(ff_content_len, 0, "Encrypted Content Length = 0 for empty final frame");
-
-    // A final frame differs from a regular frame by two additional fields:
-    // Sequence Number End (verified at ff[0..4] above) and Encrypted Content Length (at ff[20..24]).
-    // A regular frame starts directly with Sequence Number and has no content length field.
-    assert_eq!(&ff[0..4], &0xFFFF_FFFFu32.to_be_bytes(), "Sequence Number End field present (absent in regular frames)");
-    assert!(ff.len() >= 24, "final frame must contain Encrypted Content Length field at offset 20");
+    assert_eq!(final_count, 1);
+    assert_eq!(
+        final_frame_content_length(&ct).unwrap(),
+        0,
+        "empty final frame content length must be 0"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_plaintext_length_bound_must_not_encrypt_longer() {
-    //= spec/client-apis/encrypt.md#plaintext-length-bound
-    //= type=test
-    //# If this input is provided, this operation MUST NOT encrypt a plaintext with length
-    //# greater than this value.
     let keyring = test_keyring().await;
     let mut stream_input =
         EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
-    // Set data_size (plaintext length bound) to 5 bytes
     stream_input.data_size = Some(5);
-    // Provide 20 bytes of plaintext, exceeding the bound
     let plaintext = vec![0xAAu8; 20];
     let mut reader = std::io::Cursor::new(&plaintext);
     let mut output = Vec::new();
     let result = encrypt_stream(&mut reader, &mut output, &stream_input).await;
-    let err = result.expect_err(
-        "encrypt_stream must fail when plaintext exceeds plaintext length bound",
-    );
+
+    //= spec/client-apis/encrypt.md#plaintext-length-bound
+    //= type=test
+    //# If this input is provided, this operation MUST NOT encrypt a plaintext with length
+    //# greater than this value.
+    let err = result.expect_err("must reject plaintext exceeding the bound");
     assert!(
         matches!(err.kind, ErrorKind::ValidationError),
         "expected ValidationError, got {:?}",
@@ -243,25 +169,25 @@ async fn test_plaintext_length_bound_must_not_encrypt_longer() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_construct_body_plaintext_length_bound_runtime_enforcement() {
-    //= spec/client-apis/encrypt.md#construct-the-body
-    //= type=test
-    //# If [Plaintext Length Bound](#plaintext-length-bound) was specified on input
-    //# and this operation determines at any time that the plaintext being encrypted
-    //# has a length greater than this value,
-    //# this operation MUST immediately fail.
+    // Bound = 10, plaintext = 50, frame = 10. The streaming encoder must fail
+    // mid-stream once it sees more than 10 bytes — not silently truncate.
     let keyring = test_keyring().await;
     let mut stream_input =
         EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
-    // Set data_size to 10 bytes but provide 50 bytes
     stream_input.data_size = Some(10);
     stream_input.frame_length = FrameLength::new(10).unwrap();
     let plaintext = vec![0xBBu8; 50];
     let mut reader = std::io::Cursor::new(&plaintext);
     let mut output = Vec::new();
     let result = encrypt_stream(&mut reader, &mut output, &stream_input).await;
-    let err = result.expect_err(
-        "encrypt_stream must immediately fail when plaintext exceeds bound during body construction",
-    );
+
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //# If [Plaintext Length Bound](#plaintext-length-bound) was specified on input
+    //# and this operation determines at any time that the plaintext being encrypted
+    //# has a length greater than this value,
+    //# this operation MUST immediately fail.
+    let err = result.expect_err("must fail when plaintext exceeds bound during body construction");
     assert!(
         matches!(err.kind, ErrorKind::ValidationError),
         "expected ValidationError, got {:?}",

--- a/esdk/tests/test_construct_the_body.rs
+++ b/esdk/tests/test_construct_the_body.rs
@@ -7,30 +7,14 @@ mod fixtures;
 mod test_helpers;
 
 use aws_esdk::*;
-use aws_mpl_legacy::dafny::types::keyring::KeyringRef;
 use test_helpers::*;
-
-/// Encrypt with a shared keyring and frame length, returning (ct, keyring) for reuse in decrypt.
-async fn encrypt_framed(pt: &[u8], frame_length: u32) -> (Vec<u8>, KeyringRef) {
-    let keyring = test_keyring().await;
-    let mut input =
-        EncryptInput::with_legacy_keyring(pt, EncryptionContext::new(), keyring.clone());
-    input.frame_length = FrameLength::new(frame_length).unwrap();
-    let ct = encrypt(&input).await.unwrap().ciphertext;
-    (ct, keyring)
-}
-
-/// Decrypt ct with a given keyring, returning plaintext.
-async fn decrypt_ct(ct: &[u8], keyring: KeyringRef) -> Vec<u8> {
-    let dec_input = DecryptInput::with_legacy_keyring(ct, EncryptionContext::new(), keyring);
-    decrypt(&dec_input).await.unwrap().plaintext
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_process_consumable_bytes_as_regular_frames() {
     // 50 bytes / frame_length=10 → 4 regular + 1 final (10).
+    let keyring = test_keyring().await;
     let pt = vec![0xBBu8; 50];
-    let (ct, keyring) = encrypt_framed(&pt, 10).await;
+    let ct = encrypt_framed_with_keyring(&pt, 10, &keyring).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -46,15 +30,16 @@ async fn test_process_consumable_bytes_as_regular_frames() {
     //= reason=round-trip proves encrypt and decrypt agree on the body bytes
     //# The encrypted message output by the Encrypt operation MUST have a message body equal
     //# to the message body calculated in this step.
-    let result = decrypt_ct(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_end_of_input_processing() {
     // 15 bytes / frame_length=10 → 1 regular (10) + 1 final (5).
+    let keyring = test_keyring().await;
     let pt = vec![0xCCu8; 15];
-    let (ct, keyring) = encrypt_framed(&pt, 10).await;
+    let ct = encrypt_framed_with_keyring(&pt, 10, &keyring).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -65,15 +50,16 @@ async fn test_end_of_input_processing() {
     assert_eq!(final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 5);
 
-    let result = decrypt_ct(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_exact_frame_length_constructs_final_or_regular() {
     // 10 bytes / frame_length=10 → exactly one frame (final, in this impl).
+    let keyring = test_keyring().await;
     let pt = vec![0xDDu8; 10];
-    let (ct, keyring) = encrypt_framed(&pt, 10).await;
+    let ct = encrypt_framed_with_keyring(&pt, 10, &keyring).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -85,15 +71,16 @@ async fn test_exact_frame_length_constructs_final_or_regular() {
     assert_eq!(regular + final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 10);
 
-    let result = decrypt_ct(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_enough_bytes_constructs_regular_frame() {
     // 25 bytes / frame_length=10 → 2 regular + 1 final (5).
+    let keyring = test_keyring().await;
     let pt = vec![0xEEu8; 25];
-    let (ct, keyring) = encrypt_framed(&pt, 10).await;
+    let ct = encrypt_framed_with_keyring(&pt, 10, &keyring).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -106,15 +93,16 @@ async fn test_enough_bytes_constructs_regular_frame() {
     assert_eq!(final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 5);
 
-    let result = decrypt_ct(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_not_enough_bytes_constructs_final_frame() {
     // 7 bytes / frame_length=10 → single final frame.
+    let keyring = test_keyring().await;
     let pt = vec![0xFFu8; 7];
-    let (ct, keyring) = encrypt_framed(&pt, 10).await;
+    let ct = encrypt_framed_with_keyring(&pt, 10, &keyring).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -125,13 +113,14 @@ async fn test_not_enough_bytes_constructs_final_frame() {
     assert_eq!(final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 7);
 
-    let result = decrypt_ct(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_empty_plaintext_constructs_empty_final_frame() {
-    let (ct, keyring) = encrypt_framed(b"", 4096).await;
+    let keyring = test_keyring().await;
+    let ct = encrypt_framed_with_keyring(b"", 4096, &keyring).await;
     let (regular, final_count) = count_frames(&ct, 4096);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -146,7 +135,7 @@ async fn test_empty_plaintext_constructs_empty_final_frame() {
     // Round-trip cross-check: empty plaintext must decrypt back to empty.
     // Regression: the decrypt path's preallocated `result` buffer would otherwise
     // be returned unchanged, leaking frame_length zero bytes.
-    let result = decrypt_ct(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, b"", "empty plaintext must round-trip to empty");
 }
 

--- a/esdk/tests/test_construct_the_body.rs
+++ b/esdk/tests/test_construct_the_body.rs
@@ -1,0 +1,270 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/client-apis/encrypt.md#construct-the-body
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use test_helpers::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_serialization_conforms_to_spec() {
+    //= spec/client-apis/encrypt.md#construct-a-frame
+    //= type=test
+    //# The Encrypt operation MUST serialize a regular frame or final frame with the following specifics:
+    // 30 bytes with frame_length=10 → 2 regular frames + 1 final frame (10 bytes)
+    let pt = vec![0xAAu8; 30];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (regular, final_count) = count_frames(&ct, 10);
+    assert_eq!(regular, 2, "30 bytes / 10-byte frames → 2 regular frames");
+
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# Framed data MUST contain exactly one final frame.
+    assert_eq!(final_count, 1, "must have exactly 1 final frame");
+
+    // count_frames walks regular frames sequentially then finds the final frame,
+    // proving the final frame is last.
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# The final frame MUST be the last frame.
+    assert_eq!(regular + final_count, 3, "2 regular + 1 final = 3 total frames in order");
+
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //# The encrypted message output by the Encrypt operation MUST have a message body equal
+    //# to the message body calculated in this step.
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves body in output equals calculated body"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_process_consumable_bytes_as_regular_frames() {
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //# Before the end of the input is indicated,
+    //# this operation MUST process as much of the consumable bytes as possible
+    //# by [constructing regular frames](#construct-a-frame).
+    // 50 bytes with frame_length=10 → 4 regular frames + 1 final frame (10 bytes)
+    let pt = vec![0xBBu8; 50];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (regular, final_count) = count_frames(&ct, 10);
+    assert_eq!(regular, 4, "50 bytes / 10-byte frames → 4 regular frames");
+    assert_eq!(final_count, 1, "must have exactly 1 final frame");
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "all consumable bytes processed as regular frames before final"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_end_of_input_processing() {
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //# When the end of the input is indicated,
+    //# this operation MUST perform the following until all consumable plaintext bytes are processed:
+    // 15 bytes with frame_length=10 → 1 regular (10) + 1 final (5)
+    let pt = vec![0xCCu8; 15];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (regular, final_count) = count_frames(&ct, 10);
+    assert_eq!(regular, 1, "15 bytes → 1 regular frame (10 bytes)");
+    assert_eq!(final_count, 1, "must have exactly 1 final frame");
+    let content_len = final_frame_content_length(&ct).unwrap();
+    assert_eq!(
+        content_len, 5,
+        "final frame content length must be 5 (remaining bytes)"
+    );
+
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# The length of the plaintext to be encrypted in the Final Frame MUST be
+    //# greater than or equal to 0 and less than or equal to the [Frame Length](message-header.md#frame-length).
+    assert!(
+        content_len <= 10,
+        "final frame content length must be <= frame length"
+    );
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "end-of-input processing produces correct output"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_exact_frame_length_constructs_final_or_regular() {
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //# - If there are exactly enough consumable plaintext bytes to create one regular frame,
+    //# such that creating a regular frame processes all consumable bytes,
+    //# then this operation MUST [construct either a final frame or regular frame](#construct-a-frame)
+    //# with the remaining plaintext.
+    //
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# - When the length of the Plaintext is an exact multiple of the Frame Length
+    //# (including if it is equal to the frame length),
+    //# the Final Frame encrypted content length SHOULD be equal to the frame length but MAY be 0.
+    // 10 bytes with frame_length=10 → exactly one frame's worth
+    // The implementation constructs a final frame for the exact-match case.
+    let pt = vec![0xDDu8; 10];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (regular, final_count) = count_frames(&ct, 10);
+    assert_eq!(regular, 0, "exact-match case: no regular frames");
+    assert_eq!(final_count, 1, "exact-match case: exactly 1 final frame");
+    let content_len = final_frame_content_length(&ct).unwrap();
+    assert_eq!(
+        content_len, 10,
+        "final frame content length must equal frame length"
+    );
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt, "exact frame-length plaintext handled correctly");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_enough_bytes_constructs_regular_frame() {
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //# - If there are enough input plaintext bytes consumable to create a new regular frame,
+    //# such that creating a regular frame does not processes all consumable bytes,
+    //# then this operation MUST [construct a regular frame](#construct-a-frame)
+    //# using the consumable plaintext bytes.
+    // 25 bytes with frame_length=10 → 2 regular frames (10+10) + 1 final (5)
+    let pt = vec![0xEEu8; 25];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (regular, final_count) = count_frames(&ct, 10);
+    assert_eq!(regular, 2, "25 bytes → 2 regular frames (10+10)");
+    assert_eq!(final_count, 1, "must have exactly 1 final frame");
+    let content_len = final_frame_content_length(&ct).unwrap();
+    assert_eq!(content_len, 5, "final frame content length must be 5");
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "regular frames constructed when more bytes remain"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_not_enough_bytes_constructs_final_frame() {
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //# - If there are not enough input consumable plaintext bytes to create a new regular frame,
+    //# then this operation MUST [construct a final frame](#construct-a-frame)
+    // 7 bytes with frame_length=10 → single final frame (7 bytes < frame_length)
+    let pt = vec![0xFFu8; 7];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (regular, final_count) = count_frames(&ct, 10);
+
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# - When the length of the Plaintext is less than the Frame Length,
+    //# the body MUST contain exactly one frame and that frame MUST be a Final Frame.
+    assert_eq!(regular, 0, "7 bytes < frame_length → no regular frames");
+    assert_eq!(final_count, 1, "must have exactly 1 final frame");
+    let content_len = final_frame_content_length(&ct).unwrap();
+    assert_eq!(content_len, 7, "final frame content length must be 7");
+
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "short plaintext produces final frame with correct serialization"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_empty_plaintext_constructs_empty_final_frame() {
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //# If an end to the input has been indicated, there are no more consumable plaintext bytes to process,
+    //# and a final frame has not yet been constructed,
+    //# this operation MUST [construct an empty final frame](#construct-a-frame).
+    let ct = encrypt_with_frame_length(b"", 4096).await;
+    let (regular, final_count) = count_frames(&ct, 4096);
+    assert_eq!(regular, 0, "empty plaintext → no regular frames");
+    assert_eq!(final_count, 1, "must have exactly 1 final frame");
+    let content_len = final_frame_content_length(&ct).unwrap();
+    assert_eq!(content_len, 0, "empty final frame content length must be 0");
+
+    // Parse the final frame structure from raw bytes to verify field ordering.
+    // Final frame: ENDFRAME(4) + SeqNum(4) + IV(12) + ContentLen(4) + Content(0) + Tag(16) = 36 bytes
+    let endframe = 0xFFFF_FFFFu32.to_be_bytes();
+    let seq_one = 1u32.to_be_bytes();
+    let final_frame_offset = ct
+        .windows(8)
+        .position(|w| w[..4] == endframe && w[4..8] == seq_one)
+        .expect("final frame must have Sequence Number End followed by Sequence Number");
+
+    // Verify the final frame field ordering from raw bytes:
+    // Sequence Number End (4) + Sequence Number (4) + IV (12) + Content Length (4) + Content (0) + Tag (16)
+    let ff = &ct[final_frame_offset..];
+    assert_eq!(&ff[0..4], &endframe, "Sequence Number End");
+    assert_eq!(&ff[4..8], &seq_one, "Sequence Number = 1");
+    // IV at offset 8..20, ContentLen at offset 20..24, Content (0 bytes), Tag at offset 24..40
+    let ff_content_len = u32::from_be_bytes([ff[20], ff[21], ff[22], ff[23]]);
+    assert_eq!(ff_content_len, 0, "Encrypted Content Length = 0 for empty final frame");
+
+    // A final frame differs from a regular frame by two additional fields:
+    // Sequence Number End (verified at ff[0..4] above) and Encrypted Content Length (at ff[20..24]).
+    // A regular frame starts directly with Sequence Number and has no content length field.
+    assert_eq!(&ff[0..4], &0xFFFF_FFFFu32.to_be_bytes(), "Sequence Number End field present (absent in regular frames)");
+    assert!(ff.len() >= 24, "final frame must contain Encrypted Content Length field at offset 20");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_plaintext_length_bound_must_not_encrypt_longer() {
+    //= spec/client-apis/encrypt.md#plaintext-length-bound
+    //= type=test
+    //# If this input is provided, this operation MUST NOT encrypt a plaintext with length
+    //# greater than this value.
+    let keyring = test_keyring().await;
+    let mut stream_input =
+        EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
+    // Set data_size (plaintext length bound) to 5 bytes
+    stream_input.data_size = Some(5);
+    // Provide 20 bytes of plaintext, exceeding the bound
+    let plaintext = vec![0xAAu8; 20];
+    let mut reader = std::io::Cursor::new(&plaintext);
+    let mut output = Vec::new();
+    let result = encrypt_stream(&mut reader, &mut output, &stream_input).await;
+    let err = result.expect_err(
+        "encrypt_stream must fail when plaintext exceeds plaintext length bound",
+    );
+    assert!(
+        matches!(err.kind, ErrorKind::ValidationError),
+        "expected ValidationError, got {:?}",
+        err.kind
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_construct_body_plaintext_length_bound_runtime_enforcement() {
+    //= spec/client-apis/encrypt.md#construct-the-body
+    //= type=test
+    //# If [Plaintext Length Bound](#plaintext-length-bound) was specified on input
+    //# and this operation determines at any time that the plaintext being encrypted
+    //# has a length greater than this value,
+    //# this operation MUST immediately fail.
+    let keyring = test_keyring().await;
+    let mut stream_input =
+        EncryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
+    // Set data_size to 10 bytes but provide 50 bytes
+    stream_input.data_size = Some(10);
+    stream_input.frame_length = FrameLength::new(10).unwrap();
+    let plaintext = vec![0xBBu8; 50];
+    let mut reader = std::io::Cursor::new(&plaintext);
+    let mut output = Vec::new();
+    let result = encrypt_stream(&mut reader, &mut output, &stream_input).await;
+    let err = result.expect_err(
+        "encrypt_stream must immediately fail when plaintext exceeds bound during body construction",
+    );
+    assert!(
+        matches!(err.kind, ErrorKind::ValidationError),
+        "expected ValidationError, got {:?}",
+        err.kind
+    );
+}

--- a/esdk/tests/test_construct_the_body.rs
+++ b/esdk/tests/test_construct_the_body.rs
@@ -7,13 +7,30 @@ mod fixtures;
 mod test_helpers;
 
 use aws_esdk::*;
+use aws_mpl_legacy::dafny::types::keyring::KeyringRef;
 use test_helpers::*;
+
+/// Encrypt with a shared keyring and frame length, returning (ct, keyring) for reuse in decrypt.
+async fn encrypt_framed(pt: &[u8], frame_length: u32) -> (Vec<u8>, KeyringRef) {
+    let keyring = test_keyring().await;
+    let mut input =
+        EncryptInput::with_legacy_keyring(pt, EncryptionContext::new(), keyring.clone());
+    input.frame_length = FrameLength::new(frame_length).unwrap();
+    let ct = encrypt(&input).await.unwrap().ciphertext;
+    (ct, keyring)
+}
+
+/// Decrypt ct with a given keyring, returning plaintext.
+async fn decrypt_ct(ct: &[u8], keyring: KeyringRef) -> Vec<u8> {
+    let dec_input = DecryptInput::with_legacy_keyring(ct, EncryptionContext::new(), keyring);
+    decrypt(&dec_input).await.unwrap().plaintext
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_process_consumable_bytes_as_regular_frames() {
     // 50 bytes / frame_length=10 → 4 regular + 1 final (10).
     let pt = vec![0xBBu8; 50];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (ct, keyring) = encrypt_framed(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -29,7 +46,7 @@ async fn test_process_consumable_bytes_as_regular_frames() {
     //= reason=round-trip proves encrypt and decrypt agree on the body bytes
     //# The encrypted message output by the Encrypt operation MUST have a message body equal
     //# to the message body calculated in this step.
-    let result = round_trip_framed(&pt, 10).await;
+    let result = decrypt_ct(&ct, keyring).await;
     assert_eq!(result, pt);
 }
 
@@ -37,7 +54,7 @@ async fn test_process_consumable_bytes_as_regular_frames() {
 async fn test_end_of_input_processing() {
     // 15 bytes / frame_length=10 → 1 regular (10) + 1 final (5).
     let pt = vec![0xCCu8; 15];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (ct, keyring) = encrypt_framed(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -48,7 +65,7 @@ async fn test_end_of_input_processing() {
     assert_eq!(final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 5);
 
-    let result = round_trip_framed(&pt, 10).await;
+    let result = decrypt_ct(&ct, keyring).await;
     assert_eq!(result, pt);
 }
 
@@ -56,7 +73,7 @@ async fn test_end_of_input_processing() {
 async fn test_exact_frame_length_constructs_final_or_regular() {
     // 10 bytes / frame_length=10 → exactly one frame (final, in this impl).
     let pt = vec![0xDDu8; 10];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (ct, keyring) = encrypt_framed(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -68,7 +85,7 @@ async fn test_exact_frame_length_constructs_final_or_regular() {
     assert_eq!(regular + final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 10);
 
-    let result = round_trip_framed(&pt, 10).await;
+    let result = decrypt_ct(&ct, keyring).await;
     assert_eq!(result, pt);
 }
 
@@ -76,7 +93,7 @@ async fn test_exact_frame_length_constructs_final_or_regular() {
 async fn test_enough_bytes_constructs_regular_frame() {
     // 25 bytes / frame_length=10 → 2 regular + 1 final (5).
     let pt = vec![0xEEu8; 25];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (ct, keyring) = encrypt_framed(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -89,7 +106,7 @@ async fn test_enough_bytes_constructs_regular_frame() {
     assert_eq!(final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 5);
 
-    let result = round_trip_framed(&pt, 10).await;
+    let result = decrypt_ct(&ct, keyring).await;
     assert_eq!(result, pt);
 }
 
@@ -97,7 +114,7 @@ async fn test_enough_bytes_constructs_regular_frame() {
 async fn test_not_enough_bytes_constructs_final_frame() {
     // 7 bytes / frame_length=10 → single final frame.
     let pt = vec![0xFFu8; 7];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (ct, keyring) = encrypt_framed(&pt, 10).await;
     let (regular, final_count) = count_frames(&ct, 10);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -108,13 +125,13 @@ async fn test_not_enough_bytes_constructs_final_frame() {
     assert_eq!(final_count, 1);
     assert_eq!(final_frame_content_length(&ct).unwrap(), 7);
 
-    let result = round_trip_framed(&pt, 10).await;
+    let result = decrypt_ct(&ct, keyring).await;
     assert_eq!(result, pt);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_empty_plaintext_constructs_empty_final_frame() {
-    let ct = encrypt_with_frame_length(b"", 4096).await;
+    let (ct, keyring) = encrypt_framed(b"", 4096).await;
     let (regular, final_count) = count_frames(&ct, 4096);
 
     //= spec/client-apis/encrypt.md#construct-the-body
@@ -129,7 +146,7 @@ async fn test_empty_plaintext_constructs_empty_final_frame() {
     // Round-trip cross-check: empty plaintext must decrypt back to empty.
     // Regression: the decrypt path's preallocated `result` buffer would otherwise
     // be returned unchanged, leaking frame_length zero bytes.
-    let result = round_trip_framed(b"", 4096).await;
+    let result = decrypt_ct(&ct, keyring).await;
     assert_eq!(result, b"", "empty plaintext must round-trip to empty");
 }
 
@@ -174,4 +191,3 @@ async fn test_construct_body_plaintext_length_bound_runtime_enforcement() {
     let err = result.expect_err("must fail mid-stream");
     assert!(matches!(err.kind, ErrorKind::ValidationError), "got {:?}", err.kind);
 }
-

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -1,4 +1,5 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tests for spec/data-format/message-body.md
@@ -7,8 +8,6 @@ mod fixtures;
 mod test_helpers;
 
 use aws_esdk::*;
-use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
-use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
 
 use test_helpers::*;
 
@@ -200,12 +199,13 @@ async fn test_nonframed_auth_tag_length() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_framed_data_max_frame_count() {
     // With frame_length=4 and 20 bytes, we get 4 regular + 1 final = 5 frames.
-    // The implementation checks sequence_number == ENDFRAME_SEQUENCE_NUMBER to enforce the limit.
     //= spec/data-format/message-body.md#framed-data
     //= type=test
+    //= reason=The 2^32-1 boundary is unreachable in a unit test (would require ~4B frames). The implementation enforces it at body_encrypt.rs by checking sequence_number == ENDFRAME_SEQUENCE_NUMBER (0xFFFFFFFF) before writing each regular frame and returning ValidationError("Too many frames"). This test exercises a small frame count to confirm the multi-frame path works; the upper bound itself is enforced by source-side citation.
     //# - The number of frames in a single message MUST be less than or equal to `2^32 - 1`.
     let pt = vec![0xBBu8; 20];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 4).await, 4);
+    let ct = encrypt_with_frame_length(&pt, 4).await;
+    let frames = parse_all_frames(&ct, 4);
     assert_eq!(
         frames.len(),
         5,
@@ -282,8 +282,9 @@ async fn test_regular_frame_sequence_number_starts_at_one() {
     //= type=test
     //# Framed Data MUST start at Sequence Number 1.
     let pt = vec![0xDDu8; 20];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
-    assert_eq!(frames[0].0, 1, "first frame sequence number must be 1");
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    assert_eq!(frames[0].seq_num, 1, "first frame sequence number must be 1");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -292,11 +293,12 @@ async fn test_regular_frame_sequence_number_increments() {
     //= type=test
     //# Subsequent frames MUST be in order and MUST contain an increment of 1 from the previous frame.
     let pt = vec![0xEEu8; 40];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
     for i in 1..frames.len() {
         assert_eq!(
-            frames[i].0,
-            frames[i - 1].0 + 1,
+            frames[i].seq_num,
+            frames[i - 1].seq_num + 1,
             "frame {} seq num must be 1 greater than frame {}",
             i,
             i - 1
@@ -341,12 +343,12 @@ async fn test_regular_frame_iv_unique() {
     //= type=test
     //# Each frame in the [Framed Data](#framed-data) MUST include an IV that is unique within the message.
     let pt = vec![0xCCu8; 40];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
-    let ivs: Vec<&Vec<u8>> = frames.iter().map(|(_, iv, _, _, _)| iv).collect();
-    for i in 0..ivs.len() {
-        for j in (i + 1)..ivs.len() {
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    for i in 0..frames.len() {
+        for j in (i + 1)..frames.len() {
             assert_ne!(
-                ivs[i], ivs[j],
+                frames[i].iv, frames[j].iv,
                 "IV for frame {} must differ from frame {}",
                 i, j
             );
@@ -360,10 +362,11 @@ async fn test_regular_frame_iv_length_matches_algorithm() {
     //= type=test
     //# The IV length MUST be equal to the IV length of the algorithm suite specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
     let pt = vec![0xDDu8; 20];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
-    for (_, iv, _, _, _) in &frames {
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    for f in &frames {
         assert_eq!(
-            iv.len(),
+            f.iv.len(),
             IV_LEN,
             "IV length must match algorithm suite IV length (12)"
         );
@@ -406,14 +409,12 @@ async fn test_regular_frame_encrypted_content_length_equals_frame_length() {
     //# - The total bytes allowed in a single frame MUST be less than or equal to `2^32 - 1`.
     let frame_length: u32 = 10;
     let pt = vec![0xFFu8; 30];
-    let frames = parse_frames(
-        &encrypt_with_frame_length(&pt, frame_length).await,
-        frame_length,
-    );
-    for (_, _, enc_content, _, is_final) in &frames {
-        if !is_final {
+    let ct = encrypt_with_frame_length(&pt, frame_length).await;
+    let frames = parse_all_frames(&ct, frame_length);
+    for f in &frames {
+        if !f.is_final {
             assert_eq!(
-                enc_content.len(),
+                f.content.len(),
                 frame_length as usize,
                 "regular frame encrypted content length must equal frame length"
             );
@@ -428,10 +429,11 @@ async fn test_regular_frame_auth_tag_length_matches_algorithm() {
     //# The authentication tag length MUST be equal to the authentication tag length of the algorithm suite
     //# specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
     let pt = vec![0xBBu8; 20];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
-    for (_, _, _, tag, _) in &frames {
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    for f in &frames {
         assert_eq!(
-            tag.len(),
+            f.tag.len(),
             TAG_LEN,
             "auth tag length must match algorithm suite (16)"
         );
@@ -580,12 +582,16 @@ async fn test_final_frame_sequence_number_equals_total_frames() {
     //= type=test
     //# The Final Frame Sequence number MUST be equal to the total number of frames in the Framed Data.
     let pt = vec![0xAAu8; 30];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
     let final_frame = frames.last().expect("must have final frame");
-    assert!(final_frame.4, "last frame must be final");
+    assert!(final_frame.is_final, "last frame must be final");
+    let Ok(total) = u32::try_from(frames.len()) else {
+        panic!("frame count exceeds u32::MAX");
+    };
     assert_eq!(
-        final_frame.0,
-        frames.len() as u32,
+        final_frame.seq_num,
+        total,
         "final frame seq num must equal total frame count"
     );
 }
@@ -619,32 +625,18 @@ async fn test_final_frame_sequence_number_serialized_same_as_regular() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_final_frame_sequence_number_interpreted_same_as_regular() {
-    //= spec/data-format/message-body.md#final-frame-sequence-number
-    //= type=test
-    //# The Final Frame Sequence Number MUST be interpreted as the same type as the
-    //# [Regular Frame Sequence Number](#regular-frame-sequence-number).
-    // Multi-frame round-trip: decrypt reads final frame seq num as UInt32 (same as regular)
-    let pt = vec![0xCCu8; 30];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves final frame seq num is interpreted same as regular"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_final_frame_iv_unique() {
     //= spec/data-format/message-body.md#final-frame-iv
     //= type=test
     //# A generated IV MUST be a unique IV within the message.
     let pt = vec![0xDDu8; 30];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
-    let final_iv = &frames.last().expect("must have final frame").1;
-    for (i, (_, iv, _, _, is_final)) in frames.iter().enumerate() {
-        if !is_final {
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    let final_iv = frames.last().expect("must have final frame").iv;
+    for (i, f) in frames.iter().enumerate() {
+        if !f.is_final {
             assert_ne!(
-                iv, final_iv,
+                f.iv, final_iv,
                 "final frame IV must differ from regular frame {}",
                 i
             );
@@ -658,11 +650,12 @@ async fn test_final_frame_iv_length_matches_algorithm() {
     //= type=test
     //# The length of the IV field MUST be equal to the IV length of the [algorithm suite](../framework/algorithm-suites.md) that generated the message.
     let pt = vec![0xEEu8; 5];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
     let final_frame = frames.last().expect("must have final frame");
-    assert!(final_frame.4, "must be final frame");
+    assert!(final_frame.is_final, "must be final frame");
     assert_eq!(
-        final_frame.1.len(),
+        final_frame.iv.len(),
         IV_LEN,
         "final frame IV length must match algorithm suite"
     );
@@ -729,35 +722,16 @@ async fn test_final_frame_encrypted_content_length_uint32_4_bytes_be() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_final_frame_encrypted_content_length_matches() {
-    //= spec/data-format/message-body.md#final-frame-encrypted-content
-    //= type=test
-    //# The length of the serialized encrypted content field MUST be equal to the value of the [Encrypted Content Length](#final-frame-encrypted-content-length) field.
-    let pt = vec![0xDDu8; 7];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
-    let final_frame = frames.last().expect("must have final frame");
-    assert!(final_frame.4, "must be final frame");
-    // parse_frames reads content_len from the field and uses it to read enc_content
-    // If they didn't match, parsing would fail or produce wrong data
-    assert_eq!(
-        final_frame.2.len(),
-        7,
-        "encrypted content length must match the content length field"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_final_frame_auth_tag_length_matches_algorithm() {
     //= spec/data-format/message-body.md#final-frame-authentication-tag
     //= type=test
     //# The authentication tag length MUST be equal to the authentication tag length of the algorithm suite
     //# specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
     let pt = vec![0xFFu8; 5];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
-    let final_frame = frames.last().expect("must have final frame");
-    assert!(final_frame.4, "must be final frame");
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let final_frame = parse_final_frame(&ct, 10);
     assert_eq!(
-        final_frame.3.len(),
+        final_frame.tag.len(),
         TAG_LEN,
         "final frame auth tag length must match algorithm suite (16)"
     );
@@ -792,13 +766,79 @@ async fn test_final_frame_auth_tag_authenticates_final_frame() {
     );
 }
 
-async fn encrypt_v1_with_frame_length(plaintext: &[u8], frame_length: u32) -> Vec<u8> {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_auth_tag_authenticates_regular_frame() {
+    //= spec/data-format/message-body.md#regular-frame-authentication-tag
+    //= type=test
+    //# The authentication tag MUST be interpreted as bytes.
+    // Tampering with a regular frame's auth tag must cause decryption failure.
+    // Use 25 bytes / frame_length=10 so the first frame is a regular frame.
+    let pt = vec![0xCCu8; 25];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    let regular = frames.iter().find(|f| !f.is_final).expect("must have a regular frame");
+
+    let mut tampered = ct.clone();
+    tampered[regular.tag_offset] ^= 0xFF;
+
     let keyring = test_keyring().await;
-    let mut input = EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring);
-    input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
-    input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    input.frame_length = FrameLength::new(frame_length).unwrap();
-    encrypt(&input).await.unwrap().ciphertext
+    let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
+    let err = decrypt(&dec_input)
+        .await
+        .expect_err("tampered regular frame auth tag must cause decryption failure");
+    assert!(
+        matches!(err.kind, ErrorKind::CryptographicError),
+        "expected CryptographicError, got: {} ({:?})",
+        err.message,
+        err.kind
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_seq_num_out_of_order_rejected() {
+    //= spec/data-format/message-body.md#regular-frame-sequence-number
+    //= type=test
+    //# Subsequent frames MUST be in order and MUST contain an increment of 1 from the previous frame.
+    // Tamper the second regular frame's seq num so it's NOT (previous + 1). Decrypt must
+    // reject this with SerializationError ("Sequence number out of order"), per the
+    // body_decrypt.rs check `if seq_num != expected_frame { return ser_err(...) }`.
+    // Use 25 bytes / frame_length=10 → 2 regular + 1 final, so we have a frame[1] to tamper.
+    let pt = vec![0xDDu8; 25];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+
+    // Baseline: untampered ciphertext decrypts.
+    let baseline = round_trip_framed(&pt, 10).await;
+    assert_eq!(baseline, pt, "baseline plaintext mismatch");
+
+    // Tamper the second frame's seq num field at the integer level (perturb 2 → 3).
+    let frame1 = &frames[1];
+    assert_eq!(frame1.seq_num, 2, "second frame must have seq=2");
+    let original = u32::from_be_bytes([
+        ct[frame1.seq_num_offset],
+        ct[frame1.seq_num_offset + 1],
+        ct[frame1.seq_num_offset + 2],
+        ct[frame1.seq_num_offset + 3],
+    ]);
+    let tampered_seq = original + 1;
+    assert_ne!(tampered_seq, original, "tamper-effectiveness");
+
+    let mut tampered = ct.clone();
+    tampered[frame1.seq_num_offset..frame1.seq_num_offset + 4]
+        .copy_from_slice(&tampered_seq.to_be_bytes());
+
+    let keyring = test_keyring().await;
+    let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
+    let err = decrypt(&dec_input)
+        .await
+        .expect_err("out-of-order seq num must be rejected");
+    assert_eq!(
+        err.kind,
+        ErrorKind::SerializationError,
+        "expected SerializationError for out-of-order seq num, got: {} ({:?})",
+        err.message,
+        err.kind
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -807,8 +847,9 @@ async fn test_v1_regular_frame_sequence_number_starts_at_one() {
     //= type=test
     //# Framed Data MUST start at Sequence Number 1.
     let pt = vec![0xAAu8; 20];
-    let frames = parse_frames(&encrypt_v1_with_frame_length(&pt, 10).await, 10);
-    assert_eq!(frames[0].0, 1, "V1: first frame sequence number must be 1");
+    let ct = encrypt_v1_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    assert_eq!(frames[0].seq_num, 1, "V1: first frame sequence number must be 1");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -817,11 +858,12 @@ async fn test_v1_regular_frame_sequence_number_increments() {
     //= type=test
     //# Subsequent frames MUST be in order and MUST contain an increment of 1 from the previous frame.
     let pt = vec![0xBBu8; 40];
-    let frames = parse_frames(&encrypt_v1_with_frame_length(&pt, 10).await, 10);
+    let ct = encrypt_v1_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
     for i in 1..frames.len() {
         assert_eq!(
-            frames[i].0,
-            frames[i - 1].0 + 1,
+            frames[i].seq_num,
+            frames[i - 1].seq_num + 1,
             "V1: frame {} seq num must be 1 greater than frame {}",
             i,
             i - 1
@@ -835,11 +877,15 @@ async fn test_v1_regular_frame_iv_unique() {
     //= type=test
     //# Each frame in the [Framed Data](#framed-data) MUST include an IV that is unique within the message.
     let pt = vec![0xCCu8; 40];
-    let frames = parse_frames(&encrypt_v1_with_frame_length(&pt, 10).await, 10);
-    let ivs: Vec<&Vec<u8>> = frames.iter().map(|(_, iv, _, _, _)| iv).collect();
-    for i in 0..ivs.len() {
-        for j in (i + 1)..ivs.len() {
-            assert_ne!(ivs[i], ivs[j], "V1: IV for frame {} must differ from frame {}", i, j);
+    let ct = encrypt_v1_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    for i in 0..frames.len() {
+        for j in (i + 1)..frames.len() {
+            assert_ne!(
+                frames[i].iv, frames[j].iv,
+                "V1: IV for frame {} must differ from frame {}",
+                i, j
+            );
         }
     }
 }
@@ -851,11 +897,12 @@ async fn test_v1_regular_frame_encrypted_content_length_equals_frame_length() {
     //# The length of the encrypted content of a Regular Frame MUST be equal to the Frame Length.
     let frame_length: u32 = 10;
     let pt = vec![0xDDu8; 30];
-    let frames = parse_frames(&encrypt_v1_with_frame_length(&pt, frame_length).await, frame_length);
-    for (_, _, enc_content, _, is_final) in &frames {
-        if !is_final {
+    let ct = encrypt_v1_with_frame_length(&pt, frame_length).await;
+    let frames = parse_all_frames(&ct, frame_length);
+    for f in &frames {
+        if !f.is_final {
             assert_eq!(
-                enc_content.len(),
+                f.content.len(),
                 frame_length as usize,
                 "V1: regular frame encrypted content length must equal frame length"
             );
@@ -882,12 +929,16 @@ async fn test_v1_final_frame_sequence_number_equals_total_frames() {
     //= type=test
     //# The Final Frame Sequence number MUST be equal to the total number of frames in the Framed Data.
     let pt = vec![0xEEu8; 30];
-    let frames = parse_frames(&encrypt_v1_with_frame_length(&pt, 10).await, 10);
+    let ct = encrypt_v1_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
     let final_frame = frames.last().expect("must have final frame");
-    assert!(final_frame.4, "last frame must be final");
+    assert!(final_frame.is_final, "last frame must be final");
+    let Ok(total) = u32::try_from(frames.len()) else {
+        panic!("frame count exceeds u32::MAX");
+    };
     assert_eq!(
-        final_frame.0,
-        frames.len() as u32,
+        final_frame.seq_num,
+        total,
         "V1: final frame seq num must equal total frame count"
     );
 }
@@ -898,8 +949,9 @@ async fn test_framed_data_contains_exactly_one_final_frame() {
     //= type=test
     //# Framed data MUST contain exactly one final frame.
     let pt = vec![0xAAu8; 30];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
-    let final_count = frames.iter().filter(|(_, _, _, _, is_final)| *is_final).count();
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    let final_count = frames.iter().filter(|f| f.is_final).count();
     assert_eq!(final_count, 1, "framed data must contain exactly one final frame");
 }
 
@@ -909,9 +961,10 @@ async fn test_final_frame_is_last_frame() {
     //= type=test
     //# The final frame MUST be the last frame.
     let pt = vec![0xBBu8; 30];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
-    for (i, (_, _, _, _, is_final)) in frames.iter().enumerate() {
-        if *is_final {
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    for (i, f) in frames.iter().enumerate() {
+        if f.is_final {
             assert_eq!(i, frames.len() - 1, "final frame must be the last frame");
         }
     }
@@ -926,13 +979,12 @@ async fn test_final_frame_content_length_lte_frame_length() {
     let frame_length: u32 = 10;
     // 7 bytes plaintext with 10-byte frame → final frame has 7 bytes (< frame_length)
     let pt = vec![0xCCu8; 7];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, frame_length).await, frame_length);
-    let final_frame = frames.last().expect("must have final frame");
-    assert!(final_frame.4, "must be final frame");
+    let ct = encrypt_with_frame_length(&pt, frame_length).await;
+    let final_frame = parse_final_frame(&ct, frame_length);
     assert!(
-        final_frame.2.len() <= frame_length as usize,
+        final_frame.content.len() <= frame_length as usize,
         "final frame content length {} must be <= frame length {}",
-        final_frame.2.len(),
+        final_frame.content.len(),
         frame_length
     );
 }
@@ -944,9 +996,10 @@ async fn test_plaintext_less_than_frame_length_single_final_frame() {
     //# - When the length of the Plaintext is less than the Frame Length,
     //# the body MUST contain exactly one frame and that frame MUST be a Final Frame.
     let pt = vec![0xDDu8; 5];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
     assert_eq!(frames.len(), 1, "plaintext < frame length must produce exactly one frame");
-    assert!(frames[0].4, "the single frame must be a final frame");
+    assert!(frames[0].is_final, "the single frame must be a final frame");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -959,10 +1012,10 @@ async fn test_plaintext_exact_multiple_of_frame_length() {
     let frame_length: u32 = 10;
     let pt = vec![0xEEu8; frame_length as usize];
     let ct = encrypt_with_frame_length(&pt, frame_length).await;
-    let frames = parse_frames(&ct, frame_length);
-    let final_frame = frames.last().expect("must have final frame");
-    assert!(final_frame.4, "last frame must be final");
-    let final_content_len = final_frame.2.len() as u32;
+    let final_frame = parse_final_frame(&ct, frame_length);
+    let Ok(final_content_len) = u32::try_from(final_frame.content.len()) else {
+        panic!("final content length exceeds u32::MAX");
+    };
     assert!(
         final_content_len == frame_length || final_content_len == 0,
         "final frame content length must be frame_length ({}) or 0, got {}",

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -8,12 +8,29 @@ mod fixtures;
 mod test_helpers;
 
 use aws_esdk::*;
+use aws_mpl_legacy::dafny::types::keyring::KeyringRef;
 
 use test_helpers::*;
 
 // The ESDK always uses framed encryption, so nonframed deserialization
 // is exercised by parsing/decrypting the external V2 nonframed vector from
 // aws-encryption-sdk-test-vectors.
+
+/// Encrypt with a shared keyring and frame length, returning (ct, keyring) for reuse in decrypt.
+async fn encrypt_framed_shared(pt: &[u8], frame_length: u32) -> (Vec<u8>, KeyringRef) {
+    let keyring = test_keyring().await;
+    let mut input =
+        EncryptInput::with_legacy_keyring(pt, EncryptionContext::new(), keyring.clone());
+    input.frame_length = FrameLength::new(frame_length).unwrap();
+    let ct = encrypt(&input).await.unwrap().ciphertext;
+    (ct, keyring)
+}
+
+/// Decrypt ct with a given keyring, returning plaintext.
+async fn decrypt_with_keyring(ct: &[u8], keyring: KeyringRef) -> Vec<u8> {
+    let dec_input = DecryptInput::with_legacy_keyring(ct, EncryptionContext::new(), keyring);
+    decrypt(&dec_input).await.unwrap().plaintext
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_nonframed_data_serialization_order() {
@@ -219,14 +236,14 @@ async fn test_framed_data_max_frame_count() {
     //= reason=The 2^32-1 boundary is unreachable in a unit test (would require ~4B frames). The implementation enforces it at body_encrypt.rs by checking sequence_number == ENDFRAME_SEQUENCE_NUMBER (0xFFFFFFFF) before writing each regular frame and returning ValidationError("Too many frames"). This test exercises a small frame count to confirm the multi-frame path works; the upper bound itself is enforced by source-side citation.
     //# - The number of frames in a single message MUST be less than or equal to `2^32 - 1`.
     let pt = vec![0xBBu8; 20];
-    let ct = encrypt_with_frame_length(&pt, 4).await;
+    let (ct, keyring) = encrypt_framed_shared(&pt, 4).await;
     let frames = parse_all_frames(&ct, 4);
     assert_eq!(
         frames.len(),
         5,
         "20 bytes / 4-byte frames = 4 regular + 1 final = 5 frames"
     );
-    let result = round_trip_framed(&pt, 4).await;
+    let result = decrypt_with_keyring(&ct, keyring).await;
     assert_eq!(result, pt);
 }
 
@@ -245,7 +262,7 @@ async fn test_regular_frame_serialization_order() {
     // proving Field 4's end offset is exactly 4 + IV_LEN + FRAME_LEN + TAG_LEN.
     const FRAME_LEN: u32 = 10;
     let pt = vec![0xCCu8; 25];
-    let ct = encrypt_with_frame_length(&pt, FRAME_LEN).await;
+    let (ct, keyring) = encrypt_framed_shared(&pt, FRAME_LEN).await;
     let frames = parse_all_frames(&ct, FRAME_LEN);
     assert_eq!(frames.len(), 3, "expected 2 regular + 1 final frame");
     let f = &frames[0];
@@ -287,7 +304,7 @@ async fn test_regular_frame_serialization_order() {
         "next regular frame's seq must be 2 (proves Field 4 ends at the spec-required offset)");
 
     // Round-trip cross-check.
-    let result = round_trip_framed(&pt, FRAME_LEN).await;
+    let result = decrypt_with_keyring(&ct, keyring).await;
     assert_eq!(result, pt, "round-trip corroborates regular frame serialization order");
 }
 
@@ -445,7 +462,7 @@ async fn test_final_frame_serialization_order() {
     const FRAME_LEN: u32 = 10;
     const PT_LEN: usize = 7;
     let pt = vec![0xAAu8; PT_LEN];
-    let ct = encrypt_with_frame_length(&pt, FRAME_LEN).await;
+    let (ct, keyring) = encrypt_framed_shared(&pt, FRAME_LEN).await;
     let f = parse_final_frame(&ct, FRAME_LEN);
 
     // Field 1 of 6: Sequence Number End — 4 bytes equal to 0xFF FF FF FF.
@@ -492,7 +509,7 @@ async fn test_final_frame_serialization_order() {
         "final frame must occupy exactly {} bytes", expected_total);
 
     // Round-trip cross-check.
-    let result = round_trip_framed(&pt, FRAME_LEN).await;
+    let result = decrypt_with_keyring(&ct, keyring).await;
     assert_eq!(result, pt);
 }
 
@@ -505,7 +522,7 @@ async fn test_final_frame_is_regular_frame_plus_additions() {
     //# and Encrypted Content Length.
     const FRAME_LEN: u32 = 10;
     let pt = vec![0xBBu8; 5];
-    let ct = encrypt_with_frame_length(&pt, FRAME_LEN).await;
+    let (ct, keyring) = encrypt_framed_shared(&pt, FRAME_LEN).await;
     let f = parse_final_frame(&ct, FRAME_LEN);
 
     // The two ADDITIONS over a regular frame:
@@ -521,7 +538,7 @@ async fn test_final_frame_is_regular_frame_plus_additions() {
     assert!(f.content_length_offset.is_some(),
         "final frame must have an Encrypted Content Length offset");
 
-    let result = round_trip_framed(&pt, FRAME_LEN).await;
+    let result = decrypt_with_keyring(&ct, keyring).await;
     assert_eq!(result, pt);
 }
 
@@ -595,7 +612,7 @@ async fn test_final_frame_sequence_number_serialized_same_as_regular() {
     //# [Regular Frame Sequence Number](#regular-frame-sequence-number).
     const FRAME_LEN: u32 = 10;
     let pt = vec![0xBBu8; 20];
-    let ct = encrypt_with_frame_length(&pt, FRAME_LEN).await;
+    let (ct, keyring) = encrypt_framed_shared(&pt, FRAME_LEN).await;
     let frames = parse_all_frames(&ct, FRAME_LEN);
 
     // Find a regular frame and the final frame; their seq num field widths must match.
@@ -608,7 +625,7 @@ async fn test_final_frame_sequence_number_serialized_same_as_regular() {
     );
     assert_eq!(regular.seq_num_bytes.len(), 4, "seq num field width must be 4 bytes");
 
-    let result = round_trip_framed(&pt, FRAME_LEN).await;
+    let result = decrypt_with_keyring(&ct, keyring).await;
     assert_eq!(
         result, pt,
         "round-trip proves final frame seq num serialized same as regular"
@@ -711,17 +728,17 @@ async fn test_final_frame_auth_tag_authenticates_final_frame() {
     //# It MUST be used to authenticate the final frame.
     // Successful decrypt proves the auth tag authenticated the final frame.
     let pt = vec![0xBBu8; 5];
-    assert_eq!(round_trip_framed(&pt, 10).await, pt);
+    let (ct, keyring) = encrypt_framed_shared(&pt, 10).await;
+    assert_eq!(decrypt_with_keyring(&ct, keyring.clone()).await, pt);
 
     // Tampering with the final frame's auth tag must cause decryption failure.
-    let ct = encrypt_with_frame_length(&pt, 10).await;
     let final_frame = parse_final_frame(&ct, 10);
 
     let mut tampered = ct.clone();
     tampered[final_frame.tag_offset] ^= 0xFF;
 
-    let keyring = test_keyring().await;
-    let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
+    let dec_input =
+        DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
     let err = decrypt(&dec_input)
         .await
         .expect_err("tampered final frame auth tag must cause decryption failure");
@@ -741,15 +758,15 @@ async fn test_regular_frame_auth_tag_authenticates_regular_frame() {
     // Tampering with a regular frame's auth tag must cause decryption failure.
     // Use 25 bytes / frame_length=10 so the first frame is a regular frame.
     let pt = vec![0xCCu8; 25];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (ct, keyring) = encrypt_framed_shared(&pt, 10).await;
     let frames = parse_all_frames(&ct, 10);
     let regular = frames.iter().find(|f| !f.is_final).expect("must have a regular frame");
 
     let mut tampered = ct.clone();
     tampered[regular.tag_offset] ^= 0xFF;
 
-    let keyring = test_keyring().await;
-    let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
+    let dec_input =
+        DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
     let err = decrypt(&dec_input)
         .await
         .expect_err("tampered regular frame auth tag must cause decryption failure");
@@ -771,11 +788,11 @@ async fn test_regular_frame_seq_num_out_of_order_rejected() {
     // body_decrypt.rs check `if seq_num != expected_frame { return ser_err(...) }`.
     // Use 25 bytes / frame_length=10 → 2 regular + 1 final, so we have a frame[1] to tamper.
     let pt = vec![0xDDu8; 25];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let (ct, keyring) = encrypt_framed_shared(&pt, 10).await;
     let frames = parse_all_frames(&ct, 10);
 
     // Baseline: untampered ciphertext decrypts.
-    let baseline = round_trip_framed(&pt, 10).await;
+    let baseline = decrypt_with_keyring(&ct, keyring.clone()).await;
     assert_eq!(baseline, pt, "baseline plaintext mismatch");
 
     // Tamper the second frame's seq num field at the integer level (perturb 2 → 3).
@@ -794,8 +811,8 @@ async fn test_regular_frame_seq_num_out_of_order_rejected() {
     tampered[frame1.seq_num_offset..frame1.seq_num_offset + 4]
         .copy_from_slice(&tampered_seq.to_be_bytes());
 
-    let keyring = test_keyring().await;
-    let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
+    let dec_input =
+        DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
     let err = decrypt(&dec_input)
         .await
         .expect_err("out-of-order seq num must be rejected");
@@ -978,7 +995,7 @@ async fn test_plaintext_exact_multiple_of_frame_length() {
     //# the Final Frame encrypted content length SHOULD be equal to the frame length but MAY be 0.
     let frame_length: u32 = 10;
     let pt = vec![0xEEu8; frame_length as usize];
-    let ct = encrypt_with_frame_length(&pt, frame_length).await;
+    let (ct, keyring) = encrypt_framed_shared(&pt, frame_length).await;
     let final_frame = parse_final_frame(&ct, frame_length);
     let Ok(final_content_len) = u32::try_from(final_frame.content.len()) else {
         panic!("final content length exceeds u32::MAX");
@@ -989,7 +1006,7 @@ async fn test_plaintext_exact_multiple_of_frame_length() {
         frame_length,
         final_content_len
     );
-    let result = round_trip_framed(&pt, frame_length).await;
+    let result = decrypt_with_keyring(&ct, keyring).await;
     assert_eq!(result, pt, "round-trip must succeed for exact multiple of frame length");
 }
 

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -224,24 +224,91 @@ async fn test_regular_frame_serialization_order() {
     //# IV,
     //# Encrypted Content,
     //# and Authentication Tag.
-    let pt = vec![0xCCu8; 20];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    let body_start = find_body_start(&ct, 10).expect("must find body");
-    // First regular frame at body_start: SeqNum(4) + IV(12) + Content(10) + Tag(16)
+    // Use frame_length=10 with 25 bytes of plaintext: produces 2 regular frames
+    // (10 bytes each) followed by 1 final frame (5 bytes). The first regular
+    // frame's tag MUST be immediately followed by the next regular frame's seq=2,
+    // proving Field 4's end offset is exactly 4 + IV_LEN + FRAME_LEN + TAG_LEN.
+    const FRAME_LEN: usize = 10;
+    let pt = vec![0xCCu8; 25];
+    let ct = encrypt_with_frame_length(&pt, FRAME_LEN as u32).await;
+    let body_start = find_body_start(&ct, FRAME_LEN as u32).expect("must find body");
+
+    // Field 1 of 4: Sequence Number — first 4 bytes, UInt32 BE = 1.
+    let seq_off = body_start;
     let seq = u32::from_be_bytes([
-        ct[body_start],
-        ct[body_start + 1],
-        ct[body_start + 2],
-        ct[body_start + 3],
+        ct[seq_off],
+        ct[seq_off + 1],
+        ct[seq_off + 2],
+        ct[seq_off + 3],
     ]);
-    assert_eq!(seq, 1, "first field is sequence number");
-    // IV follows at body_start+4, content at body_start+16, tag at body_start+26
-    // Verify by successful round-trip (wrong order would fail decryption)
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves regular frame serialization order is correct"
+    assert_eq!(seq, 1, "Field 1: sequence number must be 1 for first regular frame");
+
+    // Field 2 of 4: IV — exactly IV_LEN (12) bytes immediately after seq num.
+    let iv_off = seq_off + 4;
+    let iv = &ct[iv_off..iv_off + IV_LEN];
+    assert_eq!(iv.len(), IV_LEN, "Field 2: IV must be exactly IV_LEN bytes");
+    // Sanity: a real AES-GCM IV is not all zeros.
+    assert!(
+        iv.iter().any(|&b| b != 0),
+        "Field 2: IV must not be all zeros (real AES-GCM IV)"
     );
+
+    // Field 3 of 4: Encrypted Content — exactly FRAME_LEN bytes immediately after IV
+    // (regular frame: encrypted content length equals frame length).
+    let content_off = iv_off + IV_LEN;
+    let content = &ct[content_off..content_off + FRAME_LEN];
+    assert_eq!(
+        content.len(),
+        FRAME_LEN,
+        "Field 3: regular frame encrypted content length must equal frame length"
+    );
+    // Sanity: encrypted content must NOT equal the plaintext input (proves encryption happened).
+    assert_ne!(
+        content,
+        &pt[..FRAME_LEN],
+        "Field 3: encrypted content must differ from plaintext"
+    );
+
+    // Field 4 of 4: Authentication Tag — exactly TAG_LEN (16) bytes immediately after content.
+    let tag_off = content_off + FRAME_LEN;
+    let tag = &ct[tag_off..tag_off + TAG_LEN];
+    assert_eq!(tag.len(), TAG_LEN, "Field 4: auth tag must be exactly TAG_LEN bytes");
+    // Sanity: a real AES-GCM tag is not all zeros.
+    assert!(
+        tag.iter().any(|&b| b != 0),
+        "Field 4: auth tag must not be all zeros (real AES-GCM output)"
+    );
+
+    // Boundary check: the byte immediately after the tag must be the next frame's
+    // seq num (= 2). This proves Field 4 ends at the spec-required offset and the
+    // four fields together occupy exactly 4 + IV_LEN + FRAME_LEN + TAG_LEN bytes.
+    let next_frame_off = tag_off + TAG_LEN;
+    let next_seq = u32::from_be_bytes([
+        ct[next_frame_off],
+        ct[next_frame_off + 1],
+        ct[next_frame_off + 2],
+        ct[next_frame_off + 3],
+    ]);
+    assert_eq!(
+        next_seq, 2,
+        "boundary: byte immediately after the regular frame must be the next frame's seq=2"
+    );
+
+    // Cross-check the manual walk against the independent parser.
+    let frames = parse_frames(&ct, FRAME_LEN as u32);
+    assert_eq!(frames.len(), 3, "expected 2 regular + 1 final frame for pt=25, frame_length=10");
+    assert_eq!(frames[0].0, 1, "parser-reported seq num matches manual walk");
+    assert_eq!(frames[0].1.as_slice(), iv, "parser-reported IV matches manual walk");
+    assert_eq!(
+        frames[0].2.as_slice(),
+        content,
+        "parser-reported encrypted content matches manual walk"
+    );
+    assert_eq!(frames[0].3.as_slice(), tag, "parser-reported tag matches manual walk");
+
+    // Round-trip cross-check: independent decrypt validates the whole frame.
+    let result = round_trip_framed(&pt, FRAME_LEN as u32).await;
+    assert_eq!(result, pt, "round-trip corroborates regular frame serialization order");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -228,86 +228,51 @@ async fn test_regular_frame_serialization_order() {
     // (10 bytes each) followed by 1 final frame (5 bytes). The first regular
     // frame's tag MUST be immediately followed by the next regular frame's seq=2,
     // proving Field 4's end offset is exactly 4 + IV_LEN + FRAME_LEN + TAG_LEN.
-    const FRAME_LEN: usize = 10;
+    const FRAME_LEN: u32 = 10;
     let pt = vec![0xCCu8; 25];
-    let ct = encrypt_with_frame_length(&pt, FRAME_LEN as u32).await;
-    let body_start = find_body_start(&ct, FRAME_LEN as u32).expect("must find body");
+    let ct = encrypt_with_frame_length(&pt, FRAME_LEN).await;
+    let frames = parse_all_frames(&ct, FRAME_LEN);
+    assert_eq!(frames.len(), 3, "expected 2 regular + 1 final frame");
+    let f = &frames[0];
+    assert!(!f.is_final, "first frame must be regular");
 
     // Field 1 of 4: Sequence Number — first 4 bytes, UInt32 BE = 1.
-    let seq_off = body_start;
-    let seq = u32::from_be_bytes([
-        ct[seq_off],
-        ct[seq_off + 1],
-        ct[seq_off + 2],
-        ct[seq_off + 3],
-    ]);
-    assert_eq!(seq, 1, "Field 1: sequence number must be 1 for first regular frame");
+    assert_eq!(f.seq_num, 1, "Field 1: sequence number must be 1 for first regular frame");
+    assert_eq!(f.seq_num_bytes, &[0x00, 0x00, 0x00, 0x01], "Field 1: BE encoding of seq=1");
 
     // Field 2 of 4: IV — exactly IV_LEN (12) bytes immediately after seq num.
-    let iv_off = seq_off + 4;
-    let iv = &ct[iv_off..iv_off + IV_LEN];
-    assert_eq!(iv.len(), IV_LEN, "Field 2: IV must be exactly IV_LEN bytes");
-    // Sanity: a real AES-GCM IV is not all zeros.
-    assert!(
-        iv.iter().any(|&b| b != 0),
-        "Field 2: IV must not be all zeros (real AES-GCM IV)"
-    );
+    assert_eq!(f.iv.len(), IV_LEN, "Field 2: IV must be exactly IV_LEN bytes");
+    assert_eq!(f.iv_offset, f.seq_num_offset + 4, "Field 2 must immediately follow Field 1");
+    assert!(f.iv.iter().any(|&b| b != 0),
+        "Field 2: IV must not be all zeros (real AES-GCM IV)");
 
-    // Field 3 of 4: Encrypted Content — exactly FRAME_LEN bytes immediately after IV
-    // (regular frame: encrypted content length equals frame length).
-    let content_off = iv_off + IV_LEN;
-    let content = &ct[content_off..content_off + FRAME_LEN];
-    assert_eq!(
-        content.len(),
-        FRAME_LEN,
-        "Field 3: regular frame encrypted content length must equal frame length"
-    );
-    // Sanity: encrypted content must NOT equal the plaintext input (proves encryption happened).
-    assert_ne!(
-        content,
-        &pt[..FRAME_LEN],
-        "Field 3: encrypted content must differ from plaintext"
-    );
+    // Field 3 of 4: Encrypted Content — exactly FRAME_LEN bytes immediately after IV.
+    assert_eq!(f.content.len(), FRAME_LEN as usize,
+        "Field 3: regular frame encrypted content length must equal frame length");
+    assert_eq!(f.content_offset, f.iv_offset + IV_LEN, "Field 3 must immediately follow Field 2");
+    assert_ne!(f.content, &pt[..FRAME_LEN as usize],
+        "Field 3: encrypted content must differ from plaintext");
 
-    // Field 4 of 4: Authentication Tag — exactly TAG_LEN (16) bytes immediately after content.
-    let tag_off = content_off + FRAME_LEN;
-    let tag = &ct[tag_off..tag_off + TAG_LEN];
-    assert_eq!(tag.len(), TAG_LEN, "Field 4: auth tag must be exactly TAG_LEN bytes");
-    // Sanity: a real AES-GCM tag is not all zeros.
-    assert!(
-        tag.iter().any(|&b| b != 0),
-        "Field 4: auth tag must not be all zeros (real AES-GCM output)"
-    );
+    // Field 4 of 4: Authentication Tag — exactly TAG_LEN bytes immediately after content.
+    assert_eq!(f.tag.len(), TAG_LEN, "Field 4: auth tag must be exactly TAG_LEN bytes");
+    assert_eq!(f.tag_offset, f.content_offset + FRAME_LEN as usize,
+        "Field 4 must immediately follow Field 3");
+    assert!(f.tag.iter().any(|&b| b != 0),
+        "Field 4: auth tag must not be all zeros (real AES-GCM output)");
 
-    // Boundary check: the byte immediately after the tag must be the next frame's
-    // seq num (= 2). This proves Field 4 ends at the spec-required offset and the
-    // four fields together occupy exactly 4 + IV_LEN + FRAME_LEN + TAG_LEN bytes.
-    let next_frame_off = tag_off + TAG_LEN;
-    let next_seq = u32::from_be_bytes([
-        ct[next_frame_off],
-        ct[next_frame_off + 1],
-        ct[next_frame_off + 2],
-        ct[next_frame_off + 3],
-    ]);
-    assert_eq!(
-        next_seq, 2,
-        "boundary: byte immediately after the regular frame must be the next frame's seq=2"
-    );
+    // Boundary: end_offset must equal frame_offset + 4 + IV_LEN + FRAME_LEN + TAG_LEN.
+    let expected_total = 4 + IV_LEN + FRAME_LEN as usize + TAG_LEN;
+    assert_eq!(f.end_offset, f.frame_offset + expected_total,
+        "regular frame must occupy exactly {} bytes", expected_total);
 
-    // Cross-check the manual walk against the independent parser.
-    let frames = parse_frames(&ct, FRAME_LEN as u32);
-    assert_eq!(frames.len(), 3, "expected 2 regular + 1 final frame for pt=25, frame_length=10");
-    assert_eq!(frames[0].0, 1, "parser-reported seq num matches manual walk");
-    assert_eq!(frames[0].1.as_slice(), iv, "parser-reported IV matches manual walk");
-    assert_eq!(
-        frames[0].2.as_slice(),
-        content,
-        "parser-reported encrypted content matches manual walk"
-    );
-    assert_eq!(frames[0].3.as_slice(), tag, "parser-reported tag matches manual walk");
+    // Boundary: the next frame must begin at frame[0].end_offset with seq=2.
+    assert_eq!(frames[1].frame_offset, f.end_offset,
+        "next frame must begin immediately after the previous frame's tag");
+    assert_eq!(frames[1].seq_num, 2,
+        "next regular frame's seq must be 2 (proves Field 4 ends at the spec-required offset)");
 
-    // Round-trip cross-check: independent decrypt validates the whole frame.
-    let result = round_trip_framed(&pt, FRAME_LEN as u32).await;
+    // Round-trip cross-check.
+    let result = round_trip_framed(&pt, FRAME_LEN).await;
     assert_eq!(result, pt, "round-trip corroborates regular frame serialization order");
 }
 
@@ -350,30 +315,24 @@ async fn test_regular_frame_sequence_number_uint32_4_bytes_be() {
     //# The sequence number MUST be interpreted as a UInt32.
     let pt = vec![0xFFu8; 20];
     let ct = encrypt_with_frame_length(&pt, 10).await;
-    let body_start = find_body_start(&ct, 10).expect("must find body");
+    let f = &parse_all_frames(&ct, 10)[0];
+    assert!(!f.is_final, "first frame must be regular");
 
     // Per rust-conventions: prove byte-order by asserting individual bytes,
     // not just the decoded value. For seq=1 on the wire:
     //   big-endian:    [0x00, 0x00, 0x00, 0x01]  → decodes to 1
     //   little-endian: [0x01, 0x00, 0x00, 0x00]  → also decodes to 1 via from_le_bytes
     // The decoded value alone can't distinguish the two; the byte pattern can.
-    assert_eq!(ct[body_start], 0x00, "seq num byte 0 must be 0x00 for big-endian UInt32 = 1");
-    assert_eq!(ct[body_start + 1], 0x00, "seq num byte 1 must be 0x00 for big-endian UInt32 = 1");
-    assert_eq!(ct[body_start + 2], 0x00, "seq num byte 2 must be 0x00 for big-endian UInt32 = 1");
-    assert_eq!(ct[body_start + 3], 0x01, "seq num byte 3 must be 0x01 for big-endian UInt32 = 1");
+    assert_eq!(f.seq_num_bytes[0], 0x00, "seq num byte 0 must be 0x00 for big-endian UInt32 = 1");
+    assert_eq!(f.seq_num_bytes[1], 0x00, "seq num byte 1 must be 0x00 for big-endian UInt32 = 1");
+    assert_eq!(f.seq_num_bytes[2], 0x00, "seq num byte 2 must be 0x00 for big-endian UInt32 = 1");
+    assert_eq!(f.seq_num_bytes[3], 0x01, "seq num byte 3 must be 0x01 for big-endian UInt32 = 1");
+    assert_eq!(f.seq_num, 1, "decoded UInt32 BE seq num must equal 1");
 
-    // Decode as big-endian UInt32 to corroborate (decoded value alone isn't proof
-    // of byte order; the per-byte assertions above are).
-    let seq = u32::from_be_bytes([
-        ct[body_start],
-        ct[body_start + 1],
-        ct[body_start + 2],
-        ct[body_start + 3],
-    ]);
-    assert_eq!(seq, 1, "decoded UInt32 BE seq num must equal 1");
-
-    // The 4-byte field width is corroborated by test_regular_frame_serialization_order,
-    // which proves the IV begins at body_start + 4 (the field ends where the next begins).
+    // 4-byte field width: the parser computes iv_offset = seq_num_offset + 4, so the
+    // boundary between Field 1 (seq num) and Field 2 (IV) is at seq_num_offset + 4.
+    assert_eq!(f.iv_offset - f.seq_num_offset, 4,
+        "seq num field must span exactly 4 bytes (Field 1 ends where Field 2 begins)");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -490,21 +449,57 @@ async fn test_final_frame_serialization_order() {
     //# Encrypted Content Length,
     //# Encrypted Content,
     //# and Authentication Tag.
-    let pt = vec![0xAAu8; 7];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    // Find ENDFRAME marker — that's the start of the final frame
-    let pos = ct
-        .windows(4)
-        .position(|w| w == ENDFRAME_MARKER)
-        .expect("must find ENDFRAME");
-    // Verify field order: ENDFRAME(4) + SeqNum(4) + IV(12) + ContentLen(4) + Content(7) + Tag(16)
-    let expected_total = 4 + 4 + IV_LEN + 4 + 7 + TAG_LEN;
-    assert!(
-        pos + expected_total <= ct.len(),
-        "final frame must have all fields in order"
+    const FRAME_LEN: u32 = 10;
+    const PT_LEN: usize = 7;
+    let pt = vec![0xAAu8; PT_LEN];
+    let ct = encrypt_with_frame_length(&pt, FRAME_LEN).await;
+    let f = parse_final_frame(&ct, FRAME_LEN);
+
+    // Field 1 of 6: Sequence Number End — 4 bytes equal to 0xFF FF FF FF.
+    assert_eq!(
+        f.endframe_marker_bytes.expect("final frame has marker"),
+        &[0xFF, 0xFF, 0xFF, 0xFF],
+        "Field 1: sequence number end must be 0xFFFFFFFF"
     );
-    // Verify round-trip to confirm correct serialization
-    let result = round_trip_framed(&pt, 10).await;
+
+    // Field 2 of 6: Sequence Number — UInt32 BE; with PT_LEN < FRAME_LEN there is exactly
+    // one frame, so seq_num = total frame count = 1.
+    assert_eq!(f.seq_num_bytes, &[0x00, 0x00, 0x00, 0x01], "Field 2: seq num bytes BE");
+    assert_eq!(f.seq_num, 1, "Field 2: decoded seq num");
+    assert_eq!(f.seq_num_offset, f.endframe_marker_offset.unwrap() + 4,
+        "Field 2 must immediately follow Field 1");
+
+    // Field 3 of 6: IV — exactly IV_LEN bytes immediately after seq num.
+    assert_eq!(f.iv.len(), IV_LEN, "Field 3: IV length");
+    assert_eq!(f.iv_offset, f.seq_num_offset + 4, "Field 3 must immediately follow Field 2");
+    assert!(f.iv.iter().any(|&b| b != 0), "Field 3: IV must not be all zeros (real AES-GCM IV)");
+
+    // Field 4 of 6: Encrypted Content Length — UInt32 BE = PT_LEN.
+    let cl_bytes = f.content_length_bytes.expect("final frame has content length");
+    assert_eq!(cl_bytes, &[0x00, 0x00, 0x00, PT_LEN as u8],
+        "Field 4: content length bytes BE for PT_LEN={}", PT_LEN);
+    assert_eq!(f.content_length, PT_LEN as u32, "Field 4: decoded content length");
+    assert_eq!(f.content_length_offset.unwrap(), f.iv_offset + IV_LEN,
+        "Field 4 must immediately follow Field 3");
+
+    // Field 5 of 6: Encrypted Content — exactly content_length bytes; must NOT equal plaintext.
+    assert_eq!(f.content.len(), PT_LEN, "Field 5: content length matches Field 4 value");
+    assert_eq!(f.content_offset, f.content_length_offset.unwrap() + 4,
+        "Field 5 must immediately follow Field 4");
+    assert_ne!(f.content, &pt[..], "Field 5: encrypted content must differ from plaintext");
+
+    // Field 6 of 6: Authentication Tag — exactly TAG_LEN bytes; must not be all zeros.
+    assert_eq!(f.tag.len(), TAG_LEN, "Field 6: tag length");
+    assert_eq!(f.tag_offset, f.content_offset + PT_LEN, "Field 6 must immediately follow Field 5");
+    assert!(f.tag.iter().any(|&b| b != 0), "Field 6: tag must not be all zeros (real AES-GCM tag)");
+
+    // Boundary: end_offset must equal frame_offset + ENDFRAME(4) + SeqNum(4) + IV + ContentLen(4) + Content + Tag.
+    let expected_total = 4 + 4 + IV_LEN + 4 + PT_LEN + TAG_LEN;
+    assert_eq!(f.end_offset, f.frame_offset + expected_total,
+        "final frame must occupy exactly {} bytes", expected_total);
+
+    // Round-trip cross-check.
+    let result = round_trip_framed(&pt, FRAME_LEN).await;
     assert_eq!(result, pt);
 }
 
@@ -515,25 +510,25 @@ async fn test_final_frame_is_regular_frame_plus_additions() {
     //# A final frame MUST only differ from a regular frame by the addition of the
     //# Sequence Number End
     //# and Encrypted Content Length.
+    const FRAME_LEN: u32 = 10;
     let pt = vec![0xBBu8; 5];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    let pos = ct
-        .windows(4)
-        .position(|w| w == ENDFRAME_MARKER)
-        .expect("must find ENDFRAME");
-    // Final frame has Sequence Number End (extra vs regular) at pos
+    let ct = encrypt_with_frame_length(&pt, FRAME_LEN).await;
+    let f = parse_final_frame(&ct, FRAME_LEN);
+
+    // The two ADDITIONS over a regular frame:
+    //   1. Sequence Number End at the very start of the final frame.
     assert_eq!(
-        &ct[pos..pos + 4],
+        f.endframe_marker_bytes.expect("final frame has marker"),
         &ENDFRAME_MARKER,
         "final frame starts with Sequence Number End"
     );
-    // Then SeqNum(4) + IV(12) + ContentLen(4, extra vs regular) + Content + Tag
-    let content_len = u32::from_be_bytes([ct[pos + 20], ct[pos + 21], ct[pos + 22], ct[pos + 23]]);
-    assert!(
-        content_len <= 10,
-        "final frame has Encrypted Content Length field"
-    );
-    let result = round_trip_framed(&pt, 10).await;
+    //   2. Encrypted Content Length between the IV and the encrypted content.
+    let cl = f.content_length;
+    assert!(cl <= FRAME_LEN, "final frame Encrypted Content Length must be <= frame length");
+    assert!(f.content_length_offset.is_some(),
+        "final frame must have an Encrypted Content Length offset");
+
+    let result = round_trip_framed(&pt, FRAME_LEN).await;
     assert_eq!(result, pt);
 }
 
@@ -546,18 +541,15 @@ async fn test_sequence_number_end_value() {
     //= spec/data-format/message-body.md#sequence-number-end
     //= type=test
     //# The sequence number end MUST be interpreted as bytes.
-    let pt = b"test";
-    let ct = encrypt_with_frame_length(pt, 4096).await;
-    let pos = ct
-        .windows(4)
-        .position(|w| w == ENDFRAME_MARKER)
-        .expect("must find ENDFRAME");
-    // The four on-wire bytes ARE the marker — checking each byte literally
-    // proves the field is encoded as bytes AND has the spec-required value.
-    assert_eq!(ct[pos], 0xFF);
-    assert_eq!(ct[pos + 1], 0xFF);
-    assert_eq!(ct[pos + 2], 0xFF);
-    assert_eq!(ct[pos + 3], 0xFF);
+    let ct = encrypt_with_frame_length(b"test", 4096).await;
+    let f = parse_final_frame(&ct, 4096);
+    let bytes = f.endframe_marker_bytes.expect("final frame has marker");
+    // Per-byte assertion: the four on-wire bytes ARE the marker — checking each
+    // byte literally proves the field is encoded as bytes AND has the spec-required value.
+    assert_eq!(bytes[0], 0xFF);
+    assert_eq!(bytes[1], 0xFF);
+    assert_eq!(bytes[2], 0xFF);
+    assert_eq!(bytes[3], 0xFF);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -565,17 +557,19 @@ async fn test_sequence_number_end_4_bytes() {
     //= spec/data-format/message-body.md#sequence-number-end
     //= type=test
     //# The length of the sequence number end field MUST be 4 bytes.
-    let pt = b"test";
-    let ct = encrypt_with_frame_length(pt, 4096).await;
-    // The ENDFRAME marker is exactly 4 bytes: FF FF FF FF
-    let pos = ct
-        .windows(4)
-        .position(|w| w == ENDFRAME_MARKER)
-        .expect("must find ENDFRAME");
+    let ct = encrypt_with_frame_length(b"test", 4096).await;
+    let f = parse_final_frame(&ct, 4096);
+    // The marker spans exactly [endframe_marker_offset .. seq_num_offset], which the
+    // parser computes as 4 bytes — corroborated here by the on-wire boundary.
     assert_eq!(
-        &ct[pos..pos + 4],
+        f.seq_num_offset - f.endframe_marker_offset.unwrap(),
+        4,
+        "sequence number end must be exactly 4 bytes (Field 1 ends where Field 2 begins)"
+    );
+    assert_eq!(
+        f.endframe_marker_bytes.expect("final frame has marker"),
         &[0xFF, 0xFF, 0xFF, 0xFF],
-        "sequence number end is exactly 4 bytes"
+        "sequence number end bytes"
     );
 }
 
@@ -602,19 +596,22 @@ async fn test_final_frame_sequence_number_serialized_same_as_regular() {
     //= type=test
     //# The length of the Final Frame Sequence number field MUST be the same as the
     //# [Regular Frame Sequence Number](#regular-frame-sequence-number).
+    const FRAME_LEN: u32 = 10;
     let pt = vec![0xBBu8; 20];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    let pos = ct
-        .windows(4)
-        .position(|w| w == ENDFRAME_MARKER)
-        .expect("must find ENDFRAME");
-    // Final frame seq num is at pos+4, serialized as 4-byte big-endian UInt32 (same as regular)
-    let final_seq = u32::from_be_bytes([ct[pos + 4], ct[pos + 5], ct[pos + 6], ct[pos + 7]]);
-    assert!(
-        final_seq > 0,
-        "final frame sequence number is a valid UInt32"
+    let ct = encrypt_with_frame_length(&pt, FRAME_LEN).await;
+    let frames = parse_all_frames(&ct, FRAME_LEN);
+
+    // Find a regular frame and the final frame; their seq num field widths must match.
+    let regular = frames.iter().find(|f| !f.is_final).expect("must have a regular frame");
+    let final_f = frames.iter().find(|f| f.is_final).expect("must have a final frame");
+    assert_eq!(
+        regular.seq_num_bytes.len(),
+        final_f.seq_num_bytes.len(),
+        "final frame seq num field width must equal regular frame seq num field width"
     );
-    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(regular.seq_num_bytes.len(), 4, "seq num field width must be 4 bytes");
+
+    let result = round_trip_framed(&pt, FRAME_LEN).await;
     assert_eq!(
         result, pt,
         "round-trip proves final frame seq num serialized same as regular"
@@ -696,41 +693,39 @@ async fn test_final_frame_fields_interpreted_as_bytes() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_final_frame_encrypted_content_length_4_bytes() {
+async fn test_final_frame_encrypted_content_length_uint32_4_bytes_be() {
     //= spec/data-format/message-body.md#final-frame-encrypted-content-length
     //= type=test
     //# The length of the serialized encrypted content length field MUST be 4 bytes.
-    let pt = vec![0xAAu8; 7];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    let pos = ct
-        .windows(4)
-        .position(|w| w == ENDFRAME_MARKER)
-        .expect("must find ENDFRAME");
-    // Content length field is at pos+20 (ENDFRAME(4)+SeqNum(4)+IV(12)), exactly 4 bytes
-    let content_len_bytes = &ct[pos + 20..pos + 24];
-    assert_eq!(
-        content_len_bytes.len(),
-        4,
-        "encrypted content length field must be exactly 4 bytes"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_final_frame_encrypted_content_length_uint32() {
+    //
     //= spec/data-format/message-body.md#final-frame-encrypted-content-length
     //= type=test
     //# The encrypted content length MUST be a UInt32.
-    let pt = vec![0xBBu8; 7];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    let pos = ct
-        .windows(4)
-        .position(|w| w == ENDFRAME_MARKER)
-        .expect("must find ENDFRAME");
-    let content_len = u32::from_be_bytes([ct[pos + 20], ct[pos + 21], ct[pos + 22], ct[pos + 23]]);
+    const FRAME_LEN: u32 = 10;
+    const PT_LEN: u8 = 7;
+    let pt = vec![0xAAu8; PT_LEN as usize];
+    let ct = encrypt_with_frame_length(&pt, FRAME_LEN).await;
+    let f = parse_final_frame(&ct, FRAME_LEN);
+
+    let cl_bytes = f.content_length_bytes.expect("final frame has content length");
+
+    // Per rust-conventions: prove byte-order via individual bytes, not via decoded
+    // value alone (PT_LEN=7 could decode to 7 from LE [0x07, 0x00, 0x00, 0x00] too).
+    assert_eq!(cl_bytes[0], 0x00, "content length byte 0 must be 0x00 for BE UInt32 = 7");
+    assert_eq!(cl_bytes[1], 0x00, "content length byte 1 must be 0x00 for BE UInt32 = 7");
+    assert_eq!(cl_bytes[2], 0x00, "content length byte 2 must be 0x00 for BE UInt32 = 7");
+    assert_eq!(cl_bytes[3], PT_LEN, "content length byte 3 must be PT_LEN for BE UInt32 = 7");
+
+    // 4-byte width: the field spans [content_length_offset .. content_offset], which
+    // the parser computes as exactly 4 bytes — corroborated by the on-wire boundary.
     assert_eq!(
-        content_len, 7,
-        "encrypted content length serialized as UInt32 must equal 7"
+        f.content_offset - f.content_length_offset.unwrap(),
+        4,
+        "content length field must span exactly 4 bytes (Field 4 ends where Field 5 begins)"
     );
+
+    // Decoded value corroboration.
+    assert_eq!(f.content_length, PT_LEN as u32, "decoded BE UInt32 content length");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -779,20 +774,10 @@ async fn test_final_frame_auth_tag_authenticates_final_frame() {
 
     // Tampering with the final frame's auth tag must cause decryption failure.
     let ct = encrypt_with_frame_length(&pt, 10).await;
-    let frames = parse_frames(&ct, 10);
-    let final_frame = frames.last().unwrap();
-    assert!(final_frame.4, "must be final frame");
+    let final_frame = parse_final_frame(&ct, 10);
 
-    let body_start = find_body_start(&ct, 10).unwrap();
-    // Walk to the final frame's auth tag position
-    let mut pos = body_start;
-    for f in &frames[..frames.len() - 1] {
-        pos += 4 + IV_LEN + f.2.len() + TAG_LEN; // regular frame
-    }
-    // Final frame: ENDFRAME(4) + SeqNum(4) + IV(12) + ContentLen(4) + Content(N) + Tag(16)
-    let tag_offset = pos + 4 + 4 + IV_LEN + 4 + final_frame.2.len();
     let mut tampered = ct.clone();
-    tampered[tag_offset] ^= 0xFF;
+    tampered[final_frame.tag_offset] ^= 0xFF;
 
     let keyring = test_keyring().await;
     let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
@@ -883,13 +868,12 @@ async fn test_v1_sequence_number_end_value() {
     //= spec/data-format/message-body.md#sequence-number-end
     //= type=test
     //# The value MUST be encoded as the 4 bytes `FF FF FF FF` in hexadecimal notation.
-    let pt = b"v1 test";
-    let ct = encrypt_v1_with_frame_length(pt, 4096).await;
-    let pos = ct
-        .windows(4)
-        .position(|w| w == ENDFRAME_MARKER)
-        .expect("V1: must find ENDFRAME");
-    assert_eq!(&ct[pos..pos + 4], &[0xFF, 0xFF, 0xFF, 0xFF]);
+    let ct = encrypt_v1_with_frame_length(b"v1 test", 4096).await;
+    let f = parse_final_frame(&ct, 4096);
+    assert_eq!(
+        f.endframe_marker_bytes.expect("V1: final frame has marker"),
+        &[0xFF, 0xFF, 0xFF, 0xFF]
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -69,11 +69,22 @@ async fn test_nonframed_encrypted_content_length_uint64() {
     //= type=test
     //# The encrypted content length MUST be interpreted as a UInt64.
     let body = parse_nonframed_body(EXTERNAL_V2_NONFRAMED_CT);
+    let pt_len_u64 =
+        u64::try_from(EXTERNAL_V2_NONFRAMED_PT.len()).expect("plaintext length fits in u64");
     assert_eq!(
-        body.encrypted_content_length,
-        EXTERNAL_V2_NONFRAMED_PT.len() as u64,
-        "encrypted content length interpreted as UInt64 must equal plaintext length"
+        body.encrypted_content_length, pt_len_u64,
+        "decoded UInt64 BE content length must equal plaintext length"
     );
+
+    // Per-byte BE check on the on-wire 8-byte field. For pt_len = 10240 = 0x2800:
+    //   big-endian:    [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0x00]
+    //   little-endian: [0x00, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+    // The decoded value alone could match either if pt_len fits in one byte;
+    // the byte pattern distinguishes the two.
+    let expected = pt_len_u64.to_be_bytes();
+    let cl_bytes: &[u8] = &body.encrypted_content_length_bytes;
+    assert_eq!(cl_bytes, &expected,
+        "on-wire content length bytes must match the BE encoding of the plaintext length");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -140,10 +151,19 @@ async fn test_nonframed_encrypted_content_length_field_8_bytes() {
     //= type=test
     //# The length of the Encrypted Content Length field MUST be 8 bytes.
     let body = parse_nonframed_body(EXTERNAL_V2_NONFRAMED_CT);
+    // Read the field directly from the external vector at the offset where the
+    // parser places it (body_start + IV_LEN). The parser then reads the next
+    // `encrypted_content_length` bytes for the content. So the boundary between
+    // the length field and the content is at body_start + IV_LEN + 8 — proving
+    // the field spans exactly 8 bytes on the wire.
+    let length_field_offset = body.body_start + IV_LEN;
+    let pt_len_u64 =
+        u64::try_from(EXTERNAL_V2_NONFRAMED_PT.len()).expect("plaintext length fits in u64");
+    let on_wire_bytes = &EXTERNAL_V2_NONFRAMED_CT[length_field_offset..length_field_offset + 8];
     assert_eq!(
-        body.encrypted_content_length_bytes.len(),
-        8,
-        "encrypted content length field must be exactly 8 bytes"
+        on_wire_bytes,
+        &pt_len_u64.to_be_bytes(),
+        "on-wire content length field at offset {length_field_offset} must be the 8-byte BE encoding of {pt_len_u64}"
     );
 }
 
@@ -152,11 +172,29 @@ async fn test_nonframed_encrypted_content_length_matches_content() {
     //= spec/data-format/message-body.md#nonframed-data-encrypted-content
     //= type=test
     //# The length of the serialized encrypted content field MUST be equal to the value of the [Encrypted Content Length](#nonframed-data-encrypted-content-length) field.
+    // Read the on-wire content-length field bytes directly from the external vector
+    // (independent of the parser's slicing), decode as BE UInt64, then compute the
+    // span of the on-wire content slice from offsets and assert they match.
     let body = parse_nonframed_body(EXTERNAL_V2_NONFRAMED_CT);
+    let length_field_offset = body.body_start + IV_LEN;
+    let on_wire_length_bytes: [u8; 8] = EXTERNAL_V2_NONFRAMED_CT
+        [length_field_offset..length_field_offset + 8]
+        .try_into()
+        .expect("8 bytes");
+    let on_wire_length = u64::from_be_bytes(on_wire_length_bytes);
+
+    // Content slice starts immediately after the 8-byte length field and ends
+    // immediately before the auth tag. Compute its span from offsets:
+    //   content_start = body_start + IV_LEN + 8
+    //   content_end   = total_len - TAG_LEN
+    let content_start = length_field_offset + 8;
+    let content_end = EXTERNAL_V2_NONFRAMED_CT.len() - TAG_LEN;
+    let on_wire_content_len = u64::try_from(content_end - content_start)
+        .expect("content length fits in u64");
+
     assert_eq!(
-        body.encrypted_content.len(),
-        body.encrypted_content_length as usize,
-        "encrypted content byte count must equal the content length field value"
+        on_wire_content_len, on_wire_length,
+        "on-wire content slice length must equal the value of the on-wire content-length field"
     );
 }
 

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -65,14 +65,25 @@ async fn test_nonframed_iv_length() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_nonframed_iv_interpreted_as_bytes() {
+async fn test_nonframed_fields_interpreted_as_bytes() {
     //= spec/data-format/message-body.md#nonframed-data-iv
     //= type=test
     //# The IV MUST be interpreted as bytes.
+    //
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content
+    //= type=test
+    //# The encrypted content value MUST be interpreted as bytes.
+    //
+    //= spec/data-format/message-body.md#nonframed-data-authentication-tag
+    //= type=test
+    //# The authentication tag value MUST be interpreted as bytes.
+    // All three fields are byte-typed in the parser; a successful decrypt of the
+    // external nonframed vector proves each one is consumed as bytes (any other
+    // interpretation would corrupt the AES-GCM inputs and fail the auth tag check).
     let result = decrypt_external_nonframed_vector(Version::V2).await;
     assert_eq!(
         result, EXTERNAL_V2_NONFRAMED_PT,
-        "decrypt output did not match expected plaintext — nonframed IV was not interpreted as bytes"
+        "decrypt output did not match expected plaintext — nonframed IV/encrypted content/auth tag must be interpreted as bytes"
     );
 }
 
@@ -132,18 +143,6 @@ async fn test_nonframed_encrypted_content_length_matches_content() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_nonframed_encrypted_content_interpreted_as_bytes() {
-    //= spec/data-format/message-body.md#nonframed-data-encrypted-content
-    //= type=test
-    //# The encrypted content value MUST be interpreted as bytes.
-    let result = decrypt_external_nonframed_vector(Version::V2).await;
-    assert_eq!(
-        result, EXTERNAL_V2_NONFRAMED_PT,
-        "decrypt output did not match expected plaintext — nonframed encrypted content was not interpreted as bytes"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_nonframed_auth_tag_length() {
     //= spec/data-format/message-body.md#nonframed-data-authentication-tag
     //= type=test
@@ -153,18 +152,6 @@ async fn test_nonframed_auth_tag_length() {
         body.auth_tag.len(),
         TAG_LEN,
         "nonframed auth tag length must equal algorithm suite tag length (16)"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_nonframed_auth_tag_interpreted_as_bytes() {
-    //= spec/data-format/message-body.md#nonframed-data-authentication-tag
-    //= type=test
-    //# The authentication tag value MUST be interpreted as bytes.
-    let result = decrypt_external_nonframed_vector(Version::V2).await;
-    assert_eq!(
-        result, EXTERNAL_V2_NONFRAMED_PT,
-        "decrypt output did not match expected plaintext — nonframed auth tag was not interpreted as bytes"
     );
 }
 
@@ -313,16 +300,26 @@ async fn test_regular_frame_iv_length_matches_algorithm() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_regular_frame_iv_interpreted_as_bytes() {
+async fn test_regular_frame_fields_interpreted_as_bytes() {
     //= spec/data-format/message-body.md#regular-frame-iv
     //= type=test
     //# The IV MUST be interpreted as bytes.
-    // Round-trip proves the IV bytes are correctly interpreted during decrypt
+    //
+    //= spec/data-format/message-body.md#regular-frame-encrypted-content
+    //= type=test
+    //# The encrypted content MUST be interpreted as bytes.
+    //
+    //= spec/data-format/message-body.md#regular-frame-authentication-tag
+    //= type=test
+    //# The authentication tag MUST be interpreted as bytes.
+    // All three fields are byte-typed in the parser; a successful round-trip
+    // proves each one is consumed as bytes during decrypt (any other
+    // interpretation would corrupt the AES-GCM inputs and fail the auth tag check).
     let pt = vec![0xEEu8; 20];
     let result = round_trip_framed(&pt, 10).await;
     assert_eq!(
         result, pt,
-        "round-trip proves IV is correctly interpreted as bytes"
+        "round-trip proves regular-frame IV/encrypted content/auth tag are interpreted as bytes"
     );
 }
 
@@ -354,19 +351,6 @@ async fn test_regular_frame_encrypted_content_length_equals_frame_length() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_regular_frame_encrypted_content_interpreted_as_bytes() {
-    //= spec/data-format/message-body.md#regular-frame-encrypted-content
-    //= type=test
-    //# The encrypted content MUST be interpreted as bytes.
-    let pt = vec![0xAAu8; 20];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves encrypted content is interpreted as bytes"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_regular_frame_auth_tag_length_matches_algorithm() {
     //= spec/data-format/message-body.md#regular-frame-authentication-tag
     //= type=test
@@ -381,19 +365,6 @@ async fn test_regular_frame_auth_tag_length_matches_algorithm() {
             "auth tag length must match algorithm suite (16)"
         );
     }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_regular_frame_auth_tag_interpreted_as_bytes() {
-    //= spec/data-format/message-body.md#regular-frame-authentication-tag
-    //= type=test
-    //# The authentication tag MUST be interpreted as bytes.
-    let pt = vec![0xCCu8; 20];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves auth tag is interpreted as bytes"
-    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -459,12 +430,18 @@ async fn test_sequence_number_end_value() {
     //= spec/data-format/message-body.md#sequence-number-end
     //= type=test
     //# The value MUST be encoded as the 4 bytes `FF FF FF FF` in hexadecimal notation.
+    //
+    //= spec/data-format/message-body.md#sequence-number-end
+    //= type=test
+    //# The sequence number end MUST be interpreted as bytes.
     let pt = b"test";
     let ct = encrypt_with_frame_length(pt, 4096).await;
     let pos = ct
         .windows(4)
         .position(|w| w == ENDFRAME_MARKER)
         .expect("must find ENDFRAME");
+    // The four on-wire bytes ARE the marker — checking each byte literally
+    // proves the field is encoded as bytes AND has the spec-required value.
     assert_eq!(ct[pos], 0xFF);
     assert_eq!(ct[pos + 1], 0xFF);
     assert_eq!(ct[pos + 2], 0xFF);
@@ -487,20 +464,6 @@ async fn test_sequence_number_end_4_bytes() {
         &ct[pos..pos + 4],
         &[0xFF, 0xFF, 0xFF, 0xFF],
         "sequence number end is exactly 4 bytes"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_sequence_number_end_interpreted_as_bytes() {
-    //= spec/data-format/message-body.md#sequence-number-end
-    //= type=test
-    //# The sequence number end MUST be interpreted as bytes.
-    // Successful round-trip proves the decrypt path correctly interprets the ENDFRAME marker bytes
-    let pt = b"test seq end";
-    let result = round_trip_framed(pt, 4096).await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves sequence number end is interpreted as bytes"
     );
 }
 
@@ -597,15 +560,26 @@ async fn test_final_frame_iv_length_matches_algorithm() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_final_frame_iv_interpreted_as_bytes() {
+async fn test_final_frame_fields_interpreted_as_bytes() {
     //= spec/data-format/message-body.md#final-frame-iv
     //= type=test
     //# The IV MUST be interpreted as bytes.
+    //
+    //= spec/data-format/message-body.md#final-frame-encrypted-content
+    //= type=test
+    //# The encrypted content MUST be interpreted as bytes.
+    //
+    //= spec/data-format/message-body.md#final-frame-authentication-tag
+    //= type=test
+    //# The authentication tag MUST be interpreted as bytes.
+    // All three fields are byte-typed in the parser; a successful round-trip with
+    // a final-frame-only payload (pt < frame_length) proves each one is consumed
+    // as bytes (any other interpretation would corrupt AES-GCM and fail the auth tag).
     let pt = vec![0xFFu8; 5];
     let result = round_trip_framed(&pt, 10).await;
     assert_eq!(
         result, pt,
-        "round-trip proves final frame IV is interpreted as bytes"
+        "round-trip proves final-frame IV/encrypted content/auth tag are interpreted as bytes"
     );
 }
 
@@ -666,19 +640,6 @@ async fn test_final_frame_encrypted_content_length_matches() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_final_frame_encrypted_content_interpreted_as_bytes() {
-    //= spec/data-format/message-body.md#final-frame-encrypted-content
-    //= type=test
-    //# The encrypted content MUST be interpreted as bytes.
-    let pt = vec![0xEEu8; 5];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves final frame encrypted content is interpreted as bytes"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_final_frame_auth_tag_length_matches_algorithm() {
     //= spec/data-format/message-body.md#final-frame-authentication-tag
     //= type=test
@@ -692,19 +653,6 @@ async fn test_final_frame_auth_tag_length_matches_algorithm() {
         final_frame.3.len(),
         TAG_LEN,
         "final frame auth tag length must match algorithm suite (16)"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_final_frame_auth_tag_interpreted_as_bytes() {
-    //= spec/data-format/message-body.md#final-frame-authentication-tag
-    //= type=test
-    //# The authentication tag MUST be interpreted as bytes.
-    let pt = vec![0xAAu8; 5];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves final frame auth tag is interpreted as bytes"
     );
 }
 
@@ -754,14 +702,6 @@ async fn encrypt_v1_with_frame_length(plaintext: &[u8], frame_length: u32) -> Ve
     input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
     input.frame_length = FrameLength::new(frame_length).unwrap();
     encrypt(&input).await.unwrap().ciphertext
-}
-
-async fn round_trip_v1_framed(plaintext: &[u8], frame_length: u32) -> Vec<u8> {
-    let keyring = test_keyring().await;
-    let ct = encrypt_v1_with_frame_length(plaintext, frame_length).await;
-    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    decrypt(&dec_input).await.unwrap().plaintext
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -854,13 +794,6 @@ async fn test_v1_final_frame_sequence_number_equals_total_frames() {
         frames.len() as u32,
         "V1: final frame seq num must equal total frame count"
     );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_v1_round_trip_framed() {
-    let pt = vec![0xFFu8; 25];
-    let result = round_trip_v1_framed(&pt, 10).await;
-    assert_eq!(result, pt, "V1: round-trip proves regular frame serialization order");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -964,16 +897,42 @@ async fn test_message_begins_with_header() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_message_body_follows_header() {
-    // A successful round-trip decrypt proves the body follows the header,
-    // because the decryptor parses header then body in sequence.
-    let pt = b"body follows header test";
-    let result = round_trip_signing(pt).await;
     //= spec/data-format/message.md#structure
     //= type=test
-    //= reason=Round-trip decrypt proves body follows header: decrypt would fail if message ordering were incorrect.
     //# - The [Message Body](message-body.md) MUST follow the Message Header
-    assert_eq!(
-        result, pt,
-        "successful decrypt proves message body follows header in serialization order"
+    // Parse the on-wire header end offset for both versions and assert the bytes
+    // immediately after the header are the start of the body (frame seq=1, or the
+    // ENDFRAME marker if the only frame is a final frame).
+    let pt = b"body follows header test";
+
+    // V1: header body || IV(12) || Tag(16), then body starts.
+    let ct_v1 = encrypt_with_v1_signing_suite(pt).await;
+    let (_, _, _, frame_length_offset) = parse_v1_trailing_offsets(&ct_v1);
+    let body_start_v1 = frame_length_offset + 4 + IV_LEN + TAG_LEN;
+    let next_4_v1 = u32::from_be_bytes([
+        ct_v1[body_start_v1],
+        ct_v1[body_start_v1 + 1],
+        ct_v1[body_start_v1 + 2],
+        ct_v1[body_start_v1 + 3],
+    ]);
+    assert!(
+        next_4_v1 == 1 || next_4_v1 == 0xFFFF_FFFF,
+        "V1 body must start immediately after header with frame seq=1 or endframe marker, got {next_4_v1:#010X}"
+    );
+
+    // V2: header body || Tag(16), then body starts.
+    let ct_v2 = encrypt_with_signing_suite(pt).await;
+    let fields = parse_v2_header_field_offsets(&ct_v2);
+    let header_body_end = fields.last().expect("must have header fields").2;
+    let body_start_v2 = header_body_end + TAG_LEN;
+    let next_4_v2 = u32::from_be_bytes([
+        ct_v2[body_start_v2],
+        ct_v2[body_start_v2 + 1],
+        ct_v2[body_start_v2 + 2],
+        ct_v2[body_start_v2 + 3],
+    ]);
+    assert!(
+        next_4_v2 == 1 || next_4_v2 == 0xFFFF_FFFF,
+        "V2 body must start immediately after header with frame seq=1 or endframe marker, got {next_4_v2:#010X}"
     );
 }

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -1,5 +1,4 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tests for spec/data-format/message-body.md

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -64,29 +64,6 @@ async fn test_nonframed_iv_length() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_nonframed_fields_interpreted_as_bytes() {
-    //= spec/data-format/message-body.md#nonframed-data-iv
-    //= type=test
-    //# The IV MUST be interpreted as bytes.
-    //
-    //= spec/data-format/message-body.md#nonframed-data-encrypted-content
-    //= type=test
-    //# The encrypted content value MUST be interpreted as bytes.
-    //
-    //= spec/data-format/message-body.md#nonframed-data-authentication-tag
-    //= type=test
-    //# The authentication tag value MUST be interpreted as bytes.
-    // All three fields are byte-typed in the parser; a successful decrypt of the
-    // external nonframed vector proves each one is consumed as bytes (any other
-    // interpretation would corrupt the AES-GCM inputs and fail the auth tag check).
-    let result = decrypt_external_nonframed_vector(Version::V2).await;
-    assert_eq!(
-        result, EXTERNAL_V2_NONFRAMED_PT,
-        "decrypt output did not match expected plaintext — nonframed IV/encrypted content/auth tag must be interpreted as bytes"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_nonframed_encrypted_content_length_uint64() {
     //= spec/data-format/message-body.md#nonframed-data-encrypted-content-length
     //= type=test
@@ -374,30 +351,6 @@ async fn test_regular_frame_iv_length_matches_algorithm() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_regular_frame_fields_interpreted_as_bytes() {
-    //= spec/data-format/message-body.md#regular-frame-iv
-    //= type=test
-    //# The IV MUST be interpreted as bytes.
-    //
-    //= spec/data-format/message-body.md#regular-frame-encrypted-content
-    //= type=test
-    //# The encrypted content MUST be interpreted as bytes.
-    //
-    //= spec/data-format/message-body.md#regular-frame-authentication-tag
-    //= type=test
-    //# The authentication tag MUST be interpreted as bytes.
-    // All three fields are byte-typed in the parser; a successful round-trip
-    // proves each one is consumed as bytes during decrypt (any other
-    // interpretation would corrupt the AES-GCM inputs and fail the auth tag check).
-    let pt = vec![0xEEu8; 20];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves regular-frame IV/encrypted content/auth tag are interpreted as bytes"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_regular_frame_encrypted_content_length_equals_frame_length() {
     //= spec/data-format/message-body.md#regular-frame-encrypted-content
     //= type=test
@@ -658,30 +611,6 @@ async fn test_final_frame_iv_length_matches_algorithm() {
         final_frame.iv.len(),
         IV_LEN,
         "final frame IV length must match algorithm suite"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_final_frame_fields_interpreted_as_bytes() {
-    //= spec/data-format/message-body.md#final-frame-iv
-    //= type=test
-    //# The IV MUST be interpreted as bytes.
-    //
-    //= spec/data-format/message-body.md#final-frame-encrypted-content
-    //= type=test
-    //# The encrypted content MUST be interpreted as bytes.
-    //
-    //= spec/data-format/message-body.md#final-frame-authentication-tag
-    //= type=test
-    //# The authentication tag MUST be interpreted as bytes.
-    // All three fields are byte-typed in the parser; a successful round-trip with
-    // a final-frame-only payload (pt < frame_length) proves each one is consumed
-    // as bytes (any other interpretation would corrupt AES-GCM and fail the auth tag).
-    let pt = vec![0xFFu8; 5];
-    let result = round_trip_framed(&pt, 10).await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves final-frame IV/encrypted content/auth tag are interpreted as bytes"
     );
 }
 

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -7,29 +7,11 @@ mod fixtures;
 mod test_helpers;
 
 use aws_esdk::*;
-use aws_mpl_legacy::dafny::types::keyring::KeyringRef;
-
 use test_helpers::*;
 
 // The ESDK always uses framed encryption, so nonframed deserialization
 // is exercised by parsing/decrypting the external V2 nonframed vector from
 // aws-encryption-sdk-test-vectors.
-
-/// Encrypt with a shared keyring and frame length, returning (ct, keyring) for reuse in decrypt.
-async fn encrypt_framed_shared(pt: &[u8], frame_length: u32) -> (Vec<u8>, KeyringRef) {
-    let keyring = test_keyring().await;
-    let mut input =
-        EncryptInput::with_legacy_keyring(pt, EncryptionContext::new(), keyring.clone());
-    input.frame_length = FrameLength::new(frame_length).unwrap();
-    let ct = encrypt(&input).await.unwrap().ciphertext;
-    (ct, keyring)
-}
-
-/// Decrypt ct with a given keyring, returning plaintext.
-async fn decrypt_with_keyring(ct: &[u8], keyring: KeyringRef) -> Vec<u8> {
-    let dec_input = DecryptInput::with_legacy_keyring(ct, EncryptionContext::new(), keyring);
-    decrypt(&dec_input).await.unwrap().plaintext
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_nonframed_data_serialization_order() {
@@ -235,14 +217,15 @@ async fn test_framed_data_max_frame_count() {
     //= reason=The 2^32-1 boundary is unreachable in a unit test (would require ~4B frames). The implementation enforces it at body_encrypt.rs by checking sequence_number == ENDFRAME_SEQUENCE_NUMBER (0xFFFFFFFF) before writing each regular frame and returning ValidationError("Too many frames"). This test exercises a small frame count to confirm the multi-frame path works; the upper bound itself is enforced by source-side citation.
     //# - The number of frames in a single message MUST be less than or equal to `2^32 - 1`.
     let pt = vec![0xBBu8; 20];
-    let (ct, keyring) = encrypt_framed_shared(&pt, 4).await;
+    let keyring = test_keyring().await;
+    let ct = encrypt_framed_with_keyring(&pt, 4, &keyring).await;
     let frames = parse_all_frames(&ct, 4);
     assert_eq!(
         frames.len(),
         5,
         "20 bytes / 4-byte frames = 4 regular + 1 final = 5 frames"
     );
-    let result = decrypt_with_keyring(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt);
 }
 
@@ -261,7 +244,8 @@ async fn test_regular_frame_serialization_order() {
     // proving Field 4's end offset is exactly 4 + IV_LEN + FRAME_LEN + TAG_LEN.
     const FRAME_LEN: u32 = 10;
     let pt = vec![0xCCu8; 25];
-    let (ct, keyring) = encrypt_framed_shared(&pt, FRAME_LEN).await;
+    let keyring = test_keyring().await;
+    let ct = encrypt_framed_with_keyring(&pt, FRAME_LEN, &keyring).await;
     let frames = parse_all_frames(&ct, FRAME_LEN);
     assert_eq!(frames.len(), 3, "expected 2 regular + 1 final frame");
     let f = &frames[0];
@@ -303,7 +287,7 @@ async fn test_regular_frame_serialization_order() {
         "next regular frame's seq must be 2 (proves Field 4 ends at the spec-required offset)");
 
     // Round-trip cross-check.
-    let result = decrypt_with_keyring(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt, "round-trip corroborates regular frame serialization order");
 }
 
@@ -461,7 +445,8 @@ async fn test_final_frame_serialization_order() {
     const FRAME_LEN: u32 = 10;
     const PT_LEN: usize = 7;
     let pt = vec![0xAAu8; PT_LEN];
-    let (ct, keyring) = encrypt_framed_shared(&pt, FRAME_LEN).await;
+    let keyring = test_keyring().await;
+    let ct = encrypt_framed_with_keyring(&pt, FRAME_LEN, &keyring).await;
     let f = parse_final_frame(&ct, FRAME_LEN);
 
     // Field 1 of 6: Sequence Number End — 4 bytes equal to 0xFF FF FF FF.
@@ -508,7 +493,7 @@ async fn test_final_frame_serialization_order() {
         "final frame must occupy exactly {} bytes", expected_total);
 
     // Round-trip cross-check.
-    let result = decrypt_with_keyring(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt);
 }
 
@@ -521,7 +506,8 @@ async fn test_final_frame_is_regular_frame_plus_additions() {
     //# and Encrypted Content Length.
     const FRAME_LEN: u32 = 10;
     let pt = vec![0xBBu8; 5];
-    let (ct, keyring) = encrypt_framed_shared(&pt, FRAME_LEN).await;
+    let keyring = test_keyring().await;
+    let ct = encrypt_framed_with_keyring(&pt, FRAME_LEN, &keyring).await;
     let f = parse_final_frame(&ct, FRAME_LEN);
 
     // The two ADDITIONS over a regular frame:
@@ -537,7 +523,7 @@ async fn test_final_frame_is_regular_frame_plus_additions() {
     assert!(f.content_length_offset.is_some(),
         "final frame must have an Encrypted Content Length offset");
 
-    let result = decrypt_with_keyring(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt);
 }
 
@@ -611,7 +597,8 @@ async fn test_final_frame_sequence_number_serialized_same_as_regular() {
     //# [Regular Frame Sequence Number](#regular-frame-sequence-number).
     const FRAME_LEN: u32 = 10;
     let pt = vec![0xBBu8; 20];
-    let (ct, keyring) = encrypt_framed_shared(&pt, FRAME_LEN).await;
+    let keyring = test_keyring().await;
+    let ct = encrypt_framed_with_keyring(&pt, FRAME_LEN, &keyring).await;
     let frames = parse_all_frames(&ct, FRAME_LEN);
 
     // Find a regular frame and the final frame; their seq num field widths must match.
@@ -624,7 +611,7 @@ async fn test_final_frame_sequence_number_serialized_same_as_regular() {
     );
     assert_eq!(regular.seq_num_bytes.len(), 4, "seq num field width must be 4 bytes");
 
-    let result = decrypt_with_keyring(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(
         result, pt,
         "round-trip proves final frame seq num serialized same as regular"
@@ -727,8 +714,9 @@ async fn test_final_frame_auth_tag_authenticates_final_frame() {
     //# It MUST be used to authenticate the final frame.
     // Successful decrypt proves the auth tag authenticated the final frame.
     let pt = vec![0xBBu8; 5];
-    let (ct, keyring) = encrypt_framed_shared(&pt, 10).await;
-    assert_eq!(decrypt_with_keyring(&ct, keyring.clone()).await, pt);
+    let keyring = test_keyring().await;
+    let ct = encrypt_framed_with_keyring(&pt, 10, &keyring).await;
+    assert_eq!(decrypt_with_keyring(&ct, &keyring).await, pt);
 
     // Tampering with the final frame's auth tag must cause decryption failure.
     let final_frame = parse_final_frame(&ct, 10);
@@ -757,7 +745,8 @@ async fn test_regular_frame_auth_tag_authenticates_regular_frame() {
     // Tampering with a regular frame's auth tag must cause decryption failure.
     // Use 25 bytes / frame_length=10 so the first frame is a regular frame.
     let pt = vec![0xCCu8; 25];
-    let (ct, keyring) = encrypt_framed_shared(&pt, 10).await;
+    let keyring = test_keyring().await;
+    let ct = encrypt_framed_with_keyring(&pt, 10, &keyring).await;
     let frames = parse_all_frames(&ct, 10);
     let regular = frames.iter().find(|f| !f.is_final).expect("must have a regular frame");
 
@@ -787,11 +776,12 @@ async fn test_regular_frame_seq_num_out_of_order_rejected() {
     // body_decrypt.rs check `if seq_num != expected_frame { return ser_err(...) }`.
     // Use 25 bytes / frame_length=10 → 2 regular + 1 final, so we have a frame[1] to tamper.
     let pt = vec![0xDDu8; 25];
-    let (ct, keyring) = encrypt_framed_shared(&pt, 10).await;
+    let keyring = test_keyring().await;
+    let ct = encrypt_framed_with_keyring(&pt, 10, &keyring).await;
     let frames = parse_all_frames(&ct, 10);
 
     // Baseline: untampered ciphertext decrypts.
-    let baseline = decrypt_with_keyring(&ct, keyring.clone()).await;
+    let baseline = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(baseline, pt, "baseline plaintext mismatch");
 
     // Tamper the second frame's seq num field at the integer level (perturb 2 → 3).
@@ -994,7 +984,8 @@ async fn test_plaintext_exact_multiple_of_frame_length() {
     //# the Final Frame encrypted content length SHOULD be equal to the frame length but MAY be 0.
     let frame_length: u32 = 10;
     let pt = vec![0xEEu8; frame_length as usize];
-    let (ct, keyring) = encrypt_framed_shared(&pt, frame_length).await;
+    let keyring = test_keyring().await;
+    let ct = encrypt_framed_with_keyring(&pt, frame_length, &keyring).await;
     let final_frame = parse_final_frame(&ct, frame_length);
     let Ok(final_content_len) = u32::try_from(final_frame.content.len()) else {
         panic!("final content length exceeds u32::MAX");
@@ -1005,7 +996,7 @@ async fn test_plaintext_exact_multiple_of_frame_length() {
         frame_length,
         final_content_len
     );
-    let result = decrypt_with_keyring(&ct, keyring).await;
+    let result = decrypt_with_keyring(&ct, &keyring).await;
     assert_eq!(result, pt, "round-trip must succeed for exact multiple of frame length");
 }
 

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -108,11 +108,53 @@ async fn test_nonframed_encrypted_content_length_max_value() {
     //# due to restrictions imposed by the [implemented algorithms](../framework/algorithm-suites.md).
     let body = parse_nonframed_body(EXTERNAL_V2_NONFRAMED_CT);
     let max_allowed: u64 = (1u64 << 36) - 32;
+
+    // The conforming external vector must satisfy the bound.
     assert!(
         body.encrypted_content_length <= max_allowed,
         "encrypted content length {} must not exceed 2^36 - 32 = {}",
         body.encrypted_content_length,
         max_allowed
+    );
+
+    // Baseline: the untampered external vector decrypts successfully.
+    let baseline = try_decrypt_external_nonframed(Version::V2, EXTERNAL_V2_NONFRAMED_CT)
+        .await
+        .expect("baseline: untampered external vector must decrypt");
+    assert_eq!(baseline, EXTERNAL_V2_NONFRAMED_PT, "baseline plaintext mismatch");
+
+    // Tamper: rewrite the 8-byte content length field at body_start + IV_LEN to
+    // exceed the bound by 1, so the decrypt parser rejects it before any AES-GCM
+    // operation. (Perturbing at the integer level ensures the parser is the layer
+    // that fails.)
+    let length_offset = body.body_start + IV_LEN;
+    let original_len = u64::from_be_bytes(
+        EXTERNAL_V2_NONFRAMED_CT[length_offset..length_offset + 8]
+            .try_into()
+            .unwrap(),
+    );
+    assert_eq!(
+        original_len, body.encrypted_content_length,
+        "raw-byte read of length field must match parsed value"
+    );
+    let tampered_len = max_allowed + 1;
+    assert_ne!(
+        tampered_len, original_len,
+        "tamper-effectiveness: tampered length must differ from original"
+    );
+
+    let mut tampered = EXTERNAL_V2_NONFRAMED_CT.to_vec();
+    tampered[length_offset..length_offset + 8].copy_from_slice(&tampered_len.to_be_bytes());
+
+    let err = try_decrypt_external_nonframed(Version::V2, &tampered)
+        .await
+        .expect_err("decrypt must reject content length > 2^36 - 32");
+    assert_eq!(
+        err.kind,
+        ErrorKind::SerializationError,
+        "expected SerializationError for over-bound content length, got: {} ({:?})",
+        err.message,
+        err.kind
     );
 }
 

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -340,37 +340,40 @@ async fn test_regular_frame_sequence_number_increments() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_regular_frame_sequence_number_4_bytes() {
+async fn test_regular_frame_sequence_number_uint32_4_bytes_be() {
     //= spec/data-format/message-body.md#regular-frame-sequence-number
     //= type=test
     //# The length of the serialized sequence number field MUST be 4 bytes.
-    let pt = vec![0xFFu8; 20];
-    let ct = encrypt_with_frame_length(&pt, 10).await;
-    let body_start = find_body_start(&ct, 10).expect("must find body");
-    // Sequence number occupies exactly bytes [body_start..body_start+4]
-    let seq_bytes = &ct[body_start..body_start + 4];
-    assert_eq!(
-        seq_bytes.len(),
-        4,
-        "sequence number must be exactly 4 bytes"
-    );
-    assert_eq!(
-        u32::from_be_bytes([seq_bytes[0], seq_bytes[1], seq_bytes[2], seq_bytes[3]]),
-        1
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_regular_frame_sequence_number_uint32() {
+    //
     //= spec/data-format/message-body.md#regular-frame-sequence-number
     //= type=test
     //# The sequence number MUST be interpreted as a UInt32.
-    let pt = vec![0xAAu8; 30];
-    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
-    // All sequence numbers are valid u32 values parsed from big-endian bytes
-    for (seq, _, _, _, _) in &frames {
-        assert!(*seq > 0, "sequence number must be a valid non-zero UInt32");
-    }
+    let pt = vec![0xFFu8; 20];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let body_start = find_body_start(&ct, 10).expect("must find body");
+
+    // Per rust-conventions: prove byte-order by asserting individual bytes,
+    // not just the decoded value. For seq=1 on the wire:
+    //   big-endian:    [0x00, 0x00, 0x00, 0x01]  → decodes to 1
+    //   little-endian: [0x01, 0x00, 0x00, 0x00]  → also decodes to 1 via from_le_bytes
+    // The decoded value alone can't distinguish the two; the byte pattern can.
+    assert_eq!(ct[body_start], 0x00, "seq num byte 0 must be 0x00 for big-endian UInt32 = 1");
+    assert_eq!(ct[body_start + 1], 0x00, "seq num byte 1 must be 0x00 for big-endian UInt32 = 1");
+    assert_eq!(ct[body_start + 2], 0x00, "seq num byte 2 must be 0x00 for big-endian UInt32 = 1");
+    assert_eq!(ct[body_start + 3], 0x01, "seq num byte 3 must be 0x01 for big-endian UInt32 = 1");
+
+    // Decode as big-endian UInt32 to corroborate (decoded value alone isn't proof
+    // of byte order; the per-byte assertions above are).
+    let seq = u32::from_be_bytes([
+        ct[body_start],
+        ct[body_start + 1],
+        ct[body_start + 2],
+        ct[body_start + 3],
+    ]);
+    assert_eq!(seq, 1, "decoded UInt32 BE seq num must equal 1");
+
+    // The 4-byte field width is corroborated by test_regular_frame_serialization_order,
+    // which proves the IV begins at body_start + 4 (the field ends where the next begins).
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -25,7 +25,8 @@ async fn test_nonframed_data_serialization_order() {
     //# Encrypted Content Length,
     //# Encrypted Content,
     //# and Authentication Tag.
-    // This test verifies the fields are consumed in order via successful decrypt.
+    // This test verifies the fields are consumed in order via successful decrypt,
+    // then verifies each field's parsed length is consistent with the spec.
     let msg = EXTERNAL_V2_NONFRAMED_CT;
     let body = parse_nonframed_body(msg);
     let result = decrypt_external_nonframed_vector(Version::V2).await;
@@ -33,13 +34,20 @@ async fn test_nonframed_data_serialization_order() {
         result, EXTERNAL_V2_NONFRAMED_PT,
         "decrypt output did not match expected plaintext — nonframed body fields are not being consumed in the spec-required order"
     );
-    // Also verify the parsed field sizes are consistent
+
+    // Field 1 of 4: IV — fixed-width, must equal IV Length (12 bytes).
     assert_eq!(body.iv.len(), IV_LEN);
+
+    // Field 2 of 4: Encrypted Content Length — fixed-width UInt64 (8 bytes).
     assert_eq!(body.encrypted_content_length_bytes.len(), 8);
+
+    // Field 3 of 4: Encrypted Content — variable-width, length given by Field 2.
     assert_eq!(
         body.encrypted_content.len(),
         body.encrypted_content_length as usize
     );
+
+    // Field 4 of 4: Authentication Tag — fixed-width, must equal algorithm suite tag length (16 bytes).
     assert_eq!(body.auth_tag.len(), TAG_LEN);
 }
 

--- a/esdk/tests/test_message_body_format.rs
+++ b/esdk/tests/test_message_body_format.rs
@@ -1,0 +1,971 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/data-format/message-body.md
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
+use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
+
+use test_helpers::*;
+
+// The ESDK always uses framed encryption, so nonframed deserialization
+// is exercised by parsing/decrypting the external V2 nonframed vector from
+// aws-encryption-sdk-test-vectors.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_data_serialization_order() {
+    //= spec/data-format/message-body.md#nonframed-data
+    //= type=test
+    //# Nonframed data MUST consist of, in order,
+    //# IV,
+    //# Encrypted Content Length,
+    //# Encrypted Content,
+    //# and Authentication Tag.
+    // This test verifies the fields are consumed in order via successful decrypt.
+    let msg = EXTERNAL_V2_NONFRAMED_CT;
+    let body = parse_nonframed_body(msg);
+    let result = decrypt_external_nonframed_vector(Version::V2).await;
+    assert_eq!(
+        result, EXTERNAL_V2_NONFRAMED_PT,
+        "decrypt output did not match expected plaintext — nonframed body fields are not being consumed in the spec-required order"
+    );
+    // Also verify the parsed field sizes are consistent
+    assert_eq!(body.iv.len(), IV_LEN);
+    assert_eq!(body.encrypted_content_length_bytes.len(), 8);
+    assert_eq!(
+        body.encrypted_content.len(),
+        body.encrypted_content_length as usize
+    );
+    assert_eq!(body.auth_tag.len(), TAG_LEN);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_iv_length() {
+    //= spec/data-format/message-body.md#nonframed-data-iv
+    //= type=test
+    //# The length of the IV field MUST be [IV Length](message-header.md#iv-length) bytes.
+    let body = parse_nonframed_body(EXTERNAL_V2_NONFRAMED_CT);
+    assert_eq!(
+        body.iv.len(),
+        IV_LEN,
+        "nonframed IV must be IV_LEN (12) bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_iv_interpreted_as_bytes() {
+    //= spec/data-format/message-body.md#nonframed-data-iv
+    //= type=test
+    //# The IV MUST be interpreted as bytes.
+    let result = decrypt_external_nonframed_vector(Version::V2).await;
+    assert_eq!(
+        result, EXTERNAL_V2_NONFRAMED_PT,
+        "decrypt output did not match expected plaintext — nonframed IV was not interpreted as bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_encrypted_content_length_uint64() {
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content-length
+    //= type=test
+    //# The encrypted content length MUST be interpreted as a UInt64.
+    let body = parse_nonframed_body(EXTERNAL_V2_NONFRAMED_CT);
+    assert_eq!(
+        body.encrypted_content_length,
+        EXTERNAL_V2_NONFRAMED_PT.len() as u64,
+        "encrypted content length interpreted as UInt64 must equal plaintext length"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_encrypted_content_length_max_value() {
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content-length
+    //= type=test
+    //# The value of this field MUST NOT be greater than `2^36 - 32`, or 64 gibibytes (64 GiB),
+    //# due to restrictions imposed by the [implemented algorithms](../framework/algorithm-suites.md).
+    let body = parse_nonframed_body(EXTERNAL_V2_NONFRAMED_CT);
+    let max_allowed: u64 = (1u64 << 36) - 32;
+    assert!(
+        body.encrypted_content_length <= max_allowed,
+        "encrypted content length {} must not exceed 2^36 - 32 = {}",
+        body.encrypted_content_length,
+        max_allowed
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_encrypted_content_length_field_8_bytes() {
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content-length
+    //= type=test
+    //# The length of the Encrypted Content Length field MUST be 8 bytes.
+    let body = parse_nonframed_body(EXTERNAL_V2_NONFRAMED_CT);
+    assert_eq!(
+        body.encrypted_content_length_bytes.len(),
+        8,
+        "encrypted content length field must be exactly 8 bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_encrypted_content_length_matches_content() {
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content
+    //= type=test
+    //# The length of the serialized encrypted content field MUST be equal to the value of the [Encrypted Content Length](#nonframed-data-encrypted-content-length) field.
+    let body = parse_nonframed_body(EXTERNAL_V2_NONFRAMED_CT);
+    assert_eq!(
+        body.encrypted_content.len(),
+        body.encrypted_content_length as usize,
+        "encrypted content byte count must equal the content length field value"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_encrypted_content_interpreted_as_bytes() {
+    //= spec/data-format/message-body.md#nonframed-data-encrypted-content
+    //= type=test
+    //# The encrypted content value MUST be interpreted as bytes.
+    let result = decrypt_external_nonframed_vector(Version::V2).await;
+    assert_eq!(
+        result, EXTERNAL_V2_NONFRAMED_PT,
+        "decrypt output did not match expected plaintext — nonframed encrypted content was not interpreted as bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_auth_tag_length() {
+    //= spec/data-format/message-body.md#nonframed-data-authentication-tag
+    //= type=test
+    //# The length of the serialized authentication tag field MUST be equal to the [authentication tag length](../framework/algorithm-suites.md#authentication-tag-length) of the [algorithm suite](../framework/algorithm-suites.md) specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
+    let body = parse_nonframed_body(EXTERNAL_V2_NONFRAMED_CT);
+    assert_eq!(
+        body.auth_tag.len(),
+        TAG_LEN,
+        "nonframed auth tag length must equal algorithm suite tag length (16)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_auth_tag_interpreted_as_bytes() {
+    //= spec/data-format/message-body.md#nonframed-data-authentication-tag
+    //= type=test
+    //# The authentication tag value MUST be interpreted as bytes.
+    let result = decrypt_external_nonframed_vector(Version::V2).await;
+    assert_eq!(
+        result, EXTERNAL_V2_NONFRAMED_PT,
+        "decrypt output did not match expected plaintext — nonframed auth tag was not interpreted as bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_framed_data_max_frame_count() {
+    // With frame_length=4 and 20 bytes, we get 4 regular + 1 final = 5 frames.
+    // The implementation checks sequence_number == ENDFRAME_SEQUENCE_NUMBER to enforce the limit.
+    //= spec/data-format/message-body.md#framed-data
+    //= type=test
+    //# - The number of frames in a single message MUST be less than or equal to `2^32 - 1`.
+    let pt = vec![0xBBu8; 20];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 4).await, 4);
+    assert_eq!(
+        frames.len(),
+        5,
+        "20 bytes / 4-byte frames = 4 regular + 1 final = 5 frames"
+    );
+    let result = round_trip_framed(&pt, 4).await;
+    assert_eq!(result, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_serialization_order() {
+    //= spec/data-format/message-body.md#regular-frame
+    //= type=test
+    //# A regular frame MUST consist of, in order,
+    //# Sequence Number,
+    //# IV,
+    //# Encrypted Content,
+    //# and Authentication Tag.
+    let pt = vec![0xCCu8; 20];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let body_start = find_body_start(&ct, 10).expect("must find body");
+    // First regular frame at body_start: SeqNum(4) + IV(12) + Content(10) + Tag(16)
+    let seq = u32::from_be_bytes([
+        ct[body_start],
+        ct[body_start + 1],
+        ct[body_start + 2],
+        ct[body_start + 3],
+    ]);
+    assert_eq!(seq, 1, "first field is sequence number");
+    // IV follows at body_start+4, content at body_start+16, tag at body_start+26
+    // Verify by successful round-trip (wrong order would fail decryption)
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves regular frame serialization order is correct"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_sequence_number_starts_at_one() {
+    //= spec/data-format/message-body.md#regular-frame-sequence-number
+    //= type=test
+    //# Framed Data MUST start at Sequence Number 1.
+    let pt = vec![0xDDu8; 20];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    assert_eq!(frames[0].0, 1, "first frame sequence number must be 1");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_sequence_number_increments() {
+    //= spec/data-format/message-body.md#regular-frame-sequence-number
+    //= type=test
+    //# Subsequent frames MUST be in order and MUST contain an increment of 1 from the previous frame.
+    let pt = vec![0xEEu8; 40];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    for i in 1..frames.len() {
+        assert_eq!(
+            frames[i].0,
+            frames[i - 1].0 + 1,
+            "frame {} seq num must be 1 greater than frame {}",
+            i,
+            i - 1
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_sequence_number_4_bytes() {
+    //= spec/data-format/message-body.md#regular-frame-sequence-number
+    //= type=test
+    //# The length of the serialized sequence number field MUST be 4 bytes.
+    let pt = vec![0xFFu8; 20];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let body_start = find_body_start(&ct, 10).expect("must find body");
+    // Sequence number occupies exactly bytes [body_start..body_start+4]
+    let seq_bytes = &ct[body_start..body_start + 4];
+    assert_eq!(
+        seq_bytes.len(),
+        4,
+        "sequence number must be exactly 4 bytes"
+    );
+    assert_eq!(
+        u32::from_be_bytes([seq_bytes[0], seq_bytes[1], seq_bytes[2], seq_bytes[3]]),
+        1
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_sequence_number_uint32() {
+    //= spec/data-format/message-body.md#regular-frame-sequence-number
+    //= type=test
+    //# The sequence number MUST be interpreted as a UInt32.
+    let pt = vec![0xAAu8; 30];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    // All sequence numbers are valid u32 values parsed from big-endian bytes
+    for (seq, _, _, _, _) in &frames {
+        assert!(*seq > 0, "sequence number must be a valid non-zero UInt32");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_iv_unique() {
+    //= spec/data-format/message-body.md#regular-frame-iv
+    //= type=test
+    //# Each frame in the [Framed Data](#framed-data) MUST include an IV that is unique within the message.
+    let pt = vec![0xCCu8; 40];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let ivs: Vec<&Vec<u8>> = frames.iter().map(|(_, iv, _, _, _)| iv).collect();
+    for i in 0..ivs.len() {
+        for j in (i + 1)..ivs.len() {
+            assert_ne!(
+                ivs[i], ivs[j],
+                "IV for frame {} must differ from frame {}",
+                i, j
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_iv_length_matches_algorithm() {
+    //= spec/data-format/message-body.md#regular-frame-iv
+    //= type=test
+    //# The IV length MUST be equal to the IV length of the algorithm suite specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
+    let pt = vec![0xDDu8; 20];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    for (_, iv, _, _, _) in &frames {
+        assert_eq!(
+            iv.len(),
+            IV_LEN,
+            "IV length must match algorithm suite IV length (12)"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_iv_interpreted_as_bytes() {
+    //= spec/data-format/message-body.md#regular-frame-iv
+    //= type=test
+    //# The IV MUST be interpreted as bytes.
+    // Round-trip proves the IV bytes are correctly interpreted during decrypt
+    let pt = vec![0xEEu8; 20];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves IV is correctly interpreted as bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_encrypted_content_length_equals_frame_length() {
+    //= spec/data-format/message-body.md#regular-frame-encrypted-content
+    //= type=test
+    //# The length of the encrypted content of a Regular Frame MUST be equal to the Frame Length.
+    //
+    //= spec/data-format/message-body.md#framed-data
+    //= type=test
+    //= reason=frame length is a u32, so the type system enforces the 2^32-1 byte limit per frame; testing at the actual boundary is impractical
+    //# - The total bytes allowed in a single frame MUST be less than or equal to `2^32 - 1`.
+    let frame_length: u32 = 10;
+    let pt = vec![0xFFu8; 30];
+    let frames = parse_frames(
+        &encrypt_with_frame_length(&pt, frame_length).await,
+        frame_length,
+    );
+    for (_, _, enc_content, _, is_final) in &frames {
+        if !is_final {
+            assert_eq!(
+                enc_content.len(),
+                frame_length as usize,
+                "regular frame encrypted content length must equal frame length"
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_encrypted_content_interpreted_as_bytes() {
+    //= spec/data-format/message-body.md#regular-frame-encrypted-content
+    //= type=test
+    //# The encrypted content MUST be interpreted as bytes.
+    let pt = vec![0xAAu8; 20];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves encrypted content is interpreted as bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_auth_tag_length_matches_algorithm() {
+    //= spec/data-format/message-body.md#regular-frame-authentication-tag
+    //= type=test
+    //# The authentication tag length MUST be equal to the authentication tag length of the algorithm suite
+    //# specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
+    let pt = vec![0xBBu8; 20];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    for (_, _, _, tag, _) in &frames {
+        assert_eq!(
+            tag.len(),
+            TAG_LEN,
+            "auth tag length must match algorithm suite (16)"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_regular_frame_auth_tag_interpreted_as_bytes() {
+    //= spec/data-format/message-body.md#regular-frame-authentication-tag
+    //= type=test
+    //# The authentication tag MUST be interpreted as bytes.
+    let pt = vec![0xCCu8; 20];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves auth tag is interpreted as bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_serialization_order() {
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# A final frame MUST consist of, in order,
+    //# Sequence Number End,
+    //# Sequence Number,
+    //# IV,
+    //# Encrypted Content Length,
+    //# Encrypted Content,
+    //# and Authentication Tag.
+    let pt = vec![0xAAu8; 7];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    // Find ENDFRAME marker — that's the start of the final frame
+    let pos = ct
+        .windows(4)
+        .position(|w| w == ENDFRAME_MARKER)
+        .expect("must find ENDFRAME");
+    // Verify field order: ENDFRAME(4) + SeqNum(4) + IV(12) + ContentLen(4) + Content(7) + Tag(16)
+    let expected_total = 4 + 4 + IV_LEN + 4 + 7 + TAG_LEN;
+    assert!(
+        pos + expected_total <= ct.len(),
+        "final frame must have all fields in order"
+    );
+    // Verify round-trip to confirm correct serialization
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_is_regular_frame_plus_additions() {
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# A final frame MUST only differ from a regular frame by the addition of the
+    //# Sequence Number End
+    //# and Encrypted Content Length.
+    let pt = vec![0xBBu8; 5];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let pos = ct
+        .windows(4)
+        .position(|w| w == ENDFRAME_MARKER)
+        .expect("must find ENDFRAME");
+    // Final frame has Sequence Number End (extra vs regular) at pos
+    assert_eq!(
+        &ct[pos..pos + 4],
+        &ENDFRAME_MARKER,
+        "final frame starts with Sequence Number End"
+    );
+    // Then SeqNum(4) + IV(12) + ContentLen(4, extra vs regular) + Content + Tag
+    let content_len = u32::from_be_bytes([ct[pos + 20], ct[pos + 21], ct[pos + 22], ct[pos + 23]]);
+    assert!(
+        content_len <= 10,
+        "final frame has Encrypted Content Length field"
+    );
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(result, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sequence_number_end_value() {
+    //= spec/data-format/message-body.md#sequence-number-end
+    //= type=test
+    //# The value MUST be encoded as the 4 bytes `FF FF FF FF` in hexadecimal notation.
+    let pt = b"test";
+    let ct = encrypt_with_frame_length(pt, 4096).await;
+    let pos = ct
+        .windows(4)
+        .position(|w| w == ENDFRAME_MARKER)
+        .expect("must find ENDFRAME");
+    assert_eq!(ct[pos], 0xFF);
+    assert_eq!(ct[pos + 1], 0xFF);
+    assert_eq!(ct[pos + 2], 0xFF);
+    assert_eq!(ct[pos + 3], 0xFF);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sequence_number_end_4_bytes() {
+    //= spec/data-format/message-body.md#sequence-number-end
+    //= type=test
+    //# The length of the sequence number end field MUST be 4 bytes.
+    let pt = b"test";
+    let ct = encrypt_with_frame_length(pt, 4096).await;
+    // The ENDFRAME marker is exactly 4 bytes: FF FF FF FF
+    let pos = ct
+        .windows(4)
+        .position(|w| w == ENDFRAME_MARKER)
+        .expect("must find ENDFRAME");
+    assert_eq!(
+        &ct[pos..pos + 4],
+        &[0xFF, 0xFF, 0xFF, 0xFF],
+        "sequence number end is exactly 4 bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sequence_number_end_interpreted_as_bytes() {
+    //= spec/data-format/message-body.md#sequence-number-end
+    //= type=test
+    //# The sequence number end MUST be interpreted as bytes.
+    // Successful round-trip proves the decrypt path correctly interprets the ENDFRAME marker bytes
+    let pt = b"test seq end";
+    let result = round_trip_framed(pt, 4096).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves sequence number end is interpreted as bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_sequence_number_equals_total_frames() {
+    // 30 bytes / 10-byte frames → 2 regular + 1 final = 3 total frames
+    //= spec/data-format/message-body.md#final-frame-sequence-number
+    //= type=test
+    //# The Final Frame Sequence number MUST be equal to the total number of frames in the Framed Data.
+    let pt = vec![0xAAu8; 30];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let final_frame = frames.last().expect("must have final frame");
+    assert!(final_frame.4, "last frame must be final");
+    assert_eq!(
+        final_frame.0,
+        frames.len() as u32,
+        "final frame seq num must equal total frame count"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_sequence_number_serialized_same_as_regular() {
+    //= spec/data-format/message-body.md#final-frame-sequence-number
+    //= type=test
+    //# The length of the Final Frame Sequence number field MUST be the same as the
+    //# [Regular Frame Sequence Number](#regular-frame-sequence-number).
+    let pt = vec![0xBBu8; 20];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let pos = ct
+        .windows(4)
+        .position(|w| w == ENDFRAME_MARKER)
+        .expect("must find ENDFRAME");
+    // Final frame seq num is at pos+4, serialized as 4-byte big-endian UInt32 (same as regular)
+    let final_seq = u32::from_be_bytes([ct[pos + 4], ct[pos + 5], ct[pos + 6], ct[pos + 7]]);
+    assert!(
+        final_seq > 0,
+        "final frame sequence number is a valid UInt32"
+    );
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves final frame seq num serialized same as regular"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_sequence_number_interpreted_same_as_regular() {
+    //= spec/data-format/message-body.md#final-frame-sequence-number
+    //= type=test
+    //# The Final Frame Sequence Number MUST be interpreted as the same type as the
+    //# [Regular Frame Sequence Number](#regular-frame-sequence-number).
+    // Multi-frame round-trip: decrypt reads final frame seq num as UInt32 (same as regular)
+    let pt = vec![0xCCu8; 30];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves final frame seq num is interpreted same as regular"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_iv_unique() {
+    //= spec/data-format/message-body.md#final-frame-iv
+    //= type=test
+    //# A generated IV MUST be a unique IV within the message.
+    let pt = vec![0xDDu8; 30];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let final_iv = &frames.last().expect("must have final frame").1;
+    for (i, (_, iv, _, _, is_final)) in frames.iter().enumerate() {
+        if !is_final {
+            assert_ne!(
+                iv, final_iv,
+                "final frame IV must differ from regular frame {}",
+                i
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_iv_length_matches_algorithm() {
+    //= spec/data-format/message-body.md#final-frame-iv
+    //= type=test
+    //# The length of the IV field MUST be equal to the IV length of the [algorithm suite](../framework/algorithm-suites.md) that generated the message.
+    let pt = vec![0xEEu8; 5];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let final_frame = frames.last().expect("must have final frame");
+    assert!(final_frame.4, "must be final frame");
+    assert_eq!(
+        final_frame.1.len(),
+        IV_LEN,
+        "final frame IV length must match algorithm suite"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_iv_interpreted_as_bytes() {
+    //= spec/data-format/message-body.md#final-frame-iv
+    //= type=test
+    //# The IV MUST be interpreted as bytes.
+    let pt = vec![0xFFu8; 5];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves final frame IV is interpreted as bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_encrypted_content_length_4_bytes() {
+    //= spec/data-format/message-body.md#final-frame-encrypted-content-length
+    //= type=test
+    //# The length of the serialized encrypted content length field MUST be 4 bytes.
+    let pt = vec![0xAAu8; 7];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let pos = ct
+        .windows(4)
+        .position(|w| w == ENDFRAME_MARKER)
+        .expect("must find ENDFRAME");
+    // Content length field is at pos+20 (ENDFRAME(4)+SeqNum(4)+IV(12)), exactly 4 bytes
+    let content_len_bytes = &ct[pos + 20..pos + 24];
+    assert_eq!(
+        content_len_bytes.len(),
+        4,
+        "encrypted content length field must be exactly 4 bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_encrypted_content_length_uint32() {
+    //= spec/data-format/message-body.md#final-frame-encrypted-content-length
+    //= type=test
+    //# The encrypted content length MUST be a UInt32.
+    let pt = vec![0xBBu8; 7];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let pos = ct
+        .windows(4)
+        .position(|w| w == ENDFRAME_MARKER)
+        .expect("must find ENDFRAME");
+    let content_len = u32::from_be_bytes([ct[pos + 20], ct[pos + 21], ct[pos + 22], ct[pos + 23]]);
+    assert_eq!(
+        content_len, 7,
+        "encrypted content length serialized as UInt32 must equal 7"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_encrypted_content_length_matches() {
+    //= spec/data-format/message-body.md#final-frame-encrypted-content
+    //= type=test
+    //# The length of the serialized encrypted content field MUST be equal to the value of the [Encrypted Content Length](#final-frame-encrypted-content-length) field.
+    let pt = vec![0xDDu8; 7];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let final_frame = frames.last().expect("must have final frame");
+    assert!(final_frame.4, "must be final frame");
+    // parse_frames reads content_len from the field and uses it to read enc_content
+    // If they didn't match, parsing would fail or produce wrong data
+    assert_eq!(
+        final_frame.2.len(),
+        7,
+        "encrypted content length must match the content length field"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_encrypted_content_interpreted_as_bytes() {
+    //= spec/data-format/message-body.md#final-frame-encrypted-content
+    //= type=test
+    //# The encrypted content MUST be interpreted as bytes.
+    let pt = vec![0xEEu8; 5];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves final frame encrypted content is interpreted as bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_auth_tag_length_matches_algorithm() {
+    //= spec/data-format/message-body.md#final-frame-authentication-tag
+    //= type=test
+    //# The authentication tag length MUST be equal to the authentication tag length of the algorithm suite
+    //# specified by the [Algorithm Suite ID](message-header.md#algorithm-suite-id) field.
+    let pt = vec![0xFFu8; 5];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let final_frame = frames.last().expect("must have final frame");
+    assert!(final_frame.4, "must be final frame");
+    assert_eq!(
+        final_frame.3.len(),
+        TAG_LEN,
+        "final frame auth tag length must match algorithm suite (16)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_auth_tag_interpreted_as_bytes() {
+    //= spec/data-format/message-body.md#final-frame-authentication-tag
+    //= type=test
+    //# The authentication tag MUST be interpreted as bytes.
+    let pt = vec![0xAAu8; 5];
+    let result = round_trip_framed(&pt, 10).await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves final frame auth tag is interpreted as bytes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_auth_tag_authenticates_final_frame() {
+    //= spec/data-format/message-body.md#final-frame-authentication-tag
+    //= type=test
+    //# It MUST be used to authenticate the final frame.
+    // Successful decrypt proves the auth tag authenticated the final frame.
+    let pt = vec![0xBBu8; 5];
+    assert_eq!(round_trip_framed(&pt, 10).await, pt);
+
+    // Tampering with the final frame's auth tag must cause decryption failure.
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_frames(&ct, 10);
+    let final_frame = frames.last().unwrap();
+    assert!(final_frame.4, "must be final frame");
+
+    let body_start = find_body_start(&ct, 10).unwrap();
+    // Walk to the final frame's auth tag position
+    let mut pos = body_start;
+    for f in &frames[..frames.len() - 1] {
+        pos += 4 + IV_LEN + f.2.len() + TAG_LEN; // regular frame
+    }
+    // Final frame: ENDFRAME(4) + SeqNum(4) + IV(12) + ContentLen(4) + Content(N) + Tag(16)
+    let tag_offset = pos + 4 + 4 + IV_LEN + 4 + final_frame.2.len();
+    let mut tampered = ct.clone();
+    tampered[tag_offset] ^= 0xFF;
+
+    let keyring = test_keyring().await;
+    let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
+    let err = decrypt(&dec_input)
+        .await
+        .expect_err("tampered final frame auth tag must cause decryption failure");
+    assert!(
+        matches!(err.kind, ErrorKind::CryptographicError),
+        "expected CryptographicError, got: {} ({:?})",
+        err.message,
+        err.kind
+    );
+}
+
+async fn encrypt_v1_with_frame_length(plaintext: &[u8], frame_length: u32) -> Vec<u8> {
+    let keyring = test_keyring().await;
+    let mut input = EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring);
+    input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
+    input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    input.frame_length = FrameLength::new(frame_length).unwrap();
+    encrypt(&input).await.unwrap().ciphertext
+}
+
+async fn round_trip_v1_framed(plaintext: &[u8], frame_length: u32) -> Vec<u8> {
+    let keyring = test_keyring().await;
+    let ct = encrypt_v1_with_frame_length(plaintext, frame_length).await;
+    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    decrypt(&dec_input).await.unwrap().plaintext
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_regular_frame_sequence_number_starts_at_one() {
+    //= spec/data-format/message-body.md#regular-frame-sequence-number
+    //= type=test
+    //# Framed Data MUST start at Sequence Number 1.
+    let pt = vec![0xAAu8; 20];
+    let frames = parse_frames(&encrypt_v1_with_frame_length(&pt, 10).await, 10);
+    assert_eq!(frames[0].0, 1, "V1: first frame sequence number must be 1");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_regular_frame_sequence_number_increments() {
+    //= spec/data-format/message-body.md#regular-frame-sequence-number
+    //= type=test
+    //# Subsequent frames MUST be in order and MUST contain an increment of 1 from the previous frame.
+    let pt = vec![0xBBu8; 40];
+    let frames = parse_frames(&encrypt_v1_with_frame_length(&pt, 10).await, 10);
+    for i in 1..frames.len() {
+        assert_eq!(
+            frames[i].0,
+            frames[i - 1].0 + 1,
+            "V1: frame {} seq num must be 1 greater than frame {}",
+            i,
+            i - 1
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_regular_frame_iv_unique() {
+    //= spec/data-format/message-body.md#regular-frame-iv
+    //= type=test
+    //# Each frame in the [Framed Data](#framed-data) MUST include an IV that is unique within the message.
+    let pt = vec![0xCCu8; 40];
+    let frames = parse_frames(&encrypt_v1_with_frame_length(&pt, 10).await, 10);
+    let ivs: Vec<&Vec<u8>> = frames.iter().map(|(_, iv, _, _, _)| iv).collect();
+    for i in 0..ivs.len() {
+        for j in (i + 1)..ivs.len() {
+            assert_ne!(ivs[i], ivs[j], "V1: IV for frame {} must differ from frame {}", i, j);
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_regular_frame_encrypted_content_length_equals_frame_length() {
+    //= spec/data-format/message-body.md#regular-frame-encrypted-content
+    //= type=test
+    //# The length of the encrypted content of a Regular Frame MUST be equal to the Frame Length.
+    let frame_length: u32 = 10;
+    let pt = vec![0xDDu8; 30];
+    let frames = parse_frames(&encrypt_v1_with_frame_length(&pt, frame_length).await, frame_length);
+    for (_, _, enc_content, _, is_final) in &frames {
+        if !is_final {
+            assert_eq!(
+                enc_content.len(),
+                frame_length as usize,
+                "V1: regular frame encrypted content length must equal frame length"
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_sequence_number_end_value() {
+    //= spec/data-format/message-body.md#sequence-number-end
+    //= type=test
+    //# The value MUST be encoded as the 4 bytes `FF FF FF FF` in hexadecimal notation.
+    let pt = b"v1 test";
+    let ct = encrypt_v1_with_frame_length(pt, 4096).await;
+    let pos = ct
+        .windows(4)
+        .position(|w| w == ENDFRAME_MARKER)
+        .expect("V1: must find ENDFRAME");
+    assert_eq!(&ct[pos..pos + 4], &[0xFF, 0xFF, 0xFF, 0xFF]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_final_frame_sequence_number_equals_total_frames() {
+    //= spec/data-format/message-body.md#final-frame-sequence-number
+    //= type=test
+    //# The Final Frame Sequence number MUST be equal to the total number of frames in the Framed Data.
+    let pt = vec![0xEEu8; 30];
+    let frames = parse_frames(&encrypt_v1_with_frame_length(&pt, 10).await, 10);
+    let final_frame = frames.last().expect("must have final frame");
+    assert!(final_frame.4, "last frame must be final");
+    assert_eq!(
+        final_frame.0,
+        frames.len() as u32,
+        "V1: final frame seq num must equal total frame count"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_round_trip_framed() {
+    let pt = vec![0xFFu8; 25];
+    let result = round_trip_v1_framed(&pt, 10).await;
+    assert_eq!(result, pt, "V1: round-trip proves regular frame serialization order");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_framed_data_contains_exactly_one_final_frame() {
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# Framed data MUST contain exactly one final frame.
+    let pt = vec![0xAAu8; 30];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    let final_count = frames.iter().filter(|(_, _, _, _, is_final)| *is_final).count();
+    assert_eq!(final_count, 1, "framed data must contain exactly one final frame");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_is_last_frame() {
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# The final frame MUST be the last frame.
+    let pt = vec![0xBBu8; 30];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    for (i, (_, _, _, _, is_final)) in frames.iter().enumerate() {
+        if *is_final {
+            assert_eq!(i, frames.len() - 1, "final frame must be the last frame");
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_frame_content_length_lte_frame_length() {
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# The length of the plaintext to be encrypted in the Final Frame MUST be
+    //# greater than or equal to 0 and less than or equal to the [Frame Length](message-header.md#frame-length).
+    let frame_length: u32 = 10;
+    // 7 bytes plaintext with 10-byte frame → final frame has 7 bytes (< frame_length)
+    let pt = vec![0xCCu8; 7];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, frame_length).await, frame_length);
+    let final_frame = frames.last().expect("must have final frame");
+    assert!(final_frame.4, "must be final frame");
+    assert!(
+        final_frame.2.len() <= frame_length as usize,
+        "final frame content length {} must be <= frame length {}",
+        final_frame.2.len(),
+        frame_length
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_plaintext_less_than_frame_length_single_final_frame() {
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# - When the length of the Plaintext is less than the Frame Length,
+    //# the body MUST contain exactly one frame and that frame MUST be a Final Frame.
+    let pt = vec![0xDDu8; 5];
+    let frames = parse_frames(&encrypt_with_frame_length(&pt, 10).await, 10);
+    assert_eq!(frames.len(), 1, "plaintext < frame length must produce exactly one frame");
+    assert!(frames[0].4, "the single frame must be a final frame");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_plaintext_exact_multiple_of_frame_length() {
+    //= spec/data-format/message-body.md#final-frame
+    //= type=test
+    //# - When the length of the Plaintext is an exact multiple of the Frame Length
+    //# (including if it is equal to the frame length),
+    //# the Final Frame encrypted content length SHOULD be equal to the frame length but MAY be 0.
+    let frame_length: u32 = 10;
+    let pt = vec![0xEEu8; frame_length as usize];
+    let ct = encrypt_with_frame_length(&pt, frame_length).await;
+    let frames = parse_frames(&ct, frame_length);
+    let final_frame = frames.last().expect("must have final frame");
+    assert!(final_frame.4, "last frame must be final");
+    let final_content_len = final_frame.2.len() as u32;
+    assert!(
+        final_content_len == frame_length || final_content_len == 0,
+        "final frame content length must be frame_length ({}) or 0, got {}",
+        frame_length,
+        final_content_len
+    );
+    let result = round_trip_framed(&pt, frame_length).await;
+    assert_eq!(result, pt, "round-trip must succeed for exact multiple of frame length");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_message_begins_with_header() {
+    let ct_v1 = encrypt_with_v1_signing_suite(b"header first test").await;
+    //= spec/data-format/message.md#structure
+    //= type=test
+    //# - The message MUST begin with [Message Header](message-header.md)
+    assert_eq!(
+        ct_v1[0], 0x01,
+        "V1 message must begin with header version byte 0x01"
+    );
+
+    let ct_v2 = encrypt_with_signing_suite(b"header first test").await;
+    assert_eq!(
+        ct_v2[0], 0x02,
+        "V2 message must begin with header version byte 0x02"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_message_body_follows_header() {
+    // A successful round-trip decrypt proves the body follows the header,
+    // because the decryptor parses header then body in sequence.
+    let pt = b"body follows header test";
+    let result = round_trip_signing(pt).await;
+    //= spec/data-format/message.md#structure
+    //= type=test
+    //= reason=Round-trip decrypt proves body follows header: decrypt would fail if message ordering were incorrect.
+    //# - The [Message Body](message-body.md) MUST follow the Message Header
+    assert_eq!(
+        result, pt,
+        "successful decrypt proves message body follows header in serialization order"
+    );
+}


### PR DESCRIPTION
Implements message body framing — both framed and non-framed body serialization and deserialization — per [message-body.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/update-more-data-format/data-format/message-body.md).

Scope:
- `esdk/src/message/body/mod.rs` — body module surface and shared body types.
- `esdk/src/message/body/body_encrypt.rs` — body serialization (framed and non-framed).
- `esdk/src/message/body/body_decrypt.rs` — body deserialization (framed and non-framed).
- Tests: `esdk/tests/test_message_body_format.rs`, `esdk/tests/test_construct_the_body.rs`, `esdk/tests/test_construct_a_frame.rs`, `esdk/tests/test_authentication_tag.rs`.

Body AAD construction is reviewed separately in #900 (`message-body-aad`). Headers and footer that bracket the body are reviewed in #909 / #901 / #898 respectively.

---

**Note:** CI does not run on this PR. This branch is scoped for focused review and intentionally omits test helpers, scaffolding, and other supporting code. Full code — including helpers, test infrastructure, and working tests — lives on the [`aws-crypto-rust/unreviewed`](https://github.com/aws/aws-encryption-sdk/tree/aws-crypto-rust/unreviewed) branch.

If you want more context or to actually run the tests, see `aws-crypto-rust/unreviewed`.

**Related spec:** [data-format/message-body.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/update-more-data-format/data-format/message-body.md)
