### PR TITLE
feat(native-rust): decrypt behavior

### DIFF
--- a/esdk/src/decrypt.rs
+++ b/esdk/src/decrypt.rs
@@ -5,7 +5,7 @@
 //! obtains decryption materials from a keyring/CMM, derives the data key,
 //! and decrypts the plaintext (handling both framed and nonframed formats).
 
-use crate::encrypt::get_esdk_id;
+use crate::encrypt::get_esdk_algorithm_suite_id;
 use crate::error::{Error, esdk_err, val_err};
 use crate::key_derivation;
 use crate::materials;
@@ -245,7 +245,7 @@ async fn internal_decrypt(
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
     //# If this algorithm suite is not [supported for the ESDK](../framework/algorithm-suites.md#supported-algorithm-suites-enum)
     //# decrypt MUST yield an error.
-    get_esdk_id(state.header.suite.id)?;
+    get_esdk_algorithm_suite_id(state.header.suite.id)?;
 
     //= spec/client-apis/decrypt.md#behavior
     //= reason=verification_key presence must match suite's signature algorithm; mismatch means misbehaving CMM
@@ -322,7 +322,7 @@ async fn internal_decrypt(
         encryption_context: ec,
         //= spec/client-apis/decrypt.md#algorithm-suite
         //# This algorithm suite MUST be [supported for the ESDK](../framework/algorithm-suites.md#supported-algorithm-suites-enum).
-        algorithm_suite_id: get_esdk_id(state.header.suite.id)?,
+        algorithm_suite_id: get_esdk_algorithm_suite_id(state.header.suite.id)?,
     })
 }
 

--- a/esdk/src/decrypt.rs
+++ b/esdk/src/decrypt.rs
@@ -136,7 +136,9 @@ pub async fn decrypt(input: &DecryptInput<'_>) -> Result<DecryptOutput, Error> {
     //= reason=decrypt() returns Result; caller cannot access output until Ok
     //# If the input encrypted message is not being [streamed](streaming.md) to this operation,
     //# all output MUST NOT be released until after these steps complete successfully.
-    let mut plaintext: Vec<u8> = Vec::with_capacity(input.ciphertext.len());
+    // Plaintext is always smaller than the ciphertext and grows as frames decrypt;
+    // pre-sizing to ciphertext.len() would over-allocate (badly so for small frames).
+    let mut plaintext: Vec<u8> = Vec::new();
 
     let out = internal_decrypt(
         &mut cursor,
@@ -243,7 +245,7 @@ async fn internal_decrypt(
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
     //# If this algorithm suite is not [supported for the ESDK](../framework/algorithm-suites.md#supported-algorithm-suites-enum)
     //# decrypt MUST yield an error.
-    let _esdk_id = get_esdk_id(state.header.suite.id)?;
+    get_esdk_id(state.header.suite.id)?;
 
     //= spec/client-apis/decrypt.md#behavior
     //= reason=verification_key presence must match suite's signature algorithm; mismatch means misbehaving CMM
@@ -669,7 +671,7 @@ fn step_verify_signature(ciphertext: &mut dyn SafeRead, state: &DecryptState) ->
             //= spec/client-apis/decrypt.md#verify-the-signature
             //# - The verification key MUST be the [verification key](../framework/structures.md#verification-key)
             //# in the decryption materials.
-            state.dec_mat.clone(),
+            &state.dec_mat,
             &mut noop,
         )?;
     } else {
@@ -708,7 +710,7 @@ pub fn get_ecdsa_alg(
 fn verify_signature(
     r: &mut dyn SafeRead,
     context: DigestContext,
-    dec_mat: aws_mpl_legacy::DecryptionMaterials,
+    dec_mat: &aws_mpl_legacy::DecryptionMaterials,
     sig_digest: &mut dyn SafeWrite,
 ) -> Result<(), Error> {
     if dec_mat.verification_key.is_none() {
@@ -722,11 +724,12 @@ fn verify_signature(
     //# the Decrypt operation MUST wait for enough bytes to become consumable or for the caller
     //# to indicate an end to the encrypted message.
     let signature = footer::read_footer(r, sig_digest)?;
-    let ecdsa_params = get_ecdsa_alg(dec_mat.algorithm_suite.signature)?;
+    let ecdsa_params = get_ecdsa_alg(dec_mat.algorithm_suite.signature.clone())?;
 
     let valid = ecdsa_verify_context(
         ecdsa_params,
         &dec_mat.verification_key
+            .as_ref()
             .ok_or_else(|| val_err("Decryption materials must contain a verification key for signature verification"))?
             .0,
         context,

--- a/esdk/src/decrypt.rs
+++ b/esdk/src/decrypt.rs
@@ -646,6 +646,8 @@ fn step_verify_signature(ciphertext: &mut dyn SafeRead, state: &DecryptState) ->
     //# the Decrypt operation MUST verify the message footer using the specified signature algorithm.
     //
     //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=implication
+    //= reason=step_verify_signature reads from the same SafeRead cursor the body decode left positioned past the body, so the next bytes read are the footer by construction
     //# After deserializing the body, the Decrypt operation MUST deserialize the next encrypted message bytes
     //# as the [message footer](../data-format/message-footer.md).
     if state.dec_mat.verification_key.is_some() {

--- a/esdk/src/decrypt.rs
+++ b/esdk/src/decrypt.rs
@@ -1,0 +1,723 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Decrypt operation — deserializes the encrypted message header and body,
+//! obtains decryption materials from a keyring/CMM, derives the data key,
+//! and decrypts the plaintext (handling both framed and nonframed formats).
+
+use crate::encrypt::get_esdk_id;
+use crate::error::{Error, esdk_err, val_err};
+use crate::key_derivation;
+use crate::materials;
+use crate::message::header_types::ContentType;
+use crate::message::serializable_types::{from_canonical_pairs, to_canonical_pairs};
+use crate::message::{
+    DigestWriter, NoopWriter, body, encryption_context, footer, header, header_auth, header_types,
+    serialize_functions, v2_header_body,
+};
+use crate::types::{
+    DecryptInput, DecryptOutput, DecryptStreamInput, DecryptStreamOutput, EncryptionContext,
+    MaterialSource, NetV400RetryPolicy, SafeRead, SafeWrite,
+};
+use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
+use aws_mpl_legacy::primitives::{
+    DigestContext, EcdsaSignatureAlgorithm, aes_decrypt, ecdsa_verify_context,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ProtectionNeeded {
+    /// Customer can see partial results, so multi-frame signed payloads forbidden
+    Yes,
+    /// Don't worry about multi-frame signed payloads
+    No,
+}
+impl ProtectionNeeded {
+    const fn yes(&self) -> bool {
+        match self {
+            Self::Yes => true,
+            Self::No => false,
+        }
+    }
+
+    // if overridden set to true, no safety needed
+    const fn needs_protection(overridden: bool) -> Self {
+        if overridden { Self::No } else { Self::Yes }
+    }
+}
+
+//= spec/client-apis/decrypt.md#security-considerations
+//= type=implication
+//= reason=Ok is only returned after signature verification; streamed bytes are unverified until then
+//# If this operation is [streaming](streaming.md) output to the caller
+//# and is decrypting messages created with an algorithm suite including a signature algorithm,
+//# any released plaintext MUST NOT be considered signed data until this operation finishes
+//# successfully.
+//
+//= spec/client-apis/decrypt.md#verify-the-header
+//= reason=Ok is returned only after step_verify_signature succeeds
+//# However, if the streamed Decrypt operation is using an algorithm suite with a signature algorithm
+//# all released output MUST NOT be considered signed data until
+//# this operation successfully completes.
+//
+//= spec/client-apis/decrypt.md#security-considerations
+//= type=implication
+//= reason=Caller obligation; Ok signals completion
+//# This means that callers that process such released plaintext MUST NOT consider any processing successful
+//# until this operation completes successfully.
+//
+//= spec/client-apis/decrypt.md#security-considerations
+//= reason=Caller obligation; Err signals discard
+//# Additionally, if this operation fails, callers MUST discard the released plaintext and encryption context
+//# and MUST rollback any processing done due to the released plaintext or encryption context.
+/// Decrypt an encrypted message stream, writing plaintext to the output.
+///
+/// # Errors
+/// Returns an error if input validation, header parsing, decryption, or signature verification fails.
+pub async fn decrypt_stream(
+    //= spec/client-apis/decrypt.md#encrypted-message
+    //= type=implication
+    //= reason=SafeRead processes bytes incrementally without buffering the full message
+    //# This input MAY be [streamed](streaming.md) to this operation.
+    //
+    //= spec/client-apis/decrypt.md#encrypted-message
+    //= type=implication
+    //= reason=SafeRead processes incrementally; full message never held in memory
+    //# If an implementation requires holding the entire encrypted message in memory in order to perform this operation,
+    //# that implementation SHOULD NOT provide an API that allows the caller to stream the encrypted message.
+    ciphertext: &mut dyn SafeRead,
+    //= spec/client-apis/decrypt.md#plaintext
+    //= type=implication
+    //= reason=SafeWrite flushes each decrypted frame without buffering the full plaintext
+    //# This operation MAY [stream](streaming.md) the plaintext as output.
+    //
+    //= spec/client-apis/decrypt.md#plaintext
+    //= type=exception
+    //= reason=Does not require holding input plaintext in memory
+    //# If an implementation requires holding the entire encrypted message in memory in order to perform this operation,
+    //# that implementation SHOULD NOT provide an API that allows the caller to stream the encrypted message.
+    plaintext: &mut dyn SafeWrite,
+    input: &DecryptStreamInput,
+) -> Result<DecryptStreamOutput, Error> {
+    input.validate()?;
+
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=exception
+    //= reason=unsafe_release_plaintext_before_verify gates multi-frame signed messages; single-frame is buffered until after verify
+    //# - The ESDK MUST provide a configuration option that causes the decryption operation
+    //# to fail immediately after parsing the header if a signed algorithm suite is used.
+    let safety = ProtectionNeeded::needs_protection(input.unsafe_release_plaintext_before_verify);
+
+    internal_decrypt(
+        ciphertext,
+        plaintext,
+        input.source.clone(),
+        &input.encryption_context,
+        input.net_v4_retry_policy,
+        safety,
+        input.max_encrypted_data_keys,
+        input.commitment_policy,
+    )
+    .await
+}
+
+//= spec/client-apis/client.md#decrypt
+//# The AWS Encryption SDK Client MUST provide an [decrypt](./decrypt.md#input) function
+//# that adheres to [decrypt](./decrypt.md).
+/// Decrypt an encrypted message, returning the plaintext and metadata.
+///
+/// # Errors
+/// Returns an error if input validation, header parsing, decryption, or signature verification fails.
+pub async fn decrypt(input: &DecryptInput<'_>) -> Result<DecryptOutput, Error> {
+    input.validate()?;
+    let mut cursor = std::io::Cursor::new(input.ciphertext);
+
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=implication
+    //= reason=decrypt() returns Result; caller cannot access output until Ok
+    //# If the input encrypted message is not being [streamed](streaming.md) to this operation,
+    //# all output MUST NOT be released until after these steps complete successfully.
+    let mut plaintext: Vec<u8> = Vec::with_capacity(input.ciphertext.len());
+
+    let out = internal_decrypt(
+        &mut cursor,
+        &mut plaintext,
+        input.source.clone(),
+        &input.encryption_context,
+        input.net_v4_retry_policy,
+        ProtectionNeeded::No, // Customer cannot see any partial results
+        input.max_encrypted_data_keys,
+        input.commitment_policy,
+    )
+    .await?;
+
+    let Ok(ciphertext_len) = u64::try_from(input.ciphertext.len()) else {
+        return Err(esdk_err("Ciphertext length does not fit in u64"));
+    };
+    if cursor.position() != ciphertext_len {
+        //= spec/client-apis/decrypt.md#behavior
+        //# - If this operation successfully completes the above steps
+        //# but there are consumable bytes which are intended to be decrypted,
+        //# this operation MUST fail.
+        return Err(esdk_err("Data after message footer"));
+    }
+
+    Ok(DecryptOutput {
+        //= spec/client-apis/decrypt.md#output
+        //= type=implication
+        //= reason=DecryptOutput struct always contains plaintext field
+        //# - Decrypt operation output MUST include a [Plaintext](#plaintext) value.
+        plaintext,
+        //= spec/client-apis/decrypt.md#output
+        //# - Decrypt operation output MUST include an [encryption context](#encryption-context) value.
+        //
+        //= spec/client-apis/decrypt.md#encryption-context
+        //= type=exception
+        //= reason=The encryption context is returned directly as a field, not via a parsed header struct
+        //# This output MAY be satisfied by outputting a [parsed header](#parsed-header) containing this value.
+        encryption_context: out.encryption_context,
+        //= spec/client-apis/decrypt.md#output
+        //# - Decrypt operation output MUST include an [algorithm suite](#algorithm-suite) value.
+        //
+        //= spec/client-apis/decrypt.md#algorithm-suite
+        //= type=exception
+        //= reason=The algorithm suite is returned directly as a field, not via a parsed header struct
+        //# This output MAY be satisfied by outputting a [parsed header](#parsed-header) containing this value.
+        algorithm_suite_id: out.algorithm_suite_id,
+        //= spec/client-apis/decrypt.md#output
+        //= type=exception
+        //= reason=Parsed header is not spec'ed out; this is a SHOULD, not a MUST
+        //# - Decrypt operation output SHOULD include a [Parsed Header](#parsed-header) value.
+    })
+}
+
+/// Intermediate state passed between decrypt steps.
+struct DecryptState {
+    header: header::HeaderInfo,
+    dec_mat: aws_mpl_legacy::DecryptionMaterials,
+    derived_data_keys: key_derivation::ExpandedKeyMaterial,
+    sig_digest: DigestWriter,
+    encryption_context_to_only_authenticate: EncryptionContext,
+}
+
+#[expect(clippy::too_many_arguments)]
+//= spec/client-apis/decrypt.md#behavior
+//= type=implication
+//= reason=SafeWrite receives output only after per-frame AEAD; last frame held until after signature verify
+//# - Output MUST NOT be released until otherwise indicated.
+//
+//= spec/client-apis/decrypt.md#behavior
+//= reason=Every step uses ?; any failure returns Err to the caller
+//# - If all bytes have been provided and this operation
+//# is unable to complete the above steps with the consumable encrypted message bytes,
+//# this operation MUST halt and indicate a failure to the caller.
+async fn internal_decrypt(
+    ciphertext: &mut dyn SafeRead,
+    plaintext: &mut dyn SafeWrite,
+    input_source: Option<MaterialSource>,
+    encryption_context: &EncryptionContext,
+    net_v4_retry_policy: NetV400RetryPolicy,
+    safety_needed: ProtectionNeeded,
+    max_encrypted_data_keys: Option<std::num::NonZeroUsize>,
+    commitment_policy: EsdkCommitmentPolicy,
+) -> Result<DecryptStreamOutput, Error> {
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=implication
+    //# - Decrypt operation Step 1 MUST be [Parse the header](#parse-the-header)
+    let (header_body, raw_header, sig_digest) =
+        step_parse_header(ciphertext, max_encrypted_data_keys)?;
+
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=implication
+    //# - Decrypt operation Step 2 MUST be [Get the decryption materials](#get-the-decryption-materials)
+    let state = step_get_decryption_materials(
+        ciphertext,
+        &header_body,
+        raw_header,
+        input_source,
+        encryption_context,
+        commitment_policy,
+        sig_digest,
+    )
+    .await?;
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# If this algorithm suite is not [supported for the ESDK](../framework/algorithm-suites.md#supported-algorithm-suites-enum)
+    //# decrypt MUST yield an error.
+    let _esdk_id = get_esdk_id(state.header.suite.id)?;
+
+    //= spec/client-apis/decrypt.md#behavior
+    //= reason=verification_key presence must match suite's signature algorithm; mismatch means misbehaving CMM
+    //# - If the message header contains an algorithm suite including a
+    //# [signature algorithm](../framework/algorithm-suites.md#signature-algorithm),
+    //# the Decrypt operation MUST perform this step.
+    let suite_has_signature = !matches!(
+        state.header.suite.signature,
+        aws_mpl_legacy::suites::SignatureAlgorithm::None
+    );
+    if suite_has_signature != state.dec_mat.verification_key.is_some() {
+        return Err(val_err(
+            "Decryption materials verification_key presence must match algorithm suite signature algorithm",
+        ));
+    }
+
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= reason=Parsed header kept in local state until step_verify_header succeeds
+    //# Until the [header is verified](#verify-the-header), this operation MUST NOT
+    //# release any parsed information from the header.
+
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=implication
+    //# - Decrypt operation Step 3 MUST be [Verify the header](#verify-the-header)
+    let mut state = step_verify_header(state, net_v4_retry_policy)?;
+
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=implication
+    //# - Decrypt operation Step 4 MUST be [Decrypt the message body](#decrypt-the-message-body)
+    let last_frame = step_decrypt_body(ciphertext, plaintext, &mut state, &safety_needed)?;
+
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=implication
+    //# - Decrypt operation Step 5 MUST be [Verify the signature](#verify-the-signature)
+    step_verify_signature(ciphertext, &state)?;
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //# Any plaintext decrypted from [nonframed data](../data-format/message-body.md#nonframed-data) or
+    //# a final frame in a streamed Decrypt operation MUST NOT be released until [signature verification](#verify-the-signature)
+    //# successfully completes.
+
+    //= spec/client-apis/decrypt.md#authenticated-data
+    //# This operation MUST NOT release any unauthenticated plaintext or unauthenticated associated data.
+    serialize_functions::write_bytes(plaintext, &last_frame)?;
+
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=exception
+    //= reason=SafeRead has no "end of stream" signal; non-streaming wrapper checks cursor position instead
+    //# - If this operation successfully completes the above steps
+    //# but there are consumable bytes which are intended to be decrypted,
+    //# this operation MUST fail.
+
+    // Merge authenticate-only encryption context with header encryption context.
+    // These sets are designed to be disjoint (authenticate-only keys are removed from the
+    // header before serialization); on any overlap, prefer the authenticate-only value
+    // because it was verified as AAD and is the source of truth.
+    let mut ec = state.header.encryption_context;
+    for (k, v) in state.encryption_context_to_only_authenticate {
+        ec.insert(k, v);
+    }
+
+    //= spec/client-apis/streaming.md#outputs
+    //= reason=All bytes written to SafeWrite before Ok is returned
+    //# Operations MUST NOT indicate completion or success until an end to the output has been indicated.
+    //
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= reason=Encryption context and suite released only after step_verify_header succeeded
+    //# - A streamed Decrypt operation SHOULD release the parsed [encryption context](#encryption-context),
+    //# [algorithm suite ID](../data-format/message-header.md#algorithm-suite-id),
+    //# and [other header information](#parsed-header)
+    //# as soon as tag verification succeeds.
+    Ok(DecryptStreamOutput {
+        encryption_context: ec,
+        //= spec/client-apis/decrypt.md#algorithm-suite
+        //# This algorithm suite MUST be [supported for the ESDK](../framework/algorithm-suites.md#supported-algorithm-suites-enum).
+        algorithm_suite_id: get_esdk_id(state.header.suite.id)?,
+    })
+}
+
+// Step 1: Parse the header
+fn step_parse_header(
+    ciphertext: &mut dyn SafeRead,
+    max_encrypted_data_keys: Option<std::num::NonZeroUsize>,
+) -> Result<(header_types::HeaderBody, Vec<u8>, DigestWriter), Error> {
+    let mut raw_header = Vec::new();
+
+    //= spec/client-apis/decrypt.md#parse-the-header
+    //= type=implication
+    //= reason=SafeRead provides sequential byte access only; no seek or random access
+    //# Given encrypted message bytes, this operation MUST process those bytes sequentially,
+    //# deserializing those bytes according to the [message format](../data-format/message.md).
+    //
+    //= spec/client-apis/decrypt.md#parse-the-header
+    //= type=implication
+    //= reason=read_header_body returns Err on incomplete data or reads until header is complete
+    //# This operation MUST attempt to deserialize all consumable encrypted message bytes until it has
+    //# successfully deserialized a valid [message header](../data-format/message-header.md).
+    let header_body =
+        header::read_header_body(ciphertext, max_encrypted_data_keys, &mut raw_header)?;
+
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= reason=sig_digest is fed header bytes immediately; raw header not retained for later
+    //# - The streamed Decrypt operation SHOULD input the serialized header to the signature algorithm as soon as it is deserialized,
+    //# such that the serialized header isn't required to remain in memory to [verify the signature](#verify-the-signature).
+    let mut sig_digest = DigestWriter::from_old_ecdsa(header_body.algorithm_suite().signature)?;
+    serialize_functions::write_bytes(&mut sig_digest, &raw_header)?;
+
+    Ok((header_body, raw_header, sig_digest))
+}
+
+// Step 2: Get the decryption materials
+async fn step_get_decryption_materials(
+    ciphertext: &mut dyn SafeRead,
+    header_body: &header_types::HeaderBody,
+    raw_header: Vec<u8>,
+    input_source: Option<MaterialSource>,
+    encryption_context: &EncryptionContext,
+    commitment_policy: EsdkCommitmentPolicy,
+    mut sig_digest: DigestWriter,
+) -> Result<DecryptState, Error> {
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# The CMM used MUST be the input CMM, if supplied.
+    //
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# If a CMM is not supplied as the input, the decrypt operation MUST construct a [default CMM](../framework/default-cmm.md)
+    //# from the input [keyring](../framework/keyring-interface.md).
+    let cmm = materials::create_cmm_from_input(input_source).await?;
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# If the parsed [algorithm suite ID](../data-format/message-header.md#algorithm-suite-id)
+    //# is not supported by the [commitment policy](client.md#commitment-policy)
+    //# configured in the [client](client.md) decrypt MUST yield an error.
+    aws_mpl_legacy::commitment::validate_commitment_policy_on_decrypt(
+        aws_mpl_legacy::commitment::ValidateCommitmentPolicyOnDecryptInput::new(
+            header_body.algorithm_suite().id,
+            aws_mpl_legacy::commitment::CommitmentPolicy::Esdk(commitment_policy),
+        ),
+    )?;
+
+    let dec_mat = materials::get_decryption_materials(
+        cmm,
+        header_body.algorithm_suite().id,
+        header_body,
+        encryption_context,
+        commitment_policy,
+    )
+    .await?;
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# The algorithm suite used as input for all decryption described below MUST be the algorithm suite
+    //# included in the [decryption materials](../framework/structures.md#decryption-materials).
+    let suite = &dec_mat.algorithm_suite;
+
+    if suite != header_body.algorithm_suite() {
+        return Err(val_err(
+            "Stored header algorithm suite does not match decryption algorithm suite",
+        ));
+    }
+
+    let header_auth =
+        //= spec/client-apis/decrypt.md#v1-header-deserialization
+        //# - MUST deserialize the [Authentication Tag](../data-format/message-header.md#authentication-tag).
+        //
+        //= spec/client-apis/decrypt.md#v2-header-deserialization
+        //# - MUST deserialize the [Authentication Tag](../data-format/message-header.md#authentication-tag).
+        header_auth::read_header_auth_tag(ciphertext, suite, &mut sig_digest)?;
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# The data key used as input for all decryption described below MUST be a data key derived from the plaintext data key
+    //# included in the [decryption materials](../framework/structures.md#decryption-materials).
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# The algorithm suite used to derive a data key from the plaintext data key MUST be
+    //# the [key derivation algorithm](../framework/algorithm-suites.md#key-derivation-algorithm) included in the
+    //# [algorithm suite](../framework/algorithm-suites.md) associated with
+    //# the returned decryption materials.
+    let derived_data_keys = key_derivation::derive_keys(
+        header_body.message_id(),
+        dec_mat
+            .plaintext_data_key
+            .as_ref()
+            .ok_or_else(|| val_err("Decryption materials must contain a plaintext data key"))?
+            .as_bytes(),
+        suite,
+        false,
+    )?;
+
+    if !header::header_version_supports_commitment(suite, header_body) {
+        return Err(val_err("Invalid commitment values found in header body"));
+    }
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# If the [algorithm suite](../framework/algorithm-suites.md#algorithm-suites-encryption-key-derivation-settings) supports [key commitment](../framework/algorithm-suites.md#key-commitment)
+    //# then the [commit key](../framework/algorithm-suites.md#commit-key) MUST be derived from the plaintext data key
+    //# using the [commit key derivation](../framework/algorithm-suites.md#algorithm-suites-commit-key-derivation-settings).
+    if v2_header_body::has_hkdf(&suite.commitment) {
+        //= spec/client-apis/decrypt.md#get-the-decryption-materials
+        //# The derived commit key MUST equal the commit key stored in the message header.
+        header::validate_suite_data(
+            suite,
+            header_body,
+            derived_data_keys.commitment_key.as_ref().ok_or_else(|| {
+                val_err("Derived key material must contain a commitment key for HKDF commitment")
+            })?,
+        )?;
+    }
+
+    let header_encryption_context = from_canonical_pairs(header_body.encryption_context().clone());
+    let encryption_context_to_only_authenticate =
+        build_encryption_context_to_only_authenticate(&dec_mat);
+
+    let header = header::HeaderInfo {
+        body: header_body.clone(),
+        raw_header,
+        encryption_context: header_encryption_context,
+        suite: suite.clone(),
+        header_auth,
+    };
+
+    Ok(DecryptState {
+        header,
+        dec_mat,
+        derived_data_keys,
+        sig_digest,
+        encryption_context_to_only_authenticate,
+    })
+}
+
+// Step 3: Verify the header
+fn step_verify_header(
+    mut state: DecryptState,
+    net_v4_retry_policy: NetV400RetryPolicy,
+) -> Result<DecryptState, Error> {
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //# The encryption context to only authenticate MUST be the [encryption context](../framework/structures.md#encryption-context)
+    //# in the [decryption materials](../framework/structures.md#decryption-materials)
+    //# filtered to only contain key value pairs listed in
+    //# the [decryption material's](../framework/structures.md#decryption-materials)
+    //# [required encryption context keys](../framework/structures.md#required-encryption-context-keys-1)
+    //# serialized according to the [encryption context serialization specification](../framework/structures.md#serialization).
+    let canonical_req_encryption_context =
+        to_canonical_pairs(state.encryption_context_to_only_authenticate.clone());
+    let mut serialized_req_encryption_context = Vec::new();
+    encryption_context::write_empty_ec_or_write_aad(
+        &mut serialized_req_encryption_context,
+        &canonical_req_encryption_context,
+    )?;
+
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //# Once a valid message header is deserialized and decryption materials are available,
+    //# this operation MUST validate the [message header body](../data-format/message-header.md#header-body)
+    //# by using the [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
+    //# to decrypt with the following inputs:
+    let mut maybe_header_auth = aes_decrypt(
+        body::get_alg_suite(&state.header.suite)?,
+        //= spec/client-apis/decrypt.md#verify-the-header
+        //# - the cipherkey MUST be the derived data key
+        &state.derived_data_keys.data_key,
+        //= spec/client-apis/decrypt.md#verify-the-header
+        //# - the ciphertext MUST be an empty byte array
+        &[],
+        //= spec/client-apis/decrypt.md#verify-the-header
+        //# - the tag MUST be the value serialized in the message header's
+        //# [authentication tag field](../data-format/message-header.md#authentication-tag)
+        state.header.header_auth.header_auth_tag(),
+        //= spec/client-apis/decrypt.md#verify-the-header
+        //# - For message format version [1.0](../data-format/message-header.md#supported-versions)
+        //# the IV MUST be the value serialized in the message header's [IV field](../data-format/message-header.md#iv).
+        //
+        //= spec/client-apis/decrypt.md#verify-the-header
+        //# For message format version [2.0](../data-format/message-header.md#supported-versions)
+        //# the IV MUST be 0.
+        state.header.header_auth.header_iv(),
+        //= spec/client-apis/decrypt.md#verify-the-header
+        //# - The AAD MUST be the concatenation of the serialized [message header body](../data-format/message-header.md#header-body)
+        //# and the serialization of encryption context to only authenticate.
+        &[
+            &state.header.raw_header[..],
+            &serialized_req_encryption_context[..],
+        ]
+        .concat(),
+        &mut [],
+    );
+
+    // ESDK-NET v4.0.0 Header Auth Catch
+    if maybe_header_auth.is_err() && net_v4_retry_policy == NetV400RetryPolicy::AllowRetry {
+        let derived_data_keys = key_derivation::derive_keys(
+            state.header.body.message_id(),
+            state
+                .dec_mat
+                .plaintext_data_key
+                .as_ref()
+                .ok_or_else(|| val_err("Decryption materials must contain a plaintext data key"))?
+                .as_bytes(),
+            &state.header.suite,
+            true,
+        )?;
+        state.derived_data_keys = derived_data_keys;
+        let mut serialized_req_encryption_context_v4 = Vec::new();
+        encryption_context::write_aad(
+            &mut serialized_req_encryption_context_v4,
+            &canonical_req_encryption_context,
+        )?;
+        maybe_header_auth = aes_decrypt(
+            body::get_alg_suite(&state.header.suite)?,
+            &state.derived_data_keys.data_key,
+            &[],
+            state.header.header_auth.header_auth_tag(),
+            state.header.header_auth.header_iv(),
+            &[
+                &state.header.raw_header[..],
+                &serialized_req_encryption_context_v4[..],
+            ]
+            .concat(),
+            &mut [],
+        );
+    }
+
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //# If this tag verification fails, this operation MUST immediately halt and fail.
+    maybe_header_auth?;
+
+    Ok(state)
+}
+
+// Step 4: Decrypt the message body
+fn step_decrypt_body(
+    ciphertext: &mut dyn SafeRead,
+    plaintext: &mut dyn SafeWrite,
+    state: &mut DecryptState,
+    safety_needed: &ProtectionNeeded,
+) -> Result<Vec<u8>, Error> {
+    let key = state.derived_data_keys.data_key.clone();
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //# Once the message header is successfully parsed, the next sequential bytes
+    //# MUST be deserialized according to the [message body spec](../data-format/message-body.md).
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //# The Decrypt operation MUST use the [content type](../data-format/message-header.md#content-type) field parsed from the
+    //# message header to determine whether the operation will deserialize the message bytes as
+    //# [framed data](../data-format/message-body.md#framed-data) or
+    //# [nonframed data](../data-format/message-body.md#nonframed-data).
+    let last_frame = match state.header.body.content_type() {
+        ContentType::NonFramed => {
+            //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+            //# Nonframed data deserialization MUST conform to the [Nonframed Data](../data-format/message-body.md#nonframed-data) specification.
+            //
+            //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+            //= reason=read_and_decrypt_non_framed_message_body deserializes and decrypts per the nonframed data specification
+            //# If a message has the [nonframed](../data-format/message-body.md#nonframed-data) content type,
+            //# the Decrypt operation MUST deserialize the message body according to the
+            //# [nonframed data specification](../data-format/message-body.md#nonframed-data)
+            //# and decrypt it using the [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
+            //# specified by the [algorithm suite](../framework/algorithm-suites.md), with the following inputs:
+            body::read_and_decrypt_non_framed_message_body(
+                ciphertext,
+                &state.header,
+                &key,
+                &mut state.sig_digest,
+            )?
+        }
+        ContentType::Framed => {
+            let fail_if_multi_frame =
+                state.dec_mat.verification_key.is_some() && safety_needed.yes();
+            body::read_and_decrypt_framed_message_body(
+                ciphertext,
+                plaintext,
+                &state.header,
+                &key,
+                &mut state.sig_digest,
+                fail_if_multi_frame,
+            )?
+        }
+    };
+    Ok(last_frame)
+}
+
+// Step 5: Verify the signature
+fn step_verify_signature(ciphertext: &mut dyn SafeRead, state: &DecryptState) -> Result<(), Error> {
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //# If the algorithm suite has a signature algorithm,
+    //# the Decrypt operation MUST verify the message footer using the specified signature algorithm.
+    //
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //# After deserializing the body, the Decrypt operation MUST deserialize the next encrypted message bytes
+    //# as the [message footer](../data-format/message-footer.md).
+    if state.dec_mat.verification_key.is_some() {
+        let mut noop = NoopWriter;
+
+        //= spec/client-apis/decrypt.md#verify-the-signature
+        //# Once the message footer is deserialized, the Decrypt operation MUST use the
+        //# [signature algorithm](../framework/algorithm-suites.md#signature-algorithm)
+        //# from the [algorithm suite](../framework/algorithm-suites.md) in the decryption materials to
+        //# verify the encrypted message, with the following inputs:
+        verify_signature(
+            ciphertext,
+            //= spec/client-apis/decrypt.md#verify-the-signature
+            //# - The input to verify MUST be the concatenation of the serialization of the
+            //# [message header](../data-format/message-header.md) and [message body](../data-format/message-body.md).
+            state.sig_digest.context.clone().ok_or_else(|| {
+                val_err("Signature digest context must be present for signature verification")
+            })?,
+            //= spec/client-apis/decrypt.md#verify-the-signature
+            //# - The verification key MUST be the [verification key](../framework/structures.md#verification-key)
+            //# in the decryption materials.
+            state.dec_mat.clone(),
+            &mut noop,
+        )?;
+    } else {
+        //= spec/client-apis/decrypt.md#behavior
+        //# - If the message header does not contain an algorithm suite including a signature algorithm,
+        //# the Decrypt operation MUST NOT perform this step.
+        return Ok(());
+    }
+    Ok(())
+}
+
+// The encryption context to only authenticate MUST be
+// the encryption context in the decryption materials filtered
+// to only contain key value pairs listed
+// in the decryption material's required encryption context keys.
+fn build_encryption_context_to_only_authenticate(
+    dec_mat: &aws_mpl_legacy::DecryptionMaterials,
+) -> EncryptionContext {
+    dec_mat
+        .encryption_context
+        .iter()
+        .filter(|(k, _)| dec_mat.required_encryption_context_keys.contains(k))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+pub fn get_ecdsa_alg(
+    alg: aws_mpl_legacy::suites::SignatureAlgorithm,
+) -> Result<EcdsaSignatureAlgorithm, Error> {
+    match alg {
+        aws_mpl_legacy::suites::SignatureAlgorithm::Ecdsa(x) => Ok(x),
+        _ => Err(val_err("Unsupported signature algorithm")),
+    }
+}
+
+fn verify_signature(
+    r: &mut dyn SafeRead,
+    context: DigestContext,
+    dec_mat: aws_mpl_legacy::DecryptionMaterials,
+    sig_digest: &mut dyn SafeWrite,
+) -> Result<(), Error> {
+    if dec_mat.verification_key.is_none() {
+        return Ok(());
+    }
+
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= reason=blocking read on the input stream implicitly waits for enough bytes
+    //# If there are not enough consumable bytes to deserialize the message footer and
+    //# the caller has not yet indicated an end to the encrypted message,
+    //# the Decrypt operation MUST wait for enough bytes to become consumable or for the caller
+    //# to indicate an end to the encrypted message.
+    let signature = footer::read_footer(r, sig_digest)?;
+    let ecdsa_params = get_ecdsa_alg(dec_mat.algorithm_suite.signature)?;
+
+    let valid = ecdsa_verify_context(
+        ecdsa_params,
+        &dec_mat.verification_key
+            .ok_or_else(|| val_err("Decryption materials must contain a verification key for signature verification"))?
+            .0,
+        context,
+        &signature,
+    )?;
+
+    if !valid {
+        //= spec/client-apis/decrypt.md#verify-the-signature
+        //# If this verification is not successful, this operation MUST immediately halt and fail.
+        return Err(esdk_err("Signature verification failed"));
+    }
+    Ok(())
+}

--- a/esdk/src/decrypt.rs
+++ b/esdk/src/decrypt.rs
@@ -310,7 +310,8 @@ async fn internal_decrypt(
     //# Operations MUST NOT indicate completion or success until an end to the output has been indicated.
     //
     //= spec/client-apis/decrypt.md#verify-the-header
-    //= reason=Encryption context and suite released only after step_verify_header succeeded
+    //= type=exception
+    //= reason=DecryptStreamOutput is returned at end of operation; encryption_context and algorithm_suite_id are available to the caller only when the function returns Ok, not eagerly "as soon as tag verification succeeds"
     //# - A streamed Decrypt operation SHOULD release the parsed [encryption context](#encryption-context),
     //# [algorithm suite ID](../data-format/message-header.md#algorithm-suite-id),
     //# and [other header information](#parsed-header)
@@ -412,6 +413,8 @@ async fn step_get_decryption_materials(
         header_auth::read_header_auth_tag(ciphertext, suite, &mut sig_digest)?;
 
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=implication
+    //= reason=Source literally passes dec_mat.plaintext_data_key as the PDK input to derive_keys
     //# The data key used as input for all decryption described below MUST be a data key derived from the plaintext data key
     //# included in the [decryption materials](../framework/structures.md#decryption-materials).
 
@@ -500,9 +503,13 @@ fn step_verify_header(
     let mut maybe_header_auth = aes_decrypt(
         body::get_alg_suite(&state.header.suite)?,
         //= spec/client-apis/decrypt.md#verify-the-header
+        //= type=implication
+        //= reason=Source literally passes derived_data_keys.data_key as the cipherkey argument
         //# - the cipherkey MUST be the derived data key
         &state.derived_data_keys.data_key,
         //= spec/client-apis/decrypt.md#verify-the-header
+        //= type=implication
+        //= reason=Source literally passes &[] (empty slice) as the ciphertext argument
         //# - the ciphertext MUST be an empty byte array
         &[],
         //= spec/client-apis/decrypt.md#verify-the-header
@@ -579,8 +586,18 @@ fn step_decrypt_body(
     let key = state.derived_data_keys.data_key.clone();
 
     //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=implication
+    //= reason=Body parsers read from the same `ciphertext` cursor passed to step_parse_header; cursor advances sequentially after the header parse
     //# Once the message header is successfully parsed, the next sequential bytes
     //# MUST be deserialized according to the [message body spec](../data-format/message-body.md).
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=implication
+    //= reason=SafeRead: std::io::Read is blocking; framed body reader loops calling read until EOF or completion, satisfying the wait/deserialize/decrypt branches
+    //# If there could still be message body left to deserialize and decrypt,
+    //# this operation MUST either wait for more of the encrypted message bytes to become consumable,
+    //# wait for the end to the encrypted message to be indicated,
+    //# or deserialize and/or decrypt the consumable bytes.
 
     //= spec/client-apis/decrypt.md#decrypt-the-message-body
     //# The Decrypt operation MUST use the [content type](../data-format/message-header.md#content-type) field parsed from the

--- a/esdk/tests/test_decrypt_behavior.rs
+++ b/esdk/tests/test_decrypt_behavior.rs
@@ -1,0 +1,162 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/client-apis/decrypt.md#behavior
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
+use test_helpers::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_skips_signature_step_for_non_signing_algorithm() {
+    let keyring = test_keyring().await;
+    let plaintext = b"test non-signing decrypt";
+    let ec = EncryptionContext::new();
+
+    // Encrypt with a non-signing algorithm suite
+    let mut encrypt_input = EncryptInput::with_legacy_keyring(plaintext, ec, keyring.clone());
+    encrypt_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey);
+    let ct = encrypt(&encrypt_input).await.unwrap().ciphertext;
+
+    // Prove the ciphertext has no footer — so if decrypt tried to run the
+    // signature step, it would attempt to read footer bytes from the body
+    // region and fail with a parse error.
+    assert!(!has_footer(&ct), "non-signing suite must not produce a footer");
+
+    // Decrypt succeeds despite no footer → signature step was skipped.
+    let decrypt_input = DecryptInput::from_encrypt(&ct, &encrypt_input);
+    let decrypt_output = decrypt(&decrypt_input).await.unwrap();
+
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=test
+    //= reason=No footer on wire + decrypt succeeds → signature step was not attempted
+    //# - If the message header does not contain an algorithm suite including a signature algorithm,
+    //# the Decrypt operation MUST NOT perform this step.
+    //
+    assert_eq!(decrypt_output.plaintext, plaintext);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_halts_on_incomplete_message() {
+    let keyring = test_keyring().await;
+    let plaintext = b"truncation test data";
+    let enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Truncate to ~60% of the message — enough for the header but not the full body
+    let truncated = &ct[..ct.len() * 3 / 5];
+    let dec_input = DecryptInput::with_legacy_keyring(truncated, EncryptionContext::new(), keyring);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when ciphertext is truncated");
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=test
+    //= reason=Truncated ciphertext triggers SerializationError, proving incomplete input halts
+    //# - If all bytes have been provided and this operation
+    //# is unable to complete the above steps with the consumable encrypted message bytes,
+    //# this operation MUST halt and indicate a failure to the caller.
+    assert_eq!(err.kind, ErrorKind::SerializationError, "truncated message must be SerializationError, got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_fails_with_trailing_bytes_after_message() {
+    let keyring = test_keyring().await;
+    let plaintext = b"trailing bytes test";
+    let enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Append extra bytes after the valid message
+    ct.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when there are trailing bytes after the message");
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=test
+    //= reason=Appended 4 extra bytes after valid message; decrypt rejects them
+    //# - If this operation successfully completes the above steps
+    //# but there are consumable bytes which are intended to be decrypted,
+    //# this operation MUST fail.
+    assert_eq!(err.kind, ErrorKind::Esdk, "trailing bytes must produce Esdk error, got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_streaming_fails_for_multi_frame_signed_without_override() {
+    let keyring = test_keyring().await;
+    // 30 bytes with frame_length=10 → 3 frames (2 regular + 1 final)
+    let plaintext = vec![0xAAu8; 30];
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(&plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.frame_length = FrameLength::new(10).unwrap();
+    enc_input.algorithm_suite_id =
+        Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // decrypt_stream with unsafe_release_plaintext_before_verify=false (default) must fail
+    // for multi-frame signed messages
+    let mut cursor = std::io::Cursor::new(ct.as_slice());
+    let mut output = Vec::new();
+    let stream_input =
+        DecryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring.clone());
+    // unsafe_release_plaintext_before_verify defaults to false
+    assert!(!stream_input.unsafe_release_plaintext_before_verify);
+    let result = decrypt_stream(&mut cursor, &mut output, &stream_input).await;
+    let err = result.expect_err("multi-frame signed message must fail with default unsafe_release_plaintext_before_verify=false");
+    assert_eq!(err.kind, ErrorKind::Esdk, "multi-frame signed without override must produce Esdk error, got: {err:?}");
+
+    // Same message succeeds when unsafe_release_plaintext_before_verify=true
+    let mut cursor2 = std::io::Cursor::new(ct.as_slice());
+    let mut output2 = Vec::new();
+    let mut stream_input2 =
+        DecryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
+    stream_input2.unsafe_release_plaintext_before_verify = true;
+    let result2 = decrypt_stream(&mut cursor2, &mut output2, &stream_input2).await;
+    assert!(
+        result2.is_ok(),
+        "multi-frame signed message must succeed with unsafe_release_plaintext_before_verify=true"
+    );
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=test
+    //= reason=Multi-frame signed fails with override=false, succeeds with override=true
+    //# - The ESDK MUST provide a configuration option that causes the decryption operation
+    //# to fail immediately after parsing the header if a signed algorithm suite is used.
+    assert_eq!(output2, plaintext);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_signing_suite_must_perform_signature_step() {
+    let keyring = test_keyring().await;
+    let plaintext = b"signing suite signature step test";
+
+    // Encrypt with a signing algorithm suite (ECDSA P384)
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id =
+        Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Tamper with the footer (signature area) to prove the signature step runs.
+    // If the step were skipped, tampering the footer would not cause failure.
+    let len = ct.len();
+    // Baseline: untampered ciphertext must decrypt successfully.
+    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
+    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+
+    ct[len - 3] ^= 0xFF;
+
+    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when signature is tampered — proves signature step was performed");
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=test
+    //= reason=Tampered footer causes failure, proving signature step runs for signing suites
+    //# - If the message header contains an algorithm suite including a
+    //# [signature algorithm](../framework/algorithm-suites.md#signature-algorithm),
+    //# the Decrypt operation MUST perform this step.
+    //
+    assert_eq!(err.kind, ErrorKind::Esdk, "tampered signature must produce Esdk error, got: {err:?}");
+}

--- a/esdk/tests/test_decrypt_behavior.rs
+++ b/esdk/tests/test_decrypt_behavior.rs
@@ -44,20 +44,28 @@ async fn test_decrypt_halts_on_incomplete_message() {
     let plaintext = b"truncation test data";
     let enc_input =
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
-    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Truncate to ~60% of the message — enough for the header but not the full body
-    let truncated = &ct[..ct.len() * 3 / 5];
-    let dec_input = DecryptInput::with_legacy_keyring(truncated, EncryptionContext::new(), keyring);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when ciphertext is truncated");
+    // Truncate to ~60% of the message — enough for the header but not the full body.
+    let truncated_ct = valid_ct[..valid_ct.len() * 3 / 5].to_vec();
+
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());
+    let truncated_input =
+        DecryptInput::with_legacy_keyring(&truncated_ct, EncryptionContext::new(), keyring);
+
     //= spec/client-apis/decrypt.md#behavior
     //= type=test
-    //= reason=Truncated ciphertext triggers SerializationError, proving incomplete input halts
+    //= reason=Full ct → Ok; ~60% truncated ct → SerializationError, halting on incomplete input
     //# - If all bytes have been provided and this operation
     //# is unable to complete the above steps with the consumable encrypted message bytes,
     //# this operation MUST halt and indicate a failure to the caller.
-    assert_eq!(err.kind, ErrorKind::SerializationError, "truncated message must be SerializationError, got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "full ct must decrypt");
+    assert_eq!(
+        decrypt(&truncated_input).await.unwrap_err().kind,
+        ErrorKind::SerializationError,
+        "truncated ct must produce SerializationError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -66,21 +74,29 @@ async fn test_decrypt_fails_with_trailing_bytes_after_message() {
     let plaintext = b"trailing bytes test";
     let enc_input =
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Append extra bytes after the valid message
-    ct.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+    // Append extra bytes after the valid message.
+    let mut trailing_ct = valid_ct.clone();
+    trailing_ct.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
 
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when there are trailing bytes after the message");
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());
+    let trailing_input =
+        DecryptInput::with_legacy_keyring(&trailing_ct, EncryptionContext::new(), keyring);
+
     //= spec/client-apis/decrypt.md#behavior
     //= type=test
-    //= reason=Appended 4 extra bytes after valid message; decrypt rejects them
+    //= reason=Clean ct → Ok; same ct + 4 trailing bytes → Esdk error, proving extra bytes are rejected
     //# - If this operation successfully completes the above steps
     //# but there are consumable bytes which are intended to be decrypted,
     //# this operation MUST fail.
-    assert_eq!(err.kind, ErrorKind::Esdk, "trailing bytes must produce Esdk error, got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "clean ct must decrypt");
+    assert_eq!(
+        decrypt(&trailing_input).await.unwrap_err().kind,
+        ErrorKind::Esdk,
+        "ct with trailing bytes must produce Esdk error"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -95,35 +111,34 @@ async fn test_streaming_fails_for_multi_frame_signed_without_override() {
         Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
     let ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // decrypt_stream with unsafe_release_plaintext_before_verify=false (default) must fail
-    // for multi-frame signed messages
-    let mut cursor = std::io::Cursor::new(ct.as_slice());
-    let mut output = Vec::new();
-    let stream_input =
+    // Two stream inputs differing only in unsafe_release_plaintext_before_verify.
+    let without_override =
         DecryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring.clone());
-    // unsafe_release_plaintext_before_verify defaults to false
-    assert!(!stream_input.unsafe_release_plaintext_before_verify);
-    let result = decrypt_stream(&mut cursor, &mut output, &stream_input).await;
-    let err = result.expect_err("multi-frame signed message must fail with default unsafe_release_plaintext_before_verify=false");
-    assert_eq!(err.kind, ErrorKind::Esdk, "multi-frame signed without override must produce Esdk error, got: {err:?}");
-
-    // Same message succeeds when unsafe_release_plaintext_before_verify=true
-    let mut cursor2 = std::io::Cursor::new(ct.as_slice());
-    let mut output2 = Vec::new();
-    let mut stream_input2 =
+    assert!(!without_override.unsafe_release_plaintext_before_verify); // default
+    let mut with_override =
         DecryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
-    stream_input2.unsafe_release_plaintext_before_verify = true;
-    let result2 = decrypt_stream(&mut cursor2, &mut output2, &stream_input2).await;
-    assert!(
-        result2.is_ok(),
-        "multi-frame signed message must succeed with unsafe_release_plaintext_before_verify=true"
-    );
+    with_override.unsafe_release_plaintext_before_verify = true;
+
+    let mut without_cursor = std::io::Cursor::new(ct.as_slice());
+    let mut without_output = Vec::new();
+    let mut with_cursor = std::io::Cursor::new(ct.as_slice());
+    let mut with_output = Vec::new();
+
     //= spec/client-apis/decrypt.md#behavior
     //= type=test
-    //= reason=Multi-frame signed fails with override=false, succeeds with override=true
+    //= reason=Multi-frame signed: without override (default) → Esdk error; with override=true → Ok and plaintext round-trips
     //# - The ESDK MUST provide a configuration option that causes the decryption operation
     //# to fail immediately after parsing the header if a signed algorithm suite is used.
-    assert_eq!(output2, plaintext);
+    assert_eq!(
+        decrypt_stream(&mut without_cursor, &mut without_output, &without_override).await.unwrap_err().kind,
+        ErrorKind::Esdk,
+        "multi-frame signed without override must produce Esdk error"
+    );
+    assert!(
+        decrypt_stream(&mut with_cursor, &mut with_output, &with_override).await.is_ok(),
+        "multi-frame signed with override must succeed"
+    );
+    assert_eq!(with_output, plaintext);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_decrypt_behavior.rs
+++ b/esdk/tests/test_decrypt_behavior.rs
@@ -35,7 +35,6 @@ async fn test_decrypt_skips_signature_step_for_non_signing_algorithm() {
     //= reason=No footer on wire + decrypt succeeds → signature step was not attempted
     //# - If the message header does not contain an algorithm suite including a signature algorithm,
     //# the Decrypt operation MUST NOT perform this step.
-    //
     assert_eq!(decrypt_output.plaintext, plaintext);
 }
 
@@ -137,26 +136,27 @@ async fn test_signing_suite_must_perform_signature_step() {
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
     enc_input.algorithm_suite_id =
         Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     // Tamper with the footer (signature area) to prove the signature step runs.
     // If the step were skipped, tampering the footer would not cause failure.
-    let len = ct.len();
-    // Baseline: untampered ciphertext must decrypt successfully.
-    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
-    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+    let mut tampered_ct = valid_ct.clone();
+    let len = tampered_ct.len();
+    tampered_ct[len - 3] ^= 0xFF;
 
-    ct[len - 3] ^= 0xFF;
+    let valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
+    let tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
 
-    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when signature is tampered — proves signature step was performed");
     //= spec/client-apis/decrypt.md#behavior
     //= type=test
-    //= reason=Tampered footer causes failure, proving signature step runs for signing suites
+    //= reason=Untampered ct decrypts; tampered footer → Esdk error, proving signature step runs for signing suites
     //# - If the message header contains an algorithm suite including a
     //# [signature algorithm](../framework/algorithm-suites.md#signature-algorithm),
     //# the Decrypt operation MUST perform this step.
-    //
-    assert_eq!(err.kind, ErrorKind::Esdk, "tampered signature must produce Esdk error, got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::Esdk,
+        "tampered signature must produce Esdk error"
+    );
 }

--- a/esdk/tests/test_decrypt_behavior.rs
+++ b/esdk/tests/test_decrypt_behavior.rs
@@ -26,15 +26,13 @@ async fn test_decrypt_skips_signature_step_for_non_signing_algorithm() {
     // region and fail with a parse error.
     assert!(!has_footer(&ct), "non-signing suite must not produce a footer");
 
-    // Decrypt succeeds despite no footer → signature step was skipped.
     let decrypt_input = DecryptInput::from_encrypt(&ct, &encrypt_input);
-    let decrypt_output = decrypt(&decrypt_input).await.unwrap();
-
     //= spec/client-apis/decrypt.md#behavior
     //= type=test
     //= reason=No footer on wire + decrypt succeeds → signature step was not attempted
     //# - If the message header does not contain an algorithm suite including a signature algorithm,
     //# the Decrypt operation MUST NOT perform this step.
+    let decrypt_output = decrypt(&decrypt_input).await.unwrap();
     assert_eq!(decrypt_output.plaintext, plaintext);
 }
 
@@ -99,6 +97,11 @@ async fn test_decrypt_fails_with_trailing_bytes_after_message() {
     );
 }
 
+// Multi-frame signed messages: rejected by default, accepted when
+// unsafe_release_plaintext_before_verify=true. The "MUST fail immediately
+// after parsing the header" requirement is type=exception on the source
+// (decrypt.rs); we fail during body decode rather than at header parse,
+// so this test only covers the configuration-option-exists aspect.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_streaming_fails_for_multi_frame_signed_without_override() {
     let keyring = test_keyring().await;
@@ -124,11 +127,6 @@ async fn test_streaming_fails_for_multi_frame_signed_without_override() {
     let mut with_cursor = std::io::Cursor::new(ct.as_slice());
     let mut with_output = Vec::new();
 
-    //= spec/client-apis/decrypt.md#behavior
-    //= type=test
-    //= reason=Multi-frame signed: without override (default) → Esdk error; with override=true → Ok and plaintext round-trips
-    //# - The ESDK MUST provide a configuration option that causes the decryption operation
-    //# to fail immediately after parsing the header if a signed algorithm suite is used.
     assert_eq!(
         decrypt_stream(&mut without_cursor, &mut without_output, &without_override).await.unwrap_err().kind,
         ErrorKind::Esdk,

--- a/esdk/tests/test_decrypt_output.rs
+++ b/esdk/tests/test_decrypt_output.rs
@@ -52,30 +52,35 @@ async fn test_decrypt_output_includes_algorithm_suite() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_decrypt_no_unauthenticated_data_released() {
+    // Non-signing suite so the per-frame auth tag is the integrity layer under test:
+    // tampering it makes the body plaintext unauthenticated (on-point for this requirement,
+    // unlike tampering the post-authentication signature).
     let keyring = test_keyring().await;
-    let plaintext = b"tamper test data";
-    let enc_input =
-        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    let pt = vec![0xABu8; 20];
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(&pt, EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey);
+    enc_input.frame_length = FrameLength::new(10).unwrap();
     let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Tamper with the ciphertext (flip a byte near the end, in the signature
-    // area for the default signing suite).
+    // Tamper the first regular frame's auth tag: [seq_num(4)][IV(12)][content(10)][tag(16)].
+    let body_start = find_body_start(&valid_ct, 10).expect("must find body");
+    let tag_end = body_start + 4 + IV_LEN + 10 + TAG_LEN - 1;
     let mut tampered_ct = valid_ct.clone();
-    let tamper_pos = tampered_ct.len() - 50;
-    tampered_ct[tamper_pos] ^= 0xFF;
+    tampered_ct[tag_end] ^= 0xFF;
 
     let valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
     let tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
 
     //= spec/client-apis/decrypt.md#authenticated-data
     //= type=test
-    //= reason=Untampered ct decrypts (Ok with plaintext); tampered ct → Err with no DecryptOutput, no plaintext released
+    //= reason=Untampered ct decrypts; tampered body auth tag → CryptographicError with no DecryptOutput, so unauthenticated plaintext is never released
     //# This operation MUST NOT release any unauthenticated plaintext or unauthenticated associated data.
     assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
     assert_eq!(
         decrypt(&tampered_input).await.unwrap_err().kind,
-        ErrorKind::Esdk,
-        "tampered ct must produce Esdk error, no plaintext"
+        ErrorKind::CryptographicError,
+        "tampered body auth tag must produce CryptographicError, no plaintext"
     );
 }
 
@@ -104,7 +109,7 @@ async fn test_streaming_callers_must_discard_on_failure() {
 
     //= spec/client-apis/decrypt.md#security-considerations
     //= type=test
-    //= reason=Untampered ct streams to Ok; tampered signature → Err signals callers to discard any released output
+    //= reason=SDK can only signal failure; tampered signature → Err is the discard trigger, the caller-side discard/rollback is not SDK-observable
     //# Additionally, if this operation fails, callers MUST discard the released plaintext and encryption context
     //# and MUST rollback any processing done due to the released plaintext or encryption context.
     assert!(

--- a/esdk/tests/test_decrypt_output.rs
+++ b/esdk/tests/test_decrypt_output.rs
@@ -56,24 +56,27 @@ async fn test_decrypt_no_unauthenticated_data_released() {
     let plaintext = b"tamper test data";
     let enc_input =
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Tamper with the ciphertext body (flip a byte near the end, in the encrypted content area)
-    let tamper_pos = ct.len() - 50;
-    // Baseline: untampered ciphertext must decrypt successfully.
-    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
-    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+    // Tamper with the ciphertext (flip a byte near the end, in the signature
+    // area for the default signing suite).
+    let mut tampered_ct = valid_ct.clone();
+    let tamper_pos = tampered_ct.len() - 50;
+    tampered_ct[tamper_pos] ^= 0xFF;
 
-    ct[tamper_pos] ^= 0xFF;
+    let valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
+    let tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
 
-    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when ciphertext is tampered — no unauthenticated data released");
     //= spec/client-apis/decrypt.md#authenticated-data
     //= type=test
-    //= reason=Tampered body produces error with no plaintext returned to caller
+    //= reason=Untampered ct decrypts (Ok with plaintext); tampered ct → Err with no DecryptOutput, no plaintext released
     //# This operation MUST NOT release any unauthenticated plaintext or unauthenticated associated data.
-    assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::Esdk,
+        "tampered ct must produce Esdk error, no plaintext"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -84,27 +87,33 @@ async fn test_streaming_callers_must_discard_on_failure() {
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
     enc_input.algorithm_suite_id =
         Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Tamper with the last few bytes (signature area) to cause verification failure
-    let len = ct.len();
-    // Baseline: untampered ciphertext must decrypt successfully.
-    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
-    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+    // Tamper with the last few bytes (signature area) to cause verification failure.
+    let mut tampered_ct = valid_ct.clone();
+    let len = tampered_ct.len();
+    tampered_ct[len - 5] ^= 0xFF;
 
-    ct[len - 5] ^= 0xFF;
-
-    let mut cursor = std::io::Cursor::new(ct.as_slice());
-    let mut output = Vec::new();
+    let mut valid_cursor = std::io::Cursor::new(valid_ct.as_slice());
+    let mut valid_output = Vec::new();
+    let mut tampered_cursor = std::io::Cursor::new(tampered_ct.as_slice());
+    let mut tampered_output = Vec::new();
     let mut stream_input =
         DecryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
     stream_input.unsafe_release_plaintext_before_verify = true;
-    let result = decrypt_stream(&mut cursor, &mut output, &stream_input).await;
-    let err = result.expect_err("decrypt_stream must return Err on tampered signature — callers must discard output");
+
     //= spec/client-apis/decrypt.md#security-considerations
     //= type=test
-    //= reason=Tampered signature to Err signals callers to discard released output
+    //= reason=Untampered ct streams to Ok; tampered signature → Err signals callers to discard any released output
     //# Additionally, if this operation fails, callers MUST discard the released plaintext and encryption context
     //# and MUST rollback any processing done due to the released plaintext or encryption context.
-    assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
+    assert!(
+        decrypt_stream(&mut valid_cursor, &mut valid_output, &stream_input).await.is_ok(),
+        "valid ct must stream to Ok"
+    );
+    assert_eq!(
+        decrypt_stream(&mut tampered_cursor, &mut tampered_output, &stream_input).await.unwrap_err().kind,
+        ErrorKind::Esdk,
+        "tampered signature must produce Esdk error"
+    );
 }

--- a/esdk/tests/test_decrypt_output.rs
+++ b/esdk/tests/test_decrypt_output.rs
@@ -1,0 +1,110 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for decrypt.md sections: #output, #algorithm-suite, #authenticated-data, #security-considerations
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
+use fixtures::*;
+use test_helpers::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_output_includes_encryption_context() {
+    let keyring = test_keyring().await;
+    let ec = small_encryption_context(SmallEncryptionContextVariation::AB);
+    let enc_input = EncryptInput::with_legacy_keyring(b"ec test", ec.clone(), keyring.clone());
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    let result = decrypt(&dec_input).await.unwrap();
+    for (k, v) in &ec {
+        //= spec/client-apis/decrypt.md#output
+        //= type=test
+        //# - Decrypt operation output MUST include an [encryption context](#encryption-context) value.
+        assert_eq!(result.encryption_context.get(k).unwrap(), v);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_output_includes_algorithm_suite() {
+    let keyring = test_keyring().await;
+    let suite = EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey;
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(b"suite test", EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id = Some(suite);
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    let result = decrypt(&dec_input).await.unwrap();
+    //= spec/client-apis/decrypt.md#output
+    //= type=test
+    //# - Decrypt operation output MUST include an [algorithm suite](#algorithm-suite) value.
+    //
+    //= spec/client-apis/decrypt.md#algorithm-suite
+    //= type=test
+    //= reason=Output suite matches a supported ESDK suite (AlgAes256GcmHkdfSha512CommitKey)
+    //# This algorithm suite MUST be [supported for the ESDK](../framework/algorithm-suites.md#supported-algorithm-suites-enum).
+    assert_eq!(result.algorithm_suite_id, suite);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_no_unauthenticated_data_released() {
+    let keyring = test_keyring().await;
+    let plaintext = b"tamper test data";
+    let enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Tamper with the ciphertext body (flip a byte near the end, in the encrypted content area)
+    let tamper_pos = ct.len() - 50;
+    // Baseline: untampered ciphertext must decrypt successfully.
+    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
+    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+
+    ct[tamper_pos] ^= 0xFF;
+
+    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when ciphertext is tampered — no unauthenticated data released");
+    //= spec/client-apis/decrypt.md#authenticated-data
+    //= type=test
+    //= reason=Tampered body produces error with no plaintext returned to caller
+    //# This operation MUST NOT release any unauthenticated plaintext or unauthenticated associated data.
+    assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_streaming_callers_must_discard_on_failure() {
+    let keyring = test_keyring().await;
+    let plaintext = b"discard on failure test";
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id =
+        Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Tamper with the last few bytes (signature area) to cause verification failure
+    let len = ct.len();
+    // Baseline: untampered ciphertext must decrypt successfully.
+    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
+    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+
+    ct[len - 5] ^= 0xFF;
+
+    let mut cursor = std::io::Cursor::new(ct.as_slice());
+    let mut output = Vec::new();
+    let mut stream_input =
+        DecryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
+    stream_input.unsafe_release_plaintext_before_verify = true;
+    let result = decrypt_stream(&mut cursor, &mut output, &stream_input).await;
+    let err = result.expect_err("decrypt_stream must return Err on tampered signature — callers must discard output");
+    //= spec/client-apis/decrypt.md#security-considerations
+    //= type=test
+    //= reason=Tampered signature to Err signals callers to discard released output
+    //# Additionally, if this operation fails, callers MUST discard the released plaintext and encryption context
+    //# and MUST rollback any processing done due to the released plaintext or encryption context.
+    assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
+}

--- a/esdk/tests/test_decrypt_parse_header.rs
+++ b/esdk/tests/test_decrypt_parse_header.rs
@@ -370,18 +370,11 @@ async fn test_v1_header_body_fields_parsed_from_wire() {
 
     //= spec/client-apis/decrypt.md#v1-header-deserialization
     //= type=test
-    //= reason=AAD length field at offset 20 declares N; content_type_offset = 22 + N
+    //= reason=AAD length field (wire bytes 20..22) = 0 for empty EC; AAD section on wire is exactly the 2-byte length field
     //# - MUST deserialize the [AAD](../data-format/message-header.md#aad).
     let aad_declared_len = u16::from_be_bytes([ct[20], ct[21]]) as usize;
-    let aad_section_len = if aad_declared_len > 0 {
-        2 + aad_declared_len
-    } else {
-        2
-    };
-    assert!(
-        20 + aad_section_len <= content_type_offset,
-        "AAD section bytes (length 2 + declared {aad_declared_len}) consumed before EDKs and trailing fields"
-    );
+    assert_eq!(aad_declared_len, 0, "empty EC ⇒ AAD declared length is 0 on wire");
+    let aad_section_len = 2 + aad_declared_len; // 2-byte length field + declared bytes
 
     //= spec/client-apis/decrypt.md#v1-header-deserialization
     //= type=test

--- a/esdk/tests/test_decrypt_parse_header.rs
+++ b/esdk/tests/test_decrypt_parse_header.rs
@@ -270,51 +270,12 @@ async fn test_no_header_info_released_before_verification() {
 
     let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
     let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail entirely when header verification fails — no partial header info released");
     //= spec/client-apis/decrypt.md#v2-header-deserialization
     //= type=test
-    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
-    //# - MUST deserialize the [Algorithm Suite ID](../data-format/message-header.md#algorithm-suite-id).
-    //
-    //= spec/client-apis/decrypt.md#v2-header-deserialization
-    //= type=test
-    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
-    //# - MUST deserialize the [Message ID](../data-format/message-header.md#message-id).
-    //
-    //= spec/client-apis/decrypt.md#v2-header-deserialization
-    //= type=test
-    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
-    //# - MUST deserialize the [AAD](../data-format/message-header.md#aad).
-    //
-    //= spec/client-apis/decrypt.md#v2-header-deserialization
-    //= type=test
-    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
-    //# - MUST deserialize the [Encrypted Data Keys](../data-format/message-header.md#encrypted-data-keys).
-    //
-    //= spec/client-apis/decrypt.md#v2-header-deserialization
-    //= type=test
-    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
-    //# - MUST deserialize the [Content Type](../data-format/message-header.md#content-type).
-    //
-    //= spec/client-apis/decrypt.md#v2-header-deserialization
-    //= type=test
-    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
-    //# - MUST deserialize the [Frame Length](../data-format/message-header.md#frame-length).
-    //
-    //= spec/client-apis/decrypt.md#v2-header-deserialization
-    //= type=test
-    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
-    //# - MUST deserialize the [Algorithm Suite Data](../data-format/message-header.md#algorithm-suite-data).
-    //
-    //= spec/client-apis/decrypt.md#v2-header-deserialization
-    //= type=test
-    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
-    //# - MUST deserialize the [Authentication Tag](../data-format/message-header.md#authentication-tag).
-    //
-    //= spec/client-apis/decrypt.md#v2-header-deserialization
-    //= type=test
+    //= reason=Tampered header → ValidationError with no DecryptOutput; nothing released to caller
     //# Until the [header is verified](#verify-the-header), this operation MUST NOT
     //# release any parsed information from the header.
+    let err = result.expect_err("decrypt must fail entirely when header verification fails — no partial header info released");
     assert_eq!(err.kind, ErrorKind::ValidationError, "got: {err:?}");
 }
 
@@ -348,52 +309,7 @@ async fn test_v1_header_auth_tag_deserialized_and_verified() {
     dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
     //= spec/client-apis/decrypt.md#v1-header-deserialization
     //= type=test
-    //= reason=Auth tag covers entire header body; tampered tag proves all fields read
-    //# - MUST deserialize the [Type](../data-format/message-header.md#type).
-    //
-    //= spec/client-apis/decrypt.md#v1-header-deserialization
-    //= type=test
-    //= reason=Auth tag covers entire header body
-    //# - MUST deserialize the [Algorithm Suite ID](../data-format/message-header.md#algorithm-suite-id).
-    //
-    //= spec/client-apis/decrypt.md#v1-header-deserialization
-    //= type=test
-    //= reason=Auth tag covers entire header body
-    //# - MUST deserialize the [Message ID](../data-format/message-header.md#message-id).
-    //
-    //= spec/client-apis/decrypt.md#v1-header-deserialization
-    //= type=test
-    //= reason=Auth tag covers entire header body
-    //# - MUST deserialize the [AAD](../data-format/message-header.md#aad).
-    //
-    //= spec/client-apis/decrypt.md#v1-header-deserialization
-    //= type=test
-    //= reason=Auth tag covers entire header body
-    //# - MUST deserialize the [Encrypted Data Keys](../data-format/message-header.md#encrypted-data-keys).
-    //
-    //= spec/client-apis/decrypt.md#v1-header-deserialization
-    //= type=test
-    //= reason=Auth tag covers entire header body
-    //# - MUST deserialize the [Content Type](../data-format/message-header.md#content-type).
-    //
-    //= spec/client-apis/decrypt.md#v1-header-deserialization
-    //= type=test
-    //= reason=Auth tag covers entire header body
-    //# - MUST deserialize the [Reserved](../data-format/message-header.md#reserved).
-    //
-    //= spec/client-apis/decrypt.md#v1-header-deserialization
-    //= type=test
-    //= reason=Auth tag covers entire header body
-    //# - MUST deserialize the [IV Length](../data-format/message-header.md#iv-length).
-    //
-    //= spec/client-apis/decrypt.md#v1-header-deserialization
-    //= type=test
-    //= reason=Auth tag covers entire header body
-    //# - MUST deserialize the [Frame Length](../data-format/message-header.md#frame-length).
-    //
-    //= spec/client-apis/decrypt.md#v1-header-deserialization
-    //= type=test
-    //= reason=Tampered V1 auth tag causes failure, proving it was deserialized and verified
+    //= reason=Tampered V1 auth tag byte causes tag verify failure, proving the tag was deserialized and used
     //# - MUST deserialize the [Authentication Tag](../data-format/message-header.md#authentication-tag).
     let err = decrypt(&dec_input).await.expect_err("tampered V1 auth tag must fail");
     assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
@@ -429,5 +345,287 @@ async fn test_v1_header_auth_iv_deserialized_and_used() {
     //= reason=Tampered V1 header auth IV causes failure, proving IV was deserialized and used
     //# - MUST deserialize the [IV](../data-format/message-header.md#iv).
     let err = decrypt(&dec_input).await.expect_err("tampered V1 header auth IV must fail");
+    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+}
+
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_header_body_fields_parsed_from_wire() {
+    // Drive the production deserialization path (read_header_body) on a known
+    // V1 ciphertext, then use independent on-wire field offsets
+    // (parse_v1_trailing_offsets) to assert each field's bytes/length/value at
+    // the spec-defined location. Each annotation is placed immediately above
+    // the assertion that proves that specific field was deserialized:
+    //
+    //   - For fields with public accessors (`message_id`, `algorithm_suite`),
+    //     the parsed value is asserted to equal the wire bytes at the field's
+    //     offset.
+    //   - For other fields, the wire bytes at the spec-defined offset are
+    //     asserted to have the expected length/value, AND `read_header_body`
+    //     returned Ok (consuming exactly those bytes in order). If the
+    //     implementation skipped a field, downstream offsets would be
+    //     misaligned and read_header_body would fail or yield wrong values
+    //     for the public-accessor fields.
+    use aws_esdk::__test_internals::*;
+
+    let keyring = test_keyring().await;
+    let plaintext = b"v1 fields parse test";
+
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring);
+    enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
+    enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Parse the V1 header body via the production deserialization function.
+    let mut cursor = std::io::Cursor::new(ct.as_slice());
+    let mut raw = Vec::new();
+    let header_body =
+        read_header_body(&mut cursor, None, &mut raw).expect("V1 header body must parse");
+    assert_eq!(
+        header_body.algorithm_suite().message_version,
+        1,
+        "expected V1 body"
+    );
+
+    // Independent on-wire field offsets for V1 trailing fields.
+    let (content_type_offset, reserved_offset, iv_length_offset, frame_length_offset) =
+        parse_v1_trailing_offsets(&ct);
+
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Wire byte 1 = 0x80 (Customer AED); read_header_body consumed it as Type
+    //# - MUST deserialize the [Type](../data-format/message-header.md#type).
+    assert_eq!(ct[1], 0x80, "V1 type byte must be 0x80 (Customer AED)");
+
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Parsed alg suite binary_id equals wire bytes 2..4
+    //# - MUST deserialize the [Algorithm Suite ID](../data-format/message-header.md#algorithm-suite-id).
+    assert_eq!(
+        header_body.algorithm_suite().binary_id,
+        [ct[2], ct[3]],
+        "parsed alg suite binary_id equals wire bytes"
+    );
+
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=V1 message_id is 16 wire bytes (4..20); pub accessor returns those bytes
+    //# - MUST deserialize the [Message ID](../data-format/message-header.md#message-id).
+    assert_eq!(
+        header_body.message_id().len(),
+        16,
+        "V1 message_id is 16 bytes"
+    );
+    assert_eq!(
+        header_body.message_id(),
+        &ct[4..20],
+        "parsed message_id equals wire bytes 4..20"
+    );
+
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=AAD length field at offset 20 declares N; content_type_offset = 22 + N
+    //# - MUST deserialize the [AAD](../data-format/message-header.md#aad).
+    let aad_declared_len = u16::from_be_bytes([ct[20], ct[21]]) as usize;
+    let aad_section_len = if aad_declared_len > 0 {
+        2 + aad_declared_len
+    } else {
+        2
+    };
+    assert!(
+        20 + aad_section_len <= content_type_offset,
+        "AAD section bytes (length 2 + declared {aad_declared_len}) consumed before EDKs and trailing fields"
+    );
+
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=EDK count and bodies consumed; content_type_offset is past EDK section
+    //# - MUST deserialize the [Encrypted Data Keys](../data-format/message-header.md#encrypted-data-keys).
+    let edk_section_start = 20 + aad_section_len;
+    let edk_count_on_wire = u16::from_be_bytes([ct[edk_section_start], ct[edk_section_start + 1]]);
+    assert_eq!(edk_count_on_wire, 1, "single keyring produces 1 EDK on wire");
+    assert!(
+        content_type_offset > edk_section_start,
+        "EDK section bytes consumed before content_type"
+    );
+
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Content type byte at trailing offset = 0x02 (Framed)
+    //# - MUST deserialize the [Content Type](../data-format/message-header.md#content-type).
+    assert_eq!(
+        ct[content_type_offset], 0x02,
+        "default content type is Framed (0x02)"
+    );
+
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Reserved is 4 zero bytes at expected offset (per spec)
+    //# - MUST deserialize the [Reserved](../data-format/message-header.md#reserved).
+    assert_eq!(
+        &ct[reserved_offset..reserved_offset + 4],
+        &[0u8; 4],
+        "Reserved must be 4 zero bytes"
+    );
+
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=IV Length is 1 byte at expected offset, value=12 for AES-GCM suite
+    //# - MUST deserialize the [IV Length](../data-format/message-header.md#iv-length).
+    assert_eq!(
+        ct[iv_length_offset], 12,
+        "V1 IV Length byte must equal AES-GCM IV length (12)"
+    );
+
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Frame length is 4 wire bytes BE = 4096 (default)
+    //# - MUST deserialize the [Frame Length](../data-format/message-header.md#frame-length).
+    let fl_value = u32::from_be_bytes([
+        ct[frame_length_offset],
+        ct[frame_length_offset + 1],
+        ct[frame_length_offset + 2],
+        ct[frame_length_offset + 3],
+    ]);
+    assert_eq!(fl_value, 4096, "default frame length on wire = 4096");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v2_header_body_fields_parsed_from_wire() {
+    // Drive the production deserialization path (read_header_body and
+    // read_header_auth_tag) on a known V2 ciphertext, then use independent
+    // on-wire field offsets (parse_v2_header_field_offsets) to assert each
+    // field's bytes/length/value at the spec-defined location. Each
+    // annotation is placed immediately above the assertion that proves
+    // that specific field was deserialized.
+    use aws_esdk::__test_internals::*;
+
+    let keyring = test_keyring().await;
+    let plaintext = b"v2 fields parse test";
+
+    let enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Parse the V2 header body via the production deserialization function.
+    let mut cursor = std::io::Cursor::new(ct.as_slice());
+    let mut raw = Vec::new();
+    let header_body =
+        read_header_body(&mut cursor, None, &mut raw).expect("V2 header body must parse");
+    assert_eq!(
+        header_body.algorithm_suite().message_version,
+        2,
+        "expected V2 body"
+    );
+
+    // Independent on-wire field offsets for V2 header.
+    let fields = parse_v2_header_field_offsets(&ct);
+    let get = |name: &'static str| -> (usize, usize) {
+        let (_, s, e) = fields
+            .iter()
+            .find(|(n, _, _)| *n == name)
+            .unwrap_or_else(|| panic!("V2 header must contain field {name}"));
+        (*s, *e)
+    };
+
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Parsed alg suite binary_id equals on-wire bytes; read_header_body consumed them
+    //# - MUST deserialize the [Algorithm Suite ID](../data-format/message-header.md#algorithm-suite-id).
+    let (suite_start, suite_end) = get("Algorithm Suite ID");
+    assert_eq!(suite_end - suite_start, 2, "Algorithm Suite ID is 2 bytes");
+    assert_eq!(
+        header_body.algorithm_suite().binary_id,
+        [ct[suite_start], ct[suite_start + 1]],
+        "parsed alg suite binary_id equals wire bytes"
+    );
+
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=V2 message_id is 32 wire bytes; pub accessor returns those bytes
+    //# - MUST deserialize the [Message ID](../data-format/message-header.md#message-id).
+    let (mid_start, mid_end) = get("Message ID");
+    assert_eq!(mid_end - mid_start, 32, "V2 message_id is 32 bytes");
+    assert_eq!(
+        header_body.message_id(),
+        &ct[mid_start..mid_end],
+        "parsed message_id equals wire bytes"
+    );
+
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=AAD section length on wire equals 2-byte length field + declared bytes
+    //# - MUST deserialize the [AAD](../data-format/message-header.md#aad).
+    let (aad_start, aad_end) = get("AAD");
+    let aad_declared = u16::from_be_bytes([ct[aad_start], ct[aad_start + 1]]) as usize;
+    assert_eq!(
+        aad_end - aad_start,
+        2 + aad_declared,
+        "AAD on-wire span = 2 (length field) + declared bytes"
+    );
+
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=EDK count read at expected offset = 1 (single keyring)
+    //# - MUST deserialize the [Encrypted Data Keys](../data-format/message-header.md#encrypted-data-keys).
+    let (edk_start, _) = get("Encrypted Data Keys");
+    let edk_count_on_wire = u16::from_be_bytes([ct[edk_start], ct[edk_start + 1]]);
+    assert_eq!(edk_count_on_wire, 1, "single keyring produces 1 EDK on wire");
+
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Content type byte at expected offset = 0x02 (Framed)
+    //# - MUST deserialize the [Content Type](../data-format/message-header.md#content-type).
+    let (ct_start, ct_end) = get("Content Type");
+    assert_eq!(ct_end - ct_start, 1, "content type is 1 byte on wire");
+    assert_eq!(ct[ct_start], 0x02, "default content type is Framed (0x02)");
+
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Frame length is 4 wire bytes BE = 4096 (default)
+    //# - MUST deserialize the [Frame Length](../data-format/message-header.md#frame-length).
+    let (fl_start, fl_end) = get("Frame Length");
+    assert_eq!(fl_end - fl_start, 4, "frame length is 4 bytes");
+    let fl_value = u32::from_be_bytes([
+        ct[fl_start],
+        ct[fl_start + 1],
+        ct[fl_start + 2],
+        ct[fl_start + 3],
+    ]);
+    assert_eq!(fl_value, 4096, "default frame length = 4096");
+
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Algorithm Suite Data is 32 wire bytes (V2 commit key field)
+    //# - MUST deserialize the [Algorithm Suite Data](../data-format/message-header.md#algorithm-suite-data).
+    let (sd_start, sd_end) = get("Algorithm Suite Data");
+    assert_eq!(
+        sd_end - sd_start,
+        32,
+        "V2 Algorithm Suite Data is 32 bytes"
+    );
+
+    // Now tamper the V2 auth tag byte (immediately after Algorithm Suite Data)
+    // and confirm decrypt fails with ValidationError — direct proof that the
+    // implementation deserialized the auth tag from the wire and used it for
+    // header verification. Baseline (untampered) ciphertext is verified above
+    // by read_header_body succeeding.
+    let auth_tag_offset = sd_end;
+    let auth_tag_end = auth_tag_offset + 16;
+    assert!(
+        auth_tag_end <= ct.len(),
+        "auth tag bytes are present in wire after Algorithm Suite Data"
+    );
+    let mut tampered = ct.clone();
+    tampered[auth_tag_offset] ^= 0xFF;
+    let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
+    let err = decrypt(&dec_input)
+        .await
+        .expect_err("tampered V2 auth tag must fail");
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Tampered V2 auth tag byte → CryptographicError, proving the auth tag was deserialized and used
+    //# - MUST deserialize the [Authentication Tag](../data-format/message-header.md#authentication-tag).
     assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
 }

--- a/esdk/tests/test_decrypt_parse_header.rs
+++ b/esdk/tests/test_decrypt_parse_header.rs
@@ -220,6 +220,7 @@ async fn test_max_encrypted_data_keys_enforcement() {
     let err = result.expect_err("decrypt must fail when EDK count exceeds max_encrypted_data_keys");
     //= spec/client-apis/decrypt.md#v2-header-deserialization
     //= type=test
+    //= reason=2 EDKs on wire + max=1 → SerializationError; proves the limit halts deserialization
     //# If the number of [encrypted data keys](../framework/structures.md#encrypted-data-keys)
     //# deserialized from the [message header](../data-format/message-header.md)
     //# is greater than the [maximum number of encrypted data keys](client.md#maximum-number-of-encrypted-data-keys) configured in the [client](client.md),

--- a/esdk/tests/test_decrypt_parse_header.rs
+++ b/esdk/tests/test_decrypt_parse_header.rs
@@ -183,29 +183,6 @@ async fn test_unsupported_type_rejected() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_trailing_bytes_after_message_rejected() {
-    let keyring = test_keyring().await;
-    let plaintext = b"trailing bytes test";
-
-    let enc_input =
-        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
-
-    // Append extra bytes after the valid message
-    ct.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
-
-    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when there are trailing bytes after the message");
-    //= spec/client-apis/decrypt.md#behavior
-    //= type=test
-    //# - If this operation successfully completes the above steps
-    //# but there are consumable bytes which are intended to be decrypted,
-    //# this operation MUST fail.
-    assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_max_encrypted_data_keys_enforcement() {
     // Create two keyrings and a multi-keyring to produce 2 EDKs
     let keyring1 = test_keyring().await;

--- a/esdk/tests/test_decrypt_parse_header.rs
+++ b/esdk/tests/test_decrypt_parse_header.rs
@@ -186,7 +186,7 @@ async fn test_unsupported_type_rejected() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_max_encrypted_data_keys_enforcement() {
-    // Create two keyrings and a multi-keyring to produce 2 EDKs
+    // Create two keyrings and a multi-keyring to produce 2 EDKs on the wire.
     let keyring1 = test_keyring().await;
     let (ns2, name2) = namespace_and_name(1);
     let keyring2 = mpl()
@@ -214,21 +214,28 @@ async fn test_max_encrypted_data_keys_enforcement() {
     );
     let ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Decrypt with max_encrypted_data_keys=1, but message has 2 EDKs → must fail
-    let mut dec_input =
+    // Two decrypt inputs differing only in max_encrypted_data_keys.
+    let mut allowing_input =
+        DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), multi_keyring.clone());
+    allowing_input.max_encrypted_data_keys = Some(std::num::NonZeroUsize::new(2).unwrap());
+    let mut limiting_input =
         DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), multi_keyring);
-    dec_input.max_encrypted_data_keys = Some(std::num::NonZeroUsize::new(1).unwrap());
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when EDK count exceeds max_encrypted_data_keys");
+    limiting_input.max_encrypted_data_keys = Some(std::num::NonZeroUsize::new(1).unwrap());
+
     //= spec/client-apis/decrypt.md#v2-header-deserialization
     //= type=test
-    //= reason=2 EDKs on wire + max=1 → SerializationError; proves the limit halts deserialization
+    //= reason=2 EDKs on wire + max=2 → Ok; same ct + max=1 → SerializationError, halting deserialization
     //# If the number of [encrypted data keys](../framework/structures.md#encrypted-data-keys)
     //# deserialized from the [message header](../data-format/message-header.md)
     //# is greater than the [maximum number of encrypted data keys](client.md#maximum-number-of-encrypted-data-keys) configured in the [client](client.md),
     //# then as soon as that can be determined during deserializing
     //# decrypt MUST process no more bytes and yield an error.
-    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+    assert!(decrypt(&allowing_input).await.is_ok(), "max=2 must decrypt 2-EDK ct");
+    assert_eq!(
+        decrypt(&limiting_input).await.unwrap_err().kind,
+        ErrorKind::SerializationError,
+        "max=1 with 2 EDKs on wire must produce SerializationError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_decrypt_parse_header.rs
+++ b/esdk/tests/test_decrypt_parse_header.rs
@@ -1,0 +1,433 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/client-apis/decrypt.md#parse-the-header
+//! and spec/client-apis/decrypt.md#behavior
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
+use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
+use fixtures::*;
+use test_helpers::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unsupported_version_rejected() {
+    let keyring = test_keyring().await;
+    let plaintext = b"unsupported version test";
+
+    let enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Valid value decrypts as expected
+    let dec_valid = DecryptInput::from_encrypt(&ct, &enc_input);
+    assert!(decrypt(&dec_valid).await.is_ok(), "valid version decrypts successfully");
+
+    // Byte 0 is the version field — set to an unsupported value
+    ct[0] = 0xFF;
+
+    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when version byte is unsupported");
+    //= spec/client-apis/decrypt.md#parse-the-header
+    //= type=test
+    //= reason=Unsupported value 0xFF rejected, proving only supported values accepted
+    //# The value MUST be a [supported version](../data-format/message-header.md#supported-versions).
+    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unsupported_content_type_v1_rejected() {
+    let keyring = test_keyring().await;
+    let plaintext = b"unsupported content type v1 test";
+
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
+    enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // V1 header layout with empty encryption context:
+    // version(1) + type(1) + alg_suite(2) + message_id(16) = 20 bytes fixed
+    // AAD section with empty EC: key_value_pairs_length(2) = 0x0000 → 2 bytes total
+    // EDK section: edk_count(2) + each EDK
+    let mut pos: usize = 20; // after version + type + alg_suite + message_id
+    // Skip AAD section: read key_value_pairs_length
+    let aad_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+    pos += 2; // past key_value_pairs_length
+    if aad_len > 0 {
+        // aad_len already includes the 2-byte key_value_pair_count
+        pos += aad_len;
+    }
+    // Skip EDK section: edk_count(2) + each EDK
+    let edk_count = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+    pos += 2;
+    for _ in 0..edk_count {
+        let provider_id_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        pos += 2 + provider_id_len;
+        let provider_info_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        pos += 2 + provider_info_len;
+        let edk_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        pos += 2 + edk_len;
+    }
+    // pos now points to the content type byte
+    let original_content_type = ct[pos];
+    assert!(
+        original_content_type == 1 || original_content_type == 2,
+        "sanity check: content type should be 1 or 2, got {original_content_type}"
+    );
+    // Valid content type decrypts as expected
+    let mut dec_valid = DecryptInput::from_encrypt(&ct, &enc_input);
+    dec_valid.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    assert!(decrypt(&dec_valid).await.is_ok(), "valid content type decrypts successfully");
+
+    ct[pos] = 0xFF; // unsupported content type
+
+    let mut dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when content type byte is unsupported");
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Unsupported value rejected; proves only valid values accepted
+    //# The value MUST be a [supported content type](../data-format/message-header.md#supported-content-types).
+    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unsupported_content_type_v2_rejected() {
+    let keyring = test_keyring().await;
+    let plaintext = b"unsupported content type v2 test";
+
+    let enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // V2 header layout with empty encryption context:
+    // version(1) + alg_suite(2) + message_id(32) = 35 bytes fixed
+    // AAD section with empty EC: key_value_pairs_length(2) = 0x0000 → 2 bytes total
+    // EDK section: edk_count(2) + each EDK
+    let mut pos: usize = 35; // after version + alg_suite + message_id (32 bytes for V2)
+    // Skip AAD section: read key_value_pairs_length
+    let aad_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+    pos += 2; // past key_value_pairs_length
+    if aad_len > 0 {
+        // aad_len already includes the 2-byte key_value_pair_count
+        pos += aad_len;
+    }
+    // Skip EDK section: edk_count(2) + each EDK
+    let edk_count = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+    pos += 2;
+    for _ in 0..edk_count {
+        let provider_id_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        pos += 2 + provider_id_len;
+        let provider_info_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        pos += 2 + provider_info_len;
+        let edk_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        pos += 2 + edk_len;
+    }
+    // pos now points to the content type byte
+    let original_content_type = ct[pos];
+    assert!(
+        original_content_type == 1 || original_content_type == 2,
+        "sanity check: content type should be 1 or 2, got {original_content_type}"
+    );
+    // Valid content type decrypts as expected
+    let dec_valid = DecryptInput::from_encrypt(&ct, &enc_input);
+    assert!(decrypt(&dec_valid).await.is_ok(), "valid content type decrypts successfully");
+
+    ct[pos] = 0xFF; // unsupported content type
+
+    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when V2 content type byte is unsupported");
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Unsupported value rejected; proves only valid values accepted
+    //# The value MUST be a [supported content type](../data-format/message-header.md#supported-content-types).
+    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unsupported_type_rejected() {
+    let keyring = test_keyring().await;
+    let plaintext = b"unsupported type test";
+
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
+    enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // V1 layout: byte 0 = version (0x01), byte 1 = type (0x80)
+    // Valid value decrypts as expected
+    let mut dec_valid = DecryptInput::from_encrypt(&ct, &enc_input);
+    dec_valid.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    assert!(decrypt(&dec_valid).await.is_ok(), "valid type decrypts successfully");
+
+    assert_eq!(ct[1], 0x80, "sanity check: V1 type should be 0x80");
+    ct[1] = 0xFF; // unsupported type
+
+    let mut dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when message type byte is unsupported");
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Unsupported value rejected; proves only valid values accepted
+    //# The value MUST be a [supported type](../data-format/message-header.md#supported-types).
+    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trailing_bytes_after_message_rejected() {
+    let keyring = test_keyring().await;
+    let plaintext = b"trailing bytes test";
+
+    let enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Append extra bytes after the valid message
+    ct.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+
+    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when there are trailing bytes after the message");
+    //= spec/client-apis/decrypt.md#behavior
+    //= type=test
+    //# - If this operation successfully completes the above steps
+    //# but there are consumable bytes which are intended to be decrypted,
+    //# this operation MUST fail.
+    assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_max_encrypted_data_keys_enforcement() {
+    // Create two keyrings and a multi-keyring to produce 2 EDKs
+    let keyring1 = test_keyring().await;
+    let (ns2, name2) = namespace_and_name(1);
+    let keyring2 = mpl()
+        .create_raw_aes_keyring()
+        .key_namespace(ns2)
+        .key_name(name2)
+        .wrapping_key(aws_smithy_types::Blob::new([1u8; 32]))
+        .wrapping_alg(aws_mpl_legacy::dafny::types::AesWrappingAlg::AlgAes256GcmIv12Tag16)
+        .send()
+        .await
+        .unwrap();
+    let multi_keyring = mpl()
+        .create_multi_keyring()
+        .generator(keyring1.clone())
+        .child_keyrings(vec![keyring2])
+        .send()
+        .await
+        .unwrap();
+
+    let plaintext = b"max edk decrypt test";
+    let enc_input = EncryptInput::with_legacy_keyring(
+        plaintext,
+        EncryptionContext::new(),
+        multi_keyring.clone(),
+    );
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Decrypt with max_encrypted_data_keys=1, but message has 2 EDKs → must fail
+    let mut dec_input =
+        DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), multi_keyring);
+    dec_input.max_encrypted_data_keys = Some(std::num::NonZeroUsize::new(1).unwrap());
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when EDK count exceeds max_encrypted_data_keys");
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //# If the number of [encrypted data keys](../framework/structures.md#encrypted-data-keys)
+    //# deserialized from the [message header](../data-format/message-header.md)
+    //# is greater than the [maximum number of encrypted data keys](client.md#maximum-number-of-encrypted-data-keys) configured in the [client](client.md),
+    //# then as soon as that can be determined during deserializing
+    //# decrypt MUST process no more bytes and yield an error.
+    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_no_header_info_released_before_verification() {
+    // Tamper with the header auth tag so header verification fails.
+    // The non-streaming decrypt must return an error with no partial output.
+    let keyring = test_keyring().await;
+    let plaintext = b"no header info before verification";
+
+    let enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Baseline: untampered ciphertext must decrypt successfully.
+    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
+    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+
+    ct[10] ^= 0xFF;
+
+    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail entirely when header verification fails — no partial header info released");
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
+    //# - MUST deserialize the [Algorithm Suite ID](../data-format/message-header.md#algorithm-suite-id).
+    //
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
+    //# - MUST deserialize the [Message ID](../data-format/message-header.md#message-id).
+    //
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
+    //# - MUST deserialize the [AAD](../data-format/message-header.md#aad).
+    //
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
+    //# - MUST deserialize the [Encrypted Data Keys](../data-format/message-header.md#encrypted-data-keys).
+    //
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
+    //# - MUST deserialize the [Content Type](../data-format/message-header.md#content-type).
+    //
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
+    //# - MUST deserialize the [Frame Length](../data-format/message-header.md#frame-length).
+    //
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
+    //# - MUST deserialize the [Algorithm Suite Data](../data-format/message-header.md#algorithm-suite-data).
+    //
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //= reason=Tampered header byte causes tag verify failure, proving all fields were parsed
+    //# - MUST deserialize the [Authentication Tag](../data-format/message-header.md#authentication-tag).
+    //
+    //= spec/client-apis/decrypt.md#v2-header-deserialization
+    //= type=test
+    //# Until the [header is verified](#verify-the-header), this operation MUST NOT
+    //# release any parsed information from the header.
+    assert_eq!(err.kind, ErrorKind::ValidationError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_header_auth_tag_deserialized_and_verified() {
+    // Tamper the V1 header auth tag to prove it was deserialized and used for verification.
+    let keyring = test_keyring().await;
+    let plaintext = b"v1 header auth tag tamper test";
+
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
+    enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Baseline: untampered V1 message decrypts.
+    let mut baseline_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    baseline_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    assert!(decrypt(&baseline_input).await.is_ok(), "baseline must pass");
+
+    // V1 header auth: IV(12) + Tag(16) at the end of the header, before the body.
+    // Tamper the last byte of the header (part of the auth tag).
+    // V1 header ends at: fixed(20) + AAD(variable) + EDKs(variable) + content_type(1)
+    //   + reserved(4) + iv_length(1) + frame_length(4) + header_auth_iv(12) + header_auth_tag(16)
+    // The auth tag's last byte is just before the body starts.
+    let body_start = find_body_start(&ct, 4096).expect("body start");
+    let auth_tag_last_byte = body_start - 1;
+    ct[auth_tag_last_byte] ^= 0xFF;
+
+    let mut dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Auth tag covers entire header body; tampered tag proves all fields read
+    //# - MUST deserialize the [Type](../data-format/message-header.md#type).
+    //
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Auth tag covers entire header body
+    //# - MUST deserialize the [Algorithm Suite ID](../data-format/message-header.md#algorithm-suite-id).
+    //
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Auth tag covers entire header body
+    //# - MUST deserialize the [Message ID](../data-format/message-header.md#message-id).
+    //
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Auth tag covers entire header body
+    //# - MUST deserialize the [AAD](../data-format/message-header.md#aad).
+    //
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Auth tag covers entire header body
+    //# - MUST deserialize the [Encrypted Data Keys](../data-format/message-header.md#encrypted-data-keys).
+    //
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Auth tag covers entire header body
+    //# - MUST deserialize the [Content Type](../data-format/message-header.md#content-type).
+    //
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Auth tag covers entire header body
+    //# - MUST deserialize the [Reserved](../data-format/message-header.md#reserved).
+    //
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Auth tag covers entire header body
+    //# - MUST deserialize the [IV Length](../data-format/message-header.md#iv-length).
+    //
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Auth tag covers entire header body
+    //# - MUST deserialize the [Frame Length](../data-format/message-header.md#frame-length).
+    //
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Tampered V1 auth tag causes failure, proving it was deserialized and verified
+    //# - MUST deserialize the [Authentication Tag](../data-format/message-header.md#authentication-tag).
+    let err = decrypt(&dec_input).await.expect_err("tampered V1 auth tag must fail");
+    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_v1_header_auth_iv_deserialized_and_used() {
+    // Tamper the V1 header auth IV to prove it was deserialized and used for verification.
+    let keyring = test_keyring().await;
+    let plaintext = b"v1 header auth iv tamper test";
+
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
+    enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Baseline
+    let mut baseline_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    baseline_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    assert!(decrypt(&baseline_input).await.is_ok(), "baseline must pass");
+
+    // V1 header auth IV is 12 bytes immediately before the 16-byte auth tag, which
+    // is immediately before the body. Tamper its first byte.
+    let body_start = find_body_start(&ct, 4096).expect("body start");
+    let iv_start = body_start - 16 - 12; // 16 bytes tag + 12 bytes IV before body
+    ct[iv_start] ^= 0xFF;
+
+    let mut dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    //= spec/client-apis/decrypt.md#v1-header-deserialization
+    //= type=test
+    //= reason=Tampered V1 header auth IV causes failure, proving IV was deserialized and used
+    //# - MUST deserialize the [IV](../data-format/message-header.md#iv).
+    let err = decrypt(&dec_input).await.expect_err("tampered V1 header auth IV must fail");
+    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+}

--- a/esdk/tests/test_decrypt_parse_header.rs
+++ b/esdk/tests/test_decrypt_parse_header.rs
@@ -52,35 +52,15 @@ async fn test_unsupported_content_type_v1_rejected() {
     enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
     let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // V1 header layout with empty encryption context:
-    // version(1) + type(1) + alg_suite(2) + message_id(16) = 20 bytes fixed
-    // AAD section with empty EC: key_value_pairs_length(2) = 0x0000 → 2 bytes total
-    // EDK section: edk_count(2) + each EDK
-    let mut pos: usize = 20; // after version + type + alg_suite + message_id
-    let aad_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
-    pos += 2;
-    if aad_len > 0 {
-        pos += aad_len;
-    }
-    let edk_count = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
-    pos += 2;
-    for _ in 0..edk_count {
-        let provider_id_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
-        pos += 2 + provider_id_len;
-        let provider_info_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
-        pos += 2 + provider_info_len;
-        let edk_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
-        pos += 2 + edk_len;
-    }
-    // pos now points to the content type byte
-    let original_content_type = valid_ct[pos];
+    let (content_type_offset, _, _, _) = parse_v1_trailing_offsets(&valid_ct);
+    let original_content_type = valid_ct[content_type_offset];
     assert!(
         original_content_type == 1 || original_content_type == 2,
         "sanity check: content type should be 1 or 2, got {original_content_type}"
     );
 
     let mut tampered_ct = valid_ct.clone();
-    tampered_ct[pos] = 0xFF; // unsupported content type
+    tampered_ct[content_type_offset] = 0xFF; // unsupported content type
 
     let mut valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
     valid_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
@@ -108,32 +88,19 @@ async fn test_unsupported_content_type_v2_rejected() {
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
     let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // V2 header layout with empty encryption context:
-    // version(1) + alg_suite(2) + message_id(32) = 35 bytes fixed
-    let mut pos: usize = 35;
-    let aad_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
-    pos += 2;
-    if aad_len > 0 {
-        pos += aad_len;
-    }
-    let edk_count = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
-    pos += 2;
-    for _ in 0..edk_count {
-        let provider_id_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
-        pos += 2 + provider_id_len;
-        let provider_info_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
-        pos += 2 + provider_info_len;
-        let edk_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
-        pos += 2 + edk_len;
-    }
-    let original_content_type = valid_ct[pos];
+    let fields = parse_v2_header_field_offsets(&valid_ct);
+    let (_, ct_start, _) = fields
+        .iter()
+        .find(|(n, _, _)| *n == "Content Type")
+        .expect("V2 header must have Content Type field");
+    let original_content_type = valid_ct[*ct_start];
     assert!(
         original_content_type == 1 || original_content_type == 2,
         "sanity check: content type should be 1 or 2, got {original_content_type}"
     );
 
     let mut tampered_ct = valid_ct.clone();
-    tampered_ct[pos] = 0xFF; // unsupported content type
+    tampered_ct[*ct_start] = 0xFF; // unsupported content type
 
     let valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
     let tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
@@ -343,21 +310,7 @@ async fn test_v1_header_auth_iv_deserialized_and_used() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_v1_header_body_fields_parsed_from_wire() {
-    // Drive the production deserialization path (read_header_body) on a known
-    // V1 ciphertext, then use independent on-wire field offsets
-    // (parse_v1_trailing_offsets) to assert each field's bytes/length/value at
-    // the spec-defined location. Each annotation is placed immediately above
-    // the assertion that proves that specific field was deserialized:
-    //
-    //   - For fields with public accessors (`message_id`, `algorithm_suite`),
-    //     the parsed value is asserted to equal the wire bytes at the field's
-    //     offset.
-    //   - For other fields, the wire bytes at the spec-defined offset are
-    //     asserted to have the expected length/value, AND `read_header_body`
-    //     returned Ok (consuming exactly those bytes in order). If the
-    //     implementation skipped a field, downstream offsets would be
-    //     misaligned and read_header_body would fail or yield wrong values
-    //     for the public-accessor fields.
+    // Drives `read_header_body` and asserts each V1 field at its on-wire offset.
     use aws_esdk::__test_internals::*;
 
     let keyring = test_keyring().await;
@@ -485,12 +438,8 @@ async fn test_v1_header_body_fields_parsed_from_wire() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_v2_header_body_fields_parsed_from_wire() {
-    // Drive the production deserialization path (read_header_body and
-    // read_header_auth_tag) on a known V2 ciphertext, then use independent
-    // on-wire field offsets (parse_v2_header_field_offsets) to assert each
-    // field's bytes/length/value at the spec-defined location. Each
-    // annotation is placed immediately above the assertion that proves
-    // that specific field was deserialized.
+    // Drives `read_header_body` and asserts each V2 field at its on-wire offset,
+    // then tampers the V2 auth tag byte to confirm it was deserialized and used.
     use aws_esdk::__test_internals::*;
 
     let keyring = test_keyring().await;

--- a/esdk/tests/test_decrypt_parse_header.rs
+++ b/esdk/tests/test_decrypt_parse_header.rs
@@ -20,23 +20,25 @@ async fn test_unsupported_version_rejected() {
 
     let enc_input =
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
-
-    // Valid value decrypts as expected
-    let dec_valid = DecryptInput::from_encrypt(&ct, &enc_input);
-    assert!(decrypt(&dec_valid).await.is_ok(), "valid version decrypts successfully");
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     // Byte 0 is the version field — set to an unsupported value
-    ct[0] = 0xFF;
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[0] = 0xFF;
 
-    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when version byte is unsupported");
+    let valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
+    let tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
+
     //= spec/client-apis/decrypt.md#parse-the-header
     //= type=test
-    //= reason=Unsupported value 0xFF rejected, proving only supported values accepted
+    //= reason=Supported version byte → Ok; unsupported value 0xFF → SerializationError
     //# The value MUST be a [supported version](../data-format/message-header.md#supported-versions).
-    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "supported version must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::SerializationError,
+        "unsupported version byte must produce SerializationError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -48,53 +50,53 @@ async fn test_unsupported_content_type_v1_rejected() {
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
     enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
     enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     // V1 header layout with empty encryption context:
     // version(1) + type(1) + alg_suite(2) + message_id(16) = 20 bytes fixed
     // AAD section with empty EC: key_value_pairs_length(2) = 0x0000 → 2 bytes total
     // EDK section: edk_count(2) + each EDK
     let mut pos: usize = 20; // after version + type + alg_suite + message_id
-    // Skip AAD section: read key_value_pairs_length
-    let aad_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
-    pos += 2; // past key_value_pairs_length
+    let aad_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
+    pos += 2;
     if aad_len > 0 {
-        // aad_len already includes the 2-byte key_value_pair_count
         pos += aad_len;
     }
-    // Skip EDK section: edk_count(2) + each EDK
-    let edk_count = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+    let edk_count = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
     pos += 2;
     for _ in 0..edk_count {
-        let provider_id_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        let provider_id_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
         pos += 2 + provider_id_len;
-        let provider_info_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        let provider_info_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
         pos += 2 + provider_info_len;
-        let edk_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        let edk_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
         pos += 2 + edk_len;
     }
     // pos now points to the content type byte
-    let original_content_type = ct[pos];
+    let original_content_type = valid_ct[pos];
     assert!(
         original_content_type == 1 || original_content_type == 2,
         "sanity check: content type should be 1 or 2, got {original_content_type}"
     );
-    // Valid content type decrypts as expected
-    let mut dec_valid = DecryptInput::from_encrypt(&ct, &enc_input);
-    dec_valid.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    assert!(decrypt(&dec_valid).await.is_ok(), "valid content type decrypts successfully");
 
-    ct[pos] = 0xFF; // unsupported content type
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[pos] = 0xFF; // unsupported content type
 
-    let mut dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when content type byte is unsupported");
+    let mut valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
+    valid_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
+    tampered_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+
     //= spec/client-apis/decrypt.md#v1-header-deserialization
     //= type=test
-    //= reason=Unsupported value rejected; proves only valid values accepted
+    //= reason=Supported content type byte → Ok; unsupported value 0xFF → SerializationError
     //# The value MUST be a [supported content type](../data-format/message-header.md#supported-content-types).
-    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "supported content type must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::SerializationError,
+        "unsupported V1 content type must produce SerializationError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -104,51 +106,48 @@ async fn test_unsupported_content_type_v2_rejected() {
 
     let enc_input =
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     // V2 header layout with empty encryption context:
     // version(1) + alg_suite(2) + message_id(32) = 35 bytes fixed
-    // AAD section with empty EC: key_value_pairs_length(2) = 0x0000 → 2 bytes total
-    // EDK section: edk_count(2) + each EDK
-    let mut pos: usize = 35; // after version + alg_suite + message_id (32 bytes for V2)
-    // Skip AAD section: read key_value_pairs_length
-    let aad_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
-    pos += 2; // past key_value_pairs_length
+    let mut pos: usize = 35;
+    let aad_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
+    pos += 2;
     if aad_len > 0 {
-        // aad_len already includes the 2-byte key_value_pair_count
         pos += aad_len;
     }
-    // Skip EDK section: edk_count(2) + each EDK
-    let edk_count = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+    let edk_count = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
     pos += 2;
     for _ in 0..edk_count {
-        let provider_id_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        let provider_id_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
         pos += 2 + provider_id_len;
-        let provider_info_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        let provider_info_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
         pos += 2 + provider_info_len;
-        let edk_len = u16::from_be_bytes([ct[pos], ct[pos + 1]]) as usize;
+        let edk_len = u16::from_be_bytes([valid_ct[pos], valid_ct[pos + 1]]) as usize;
         pos += 2 + edk_len;
     }
-    // pos now points to the content type byte
-    let original_content_type = ct[pos];
+    let original_content_type = valid_ct[pos];
     assert!(
         original_content_type == 1 || original_content_type == 2,
         "sanity check: content type should be 1 or 2, got {original_content_type}"
     );
-    // Valid content type decrypts as expected
-    let dec_valid = DecryptInput::from_encrypt(&ct, &enc_input);
-    assert!(decrypt(&dec_valid).await.is_ok(), "valid content type decrypts successfully");
 
-    ct[pos] = 0xFF; // unsupported content type
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[pos] = 0xFF; // unsupported content type
 
-    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when V2 content type byte is unsupported");
+    let valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
+    let tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
+
     //= spec/client-apis/decrypt.md#v2-header-deserialization
     //= type=test
-    //= reason=Unsupported value rejected; proves only valid values accepted
+    //= reason=Supported content type byte → Ok; unsupported value 0xFF → SerializationError
     //# The value MUST be a [supported content type](../data-format/message-header.md#supported-content-types).
-    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "supported content type must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::SerializationError,
+        "unsupported V2 content type must produce SerializationError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -160,26 +159,29 @@ async fn test_unsupported_type_rejected() {
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
     enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
     enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     // V1 layout: byte 0 = version (0x01), byte 1 = type (0x80)
-    // Valid value decrypts as expected
-    let mut dec_valid = DecryptInput::from_encrypt(&ct, &enc_input);
-    dec_valid.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    assert!(decrypt(&dec_valid).await.is_ok(), "valid type decrypts successfully");
+    assert_eq!(valid_ct[1], 0x80, "sanity check: V1 type should be 0x80");
 
-    assert_eq!(ct[1], 0x80, "sanity check: V1 type should be 0x80");
-    ct[1] = 0xFF; // unsupported type
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[1] = 0xFF; // unsupported type
 
-    let mut dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when message type byte is unsupported");
+    let mut valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
+    valid_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
+    tampered_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+
     //= spec/client-apis/decrypt.md#v1-header-deserialization
     //= type=test
-    //= reason=Unsupported value rejected; proves only valid values accepted
+    //= reason=Supported type byte (0x80) → Ok; unsupported value 0xFF → SerializationError
     //# The value MUST be a [supported type](../data-format/message-header.md#supported-types).
-    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "supported type must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::SerializationError,
+        "unsupported V1 type byte must produce SerializationError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -238,23 +240,25 @@ async fn test_no_header_info_released_before_verification() {
 
     let enc_input =
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Baseline: untampered ciphertext must decrypt successfully.
-    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
-    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[10] ^= 0xFF;
 
-    ct[10] ^= 0xFF;
+    let valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
+    let tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
 
-    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    let result = decrypt(&dec_input).await;
     //= spec/client-apis/decrypt.md#v2-header-deserialization
     //= type=test
-    //= reason=Tampered header → ValidationError with no DecryptOutput; nothing released to caller
+    //= reason=Untampered ct decrypts (Ok with output); tampered header byte → ValidationError with no DecryptOutput, so nothing released
     //# Until the [header is verified](#verify-the-header), this operation MUST NOT
     //# release any parsed information from the header.
-    let err = result.expect_err("decrypt must fail entirely when header verification fails — no partial header info released");
-    assert_eq!(err.kind, ErrorKind::ValidationError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::ValidationError,
+        "tampered header must produce ValidationError, no output"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -267,30 +271,30 @@ async fn test_v1_header_auth_tag_deserialized_and_verified() {
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
     enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
     enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
-
-    // Baseline: untampered V1 message decrypts.
-    let mut baseline_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    baseline_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    assert!(decrypt(&baseline_input).await.is_ok(), "baseline must pass");
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     // V1 header auth: IV(12) + Tag(16) at the end of the header, before the body.
     // Tamper the last byte of the header (part of the auth tag).
-    // V1 header ends at: fixed(20) + AAD(variable) + EDKs(variable) + content_type(1)
-    //   + reserved(4) + iv_length(1) + frame_length(4) + header_auth_iv(12) + header_auth_tag(16)
-    // The auth tag's last byte is just before the body starts.
-    let body_start = find_body_start(&ct, 4096).expect("body start");
+    let body_start = find_body_start(&valid_ct, 4096).expect("body start");
     let auth_tag_last_byte = body_start - 1;
-    ct[auth_tag_last_byte] ^= 0xFF;
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[auth_tag_last_byte] ^= 0xFF;
 
-    let mut dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
+    valid_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
+    tampered_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+
     //= spec/client-apis/decrypt.md#v1-header-deserialization
     //= type=test
-    //= reason=Tampered V1 auth tag byte causes tag verify failure, proving the tag was deserialized and used
+    //= reason=Untampered V1 message decrypts; tampered V1 auth tag byte → CryptographicError, proving the tag was deserialized and used
     //# - MUST deserialize the [Authentication Tag](../data-format/message-header.md#authentication-tag).
-    let err = decrypt(&dec_input).await.expect_err("tampered V1 auth tag must fail");
-    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid V1 ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::CryptographicError,
+        "tampered V1 auth tag must produce CryptographicError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -303,27 +307,30 @@ async fn test_v1_header_auth_iv_deserialized_and_used() {
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
     enc_input.algorithm_suite_id = Some(EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256);
     enc_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
-
-    // Baseline
-    let mut baseline_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    baseline_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    assert!(decrypt(&baseline_input).await.is_ok(), "baseline must pass");
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
     // V1 header auth IV is 12 bytes immediately before the 16-byte auth tag, which
     // is immediately before the body. Tamper its first byte.
-    let body_start = find_body_start(&ct, 4096).expect("body start");
+    let body_start = find_body_start(&valid_ct, 4096).expect("body start");
     let iv_start = body_start - 16 - 12; // 16 bytes tag + 12 bytes IV before body
-    ct[iv_start] ^= 0xFF;
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[iv_start] ^= 0xFF;
 
-    let mut dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
+    valid_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
+    tampered_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+
     //= spec/client-apis/decrypt.md#v1-header-deserialization
     //= type=test
-    //= reason=Tampered V1 header auth IV causes failure, proving IV was deserialized and used
+    //= reason=Untampered V1 message decrypts; tampered V1 header auth IV byte → CryptographicError, proving IV was deserialized and used
     //# - MUST deserialize the [IV](../data-format/message-header.md#iv).
-    let err = decrypt(&dec_input).await.expect_err("tampered V1 header auth IV must fail");
-    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid V1 ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::CryptographicError,
+        "tampered V1 header auth IV must produce CryptographicError"
+    );
 }
 
 
@@ -585,25 +592,31 @@ async fn test_v2_header_body_fields_parsed_from_wire() {
     );
 
     // Now tamper the V2 auth tag byte (immediately after Algorithm Suite Data)
-    // and confirm decrypt fails with ValidationError — direct proof that the
-    // implementation deserialized the auth tag from the wire and used it for
-    // header verification. Baseline (untampered) ciphertext is verified above
-    // by read_header_body succeeding.
+    // and confirm decrypt fails with CryptographicError — direct proof that
+    // the implementation deserialized the auth tag from the wire and used it
+    // for header verification.
     let auth_tag_offset = sd_end;
     let auth_tag_end = auth_tag_offset + 16;
     assert!(
         auth_tag_end <= ct.len(),
         "auth tag bytes are present in wire after Algorithm Suite Data"
     );
-    let mut tampered = ct.clone();
-    tampered[auth_tag_offset] ^= 0xFF;
-    let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
-    let err = decrypt(&dec_input)
-        .await
-        .expect_err("tampered V2 auth tag must fail");
+    let mut tampered_ct = ct.clone();
+    tampered_ct[auth_tag_offset] ^= 0xFF;
+
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone());
+    let tampered_input =
+        DecryptInput::with_legacy_keyring(&tampered_ct, EncryptionContext::new(), keyring);
+
     //= spec/client-apis/decrypt.md#v2-header-deserialization
     //= type=test
-    //= reason=Tampered V2 auth tag byte → CryptographicError, proving the auth tag was deserialized and used
+    //= reason=Untampered ct decrypts; tampered V2 auth tag byte → CryptographicError, proving the auth tag was deserialized and used
     //# - MUST deserialize the [Authentication Tag](../data-format/message-header.md#authentication-tag).
-    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid V2 ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::CryptographicError,
+        "tampered V2 auth tag must produce CryptographicError"
+    );
 }

--- a/esdk/tests/test_decrypt_the_message_body.rs
+++ b/esdk/tests/test_decrypt_the_message_body.rs
@@ -15,10 +15,10 @@ async fn test_decrypt_final_frame_content_length_validation() {
     // Encrypt a message, then tamper with the final frame's content length field
     // to exceed the frame length. Decrypt must fail.
     let pt = vec![0xEEu8; 5];
-    let mut ct = encrypt_with_frame_length(&pt, 10).await;
+    let valid_ct = encrypt_with_frame_length(&pt, 10).await;
 
     // First, verify the untampered content_length is <= frame_length on wire
-    let frames = parse_all_frames(&ct, 10);
+    let frames = parse_all_frames(&valid_ct, 10);
     let final_frame = frames.last().unwrap();
     assert!(final_frame.is_final);
     //= spec/client-apis/decrypt.md#decrypt-the-message-body
@@ -32,43 +32,60 @@ async fn test_decrypt_final_frame_content_length_validation() {
         final_frame.content_length
     );
 
-    // Valid value decrypts as expected
-    assert_eq!(decrypt_ciphertext(&ct).await.plaintext, pt, "valid content_length decrypts");
-
     // Now tamper: set content_length to 11 (exceeds frame_length=10)
-    for i in 0..ct.len().saturating_sub(24) {
-        if ct[i..i + 4] == ENDFRAME_MARKER {
+    let mut tampered_ct = valid_ct.clone();
+    for i in 0..tampered_ct.len().saturating_sub(24) {
+        if tampered_ct[i..i + 4] == ENDFRAME_MARKER {
             let bad_len = 11u32.to_be_bytes();
-            ct[i + 20..i + 24].copy_from_slice(&bad_len);
+            tampered_ct[i + 20..i + 24].copy_from_slice(&bad_len);
             break;
         }
     }
+
     let keyring = test_keyring().await;
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());
+    let tampered_input =
+        DecryptInput::with_legacy_keyring(&tampered_ct, EncryptionContext::new(), keyring);
+
     //= spec/client-apis/decrypt.md#decrypt-the-message-body
     //= type=test
-    //= reason=content_length > frame_length → SerializationError; proves the check exists
+    //= reason=Untampered ct decrypts; content_length tampered to 11 (> frame_length=10) → SerializationError
     //# If this is a final frame, this MUST be determined by using the [final frame encrypted content length](../data-format/message-body.md#final-frame-encrypted-content-length).
-    let err = decrypt(&dec_input).await.expect_err("content_length > frame_length must fail");
-    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::SerializationError,
+        "content_length > frame_length must produce SerializationError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_decrypt_fails_on_tampered_auth_tag() {
     let pt = vec![0xABu8; 20];
-    let mut ct = encrypt_with_frame_length(&pt, 10).await;
-    let body_start = find_body_start(&ct, 10).expect("must find body");
-    assert_eq!(decrypt_ciphertext(&ct).await.plaintext, pt, "baseline must pass");
+    let valid_ct = encrypt_with_frame_length(&pt, 10).await;
+    let body_start = find_body_start(&valid_ct, 10).expect("must find body");
     let tag_end = body_start + 4 + IV_LEN + 10 + TAG_LEN - 1;
-    ct[tag_end] ^= 0xFF;
+
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[tag_end] ^= 0xFF;
+
     let keyring = test_keyring().await;
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    let err = decrypt(&dec_input).await.expect_err("tampered auth tag must fail");
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());
+    let tampered_input =
+        DecryptInput::with_legacy_keyring(&tampered_ct, EncryptionContext::new(), keyring);
+
     //= spec/client-apis/decrypt.md#decrypt-the-message-body
     //= type=test
-    //= reason=Tampered auth tag → CryptographicError proves AEAD check runs
+    //= reason=Untampered ct decrypts; tampered auth tag byte → CryptographicError
     //# If this decryption fails, this operation MUST immediately halt and fail.
-    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::CryptographicError,
+        "tampered auth tag must produce CryptographicError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -130,22 +147,29 @@ async fn test_decrypt_no_unauthenticated_plaintext_released() {
     // Tamper with encrypted content in the first frame. Decrypt must fail
     // and return no plaintext at all.
     let pt = vec![0xABu8; 20];
-    let mut ct = encrypt_with_frame_length(&pt, 10).await;
-    let body_start = find_body_start(&ct, 10).expect("must find body");
-    // Baseline: untampered ciphertext decrypts successfully.
-    assert_eq!(decrypt_ciphertext(&ct).await.plaintext, pt, "baseline must pass");
-    // Tamper with a byte in the encrypted content of the first regular frame
+    let valid_ct = encrypt_with_frame_length(&pt, 10).await;
+    let body_start = find_body_start(&valid_ct, 10).expect("must find body");
     let tamper_offset = body_start + 4 + IV_LEN + 1;
-    ct[tamper_offset] ^= 0xFF;
+
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[tamper_offset] ^= 0xFF;
+
     let keyring = test_keyring().await;
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("tampered ciphertext must produce error, not partial plaintext");
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());
+    let tampered_input =
+        DecryptInput::with_legacy_keyring(&tampered_ct, EncryptionContext::new(), keyring);
+
     //= spec/client-apis/decrypt.md#decrypt-the-message-body
     //= type=test
-    //= reason=Tampered body returns Err; no DecryptOutput means no plaintext released
+    //= reason=Untampered body decrypts (Ok includes plaintext); tampered body returns Err with no DecryptOutput, so no plaintext released
     //# This operation MUST NOT release any unauthenticated plaintext.
-    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::CryptographicError,
+        "tampered body must produce CryptographicError, no plaintext"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -160,42 +184,53 @@ async fn test_decrypt_final_frame_held_until_signature_verification() {
     enc_input.frame_length = FrameLength::new(4096).unwrap();
     enc_input.algorithm_suite_id =
         Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
-    // Baseline: untampered ciphertext decrypts successfully.
-    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
-    assert!(baseline.is_ok(), "baseline must pass before tamper");
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
     // Tamper with the last byte of the signature to cause verification failure
-    let last = ct.len() - 1;
-    ct[last] ^= 0xFF;
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("tampered signature must cause decrypt failure, proving final frame was held back");
+    let mut tampered_ct = valid_ct.clone();
+    let last = tampered_ct.len() - 1;
+    tampered_ct[last] ^= 0xFF;
+
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());
+    let tampered_input =
+        DecryptInput::with_legacy_keyring(&tampered_ct, EncryptionContext::new(), keyring);
+
     //= spec/client-apis/decrypt.md#decrypt-the-message-body
     //= type=test
-    //= reason=Tampered signature → Err; final frame plaintext never reaches caller
+    //= reason=Untampered ct decrypts (Ok with plaintext); tampered signature → Err, so final frame plaintext was held back and never reaches caller
     //# Any plaintext decrypted from [nonframed data](../data-format/message-body.md#nonframed-data) or
     //# a final frame in a streamed Decrypt operation MUST NOT be released until [signature verification](#verify-the-signature)
     //# successfully completes.
-    assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::Esdk,
+        "tampered signature must produce Esdk error, no plaintext"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unframed_decrypt_fails_on_tampered_auth_tag() {
     // Tamper with the authentication tag in the external V2 nonframed vector. Decrypt must fail.
-    let mut ct = EXTERNAL_V2_NONFRAMED_CT.to_vec();
-    // Baseline: untampered vector decrypts successfully.
-    let baseline = try_decrypt_external_nonframed(Version::V2, &ct).await;
-    assert!(baseline.is_ok(), "baseline external vector must decrypt");
-    // The auth tag is the last 16 bytes of the message
-    let last = ct.len() - 1;
-    ct[last] ^= 0xFF;
-    let result = try_decrypt_external_nonframed(Version::V2, &ct).await;
-    let err = result.expect_err("tampered nonframed auth tag must cause immediate decryption failure");
+    let valid_ct = EXTERNAL_V2_NONFRAMED_CT.to_vec();
+    let mut tampered_ct = valid_ct.clone();
+    let last = tampered_ct.len() - 1;
+    tampered_ct[last] ^= 0xFF;
+
     //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
     //= type=test
-    //= reason=Tampered nonframed auth tag → CryptographicError, proving AEAD halts on failure
+    //= reason=Untampered nonframed vector decrypts; tampered auth tag → CryptographicError, AEAD halts on failure
     //# If this decryption fails, this operation MUST immediately halt and fail.
-    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+    assert!(
+        try_decrypt_external_nonframed(Version::V2, &valid_ct).await.is_ok(),
+        "valid external vector must decrypt"
+    );
+    assert_eq!(
+        try_decrypt_external_nonframed(Version::V2, &tampered_ct).await.unwrap_err().kind,
+        ErrorKind::CryptographicError,
+        "tampered nonframed auth tag must produce CryptographicError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_decrypt_the_message_body.rs
+++ b/esdk/tests/test_decrypt_the_message_body.rs
@@ -1,0 +1,387 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/client-apis/decrypt.md#decrypt-the-message-body
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
+use test_helpers::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_final_frame_content_length_validation() {
+    // Encrypt a message, then tamper with the final frame's content length field
+    // to exceed the frame length. Decrypt must fail.
+    let pt = vec![0xEEu8; 5];
+    let mut ct = encrypt_with_frame_length(&pt, 10).await;
+
+    // First, verify the untampered content_length is <= frame_length on wire
+    let frames = parse_all_frames(&ct, 10);
+    let final_frame = frames.last().unwrap();
+    assert!(final_frame.is_final);
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=On-wire content_length (5) <= frame_length (10) verified directly
+    //# MUST ensure that the length of the encrypted content field is
+    //# less than or equal to the frame length deserialized in the message header.
+    assert!(
+        final_frame.content_length <= 10,
+        "untampered: content_length {} must be <= frame_length 10",
+        final_frame.content_length
+    );
+
+    // Valid value decrypts as expected
+    assert_eq!(decrypt_ciphertext(&ct).await.plaintext, pt, "valid content_length decrypts");
+
+    // Now tamper: set content_length to 11 (exceeds frame_length=10)
+    for i in 0..ct.len().saturating_sub(24) {
+        if ct[i..i + 4] == ENDFRAME_MARKER {
+            let bad_len = 11u32.to_be_bytes();
+            ct[i + 20..i + 24].copy_from_slice(&bad_len);
+            break;
+        }
+    }
+    let keyring = test_keyring().await;
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=content_length > frame_length → SerializationError; proves the check exists
+    //# If this is a final frame, this MUST be determined by using the [final frame encrypted content length](../data-format/message-body.md#final-frame-encrypted-content-length).
+    let err = decrypt(&dec_input).await.expect_err("content_length > frame_length must fail");
+    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_fails_on_tampered_auth_tag() {
+    let pt = vec![0xABu8; 20];
+    let mut ct = encrypt_with_frame_length(&pt, 10).await;
+    let body_start = find_body_start(&ct, 10).expect("must find body");
+    assert_eq!(decrypt_ciphertext(&ct).await.plaintext, pt, "baseline must pass");
+    let tag_end = body_start + 4 + IV_LEN + 10 + TAG_LEN - 1;
+    ct[tag_end] ^= 0xFF;
+    let keyring = test_keyring().await;
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let err = decrypt(&dec_input).await.expect_err("tampered auth tag must fail");
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Tampered auth tag → CryptographicError proves AEAD check runs
+    //# If this decryption fails, this operation MUST immediately halt and fail.
+    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_frame_fields_deserialized_from_wire() {
+    // Directly verify each frame field is present at the correct wire offset.
+    // 30 bytes / frame_length=10 → 2 regular + 1 final = 3 frames.
+    let pt = vec![0xABu8; 30];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    assert_eq!(frames.len(), 3, "expected 3 frames (2 regular + 1 final)");
+
+    // Regular frame 1: verify deserialized fields on wire
+    let f = &frames[0];
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=On-wire seq_num at expected offset proves it was deserialized
+    //# - MUST deserialize the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number).
+    assert_eq!(f.seq_num, 1, "frame 1 seq_num must be 1");
+    assert_eq!(f.seq_num_bytes.len(), 4, "seq_num is 4 bytes on wire");
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=On-wire IV at expected offset proves it was deserialized
+    //# - MUST deserialize the [IV](../data-format/message-body.md#regular-frame-iv).
+    assert_eq!(f.iv.len(), IV_LEN, "IV is 12 bytes on wire");
+    assert_eq!(f.iv_offset, f.seq_num_offset + 4, "IV follows seq_num");
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=On-wire content at expected offset proves it was deserialized
+    //# - MUST deserialize the [Encrypted Content](../data-format/message-body.md#regular-frame-encrypted-content).
+    assert_eq!(f.content.len(), 10, "regular frame content is frame_length bytes");
+    assert_eq!(f.content_offset, f.iv_offset + IV_LEN, "content follows IV");
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=On-wire tag at expected offset proves it was deserialized
+    //# - MUST deserialize the [Authentication Tag](../data-format/message-body.md#regular-frame-authentication-tag).
+    assert_eq!(f.tag.len(), TAG_LEN, "auth tag is 16 bytes on wire");
+    assert_eq!(f.tag_offset, f.content_offset + 10, "tag follows content");
+
+    // Final frame: verify content_length field
+    let ff = &frames[2];
+    assert!(ff.is_final, "frame 3 must be final");
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=On-wire content_length field in final frame proves it was deserialized
+    //# - MUST deserialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
+    assert_eq!(ff.content_length_bytes.unwrap().len(), 4, "content_length is 4 bytes");
+    assert_eq!(ff.content_length, 10, "final frame content = remaining 10 bytes");
+
+    // Round-trip corroboration: all fields consumed correctly
+    let result = decrypt_ciphertext(&ct).await.plaintext;
+    assert_eq!(result, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_no_unauthenticated_plaintext_released() {
+    // Tamper with encrypted content in the first frame. Decrypt must fail
+    // and return no plaintext at all.
+    let pt = vec![0xABu8; 20];
+    let mut ct = encrypt_with_frame_length(&pt, 10).await;
+    let body_start = find_body_start(&ct, 10).expect("must find body");
+    // Baseline: untampered ciphertext decrypts successfully.
+    assert_eq!(decrypt_ciphertext(&ct).await.plaintext, pt, "baseline must pass");
+    // Tamper with a byte in the encrypted content of the first regular frame
+    let tamper_offset = body_start + 4 + IV_LEN + 1;
+    ct[tamper_offset] ^= 0xFF;
+    let keyring = test_keyring().await;
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("tampered ciphertext must produce error, not partial plaintext");
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Tampered body returns Err; no DecryptOutput means no plaintext released
+    //# This operation MUST NOT release any unauthenticated plaintext.
+    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_final_frame_held_until_signature_verification() {
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Tampered signature → Err; proves final frame plaintext was held back
+    //# Any plaintext decrypted from [nonframed data](../data-format/message-body.md#nonframed-data) or
+    //# a final frame in a streamed Decrypt operation MUST NOT be released until [signature verification](#verify-the-signature)
+    //# successfully completes.
+    // Encrypt with a signing algorithm suite, then tamper with the signature.
+    // Decrypt must fail, proving the final frame plaintext was held back
+    // pending signature verification and never released.
+    let keyring = test_keyring().await;
+    let pt = vec![0xABu8; 16];
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(&pt, EncryptionContext::new(), keyring.clone());
+    enc_input.frame_length = FrameLength::new(4096).unwrap();
+    enc_input.algorithm_suite_id =
+        Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    // Baseline: untampered ciphertext decrypts successfully.
+    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
+    assert!(baseline.is_ok(), "baseline must pass before tamper");
+    // Tamper with the last byte of the signature to cause verification failure
+    let last = ct.len() - 1;
+    ct[last] ^= 0xFF;
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("tampered signature must cause decrypt failure, proving final frame was held back");
+    assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unframed_decrypt_fails_on_tampered_auth_tag() {
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //= type=test
+    //# If this decryption fails, this operation MUST immediately halt and fail.
+    // Tamper with the authentication tag in the external V2 nonframed vector. Decrypt must fail.
+    let mut ct = EXTERNAL_V2_NONFRAMED_CT.to_vec();
+    // Baseline: untampered vector decrypts successfully.
+    let baseline = try_decrypt_external_nonframed(Version::V2, &ct).await;
+    assert!(baseline.is_ok(), "baseline external vector must decrypt");
+    // The auth tag is the last 16 bytes of the message
+    let last = ct.len() - 1;
+    ct[last] ^= 0xFF;
+    let result = try_decrypt_external_nonframed(Version::V2, &ct).await;
+    let err = result.expect_err("tampered nonframed auth tag must cause immediate decryption failure");
+    assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sequence_number_end_value_is_0xffffffff() {
+    let pt = vec![0xBBu8; 5];
+    let ct = encrypt_with_frame_length(&pt, 4096).await;
+    let frames = parse_all_frames(&ct, 4096);
+    assert_eq!(frames.len(), 1, "single final frame expected");
+    let f = &frames[0];
+    assert!(f.is_final, "frame must be a final frame");
+
+    // Byte-level check: the ENDFRAME marker is 0xFFFFFFFF at the frame start
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=On-wire bytes at frame start are exactly 0xFF 0xFF 0xFF 0xFF
+    //# The value MUST be `0xFFFFFFFF`.
+    let marker = f.endframe_marker_bytes.expect("final frame must have endframe marker");
+    assert_eq!(marker, &[0xFF, 0xFF, 0xFF, 0xFF], "endframe marker must be 0xFFFFFFFF byte-by-byte");
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Endframe marker field present at frame_offset on wire
+    //# - MUST deserialize the [Sequence Number End](../data-format/message-body.md#sequence-number-end).
+    assert_eq!(f.endframe_marker_offset, Some(f.frame_offset), "endframe marker at frame start");
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Seq num field at expected offset, value=1 for single final frame
+    //# - MUST deserialize the [Sequence Number](../data-format/message-body.md#final-frame-sequence-number).
+    assert_eq!(f.seq_num, 1, "final frame seq_num must be 1");
+    assert_eq!(f.seq_num_offset, f.frame_offset + 4, "seq_num follows endframe marker");
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=IV field at expected offset, 12 bytes
+    //# - MUST deserialize the [IV](../data-format/message-body.md#final-frame-iv).
+    assert_eq!(f.iv.len(), IV_LEN, "IV is 12 bytes");
+    assert_eq!(f.iv_offset, f.seq_num_offset + 4, "IV follows seq_num");
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Content length field at expected offset, 4 bytes, value=5
+    //# - MUST deserialize the [Encrypted Content Length](../data-format/message-body.md#final-frame-encrypted-content-length).
+    let cl_bytes = f.content_length_bytes.expect("final frame has content_length field");
+    assert_eq!(cl_bytes.len(), 4, "content_length is 4 bytes on wire");
+    assert_eq!(f.content_length, 5, "content_length = plaintext length for final frame");
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Encrypted content at expected offset, length matches content_length field
+    //# - MUST deserialize the [Encrypted Content](../data-format/message-body.md#final-frame-encrypted-content).
+    assert_eq!(f.content.len(), 5, "encrypted content = content_length bytes");
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Auth tag at expected offset, 16 bytes
+    //# - MUST deserialize the [Authentication Tag](../data-format/message-body.md#final-frame-authentication-tag).
+    assert_eq!(f.tag.len(), TAG_LEN, "auth tag is 16 bytes");
+    assert_eq!(f.tag_offset, f.content_offset + 5, "tag follows content");
+
+    // Round-trip corroboration
+    let result = decrypt_ciphertext(&ct).await.plaintext;
+    assert_eq!(result, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_first_frame_sequence_number_is_one() {
+    // Parse the on-wire ciphertext and verify the first frame's sequence number is 1.
+    let pt = vec![0xAAu8; 30];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    assert!(frames.len() >= 2, "need at least 2 frames");
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=On-wire first frame seq_num == 1 proves requirement
+    //# If this is framed data and the first frame sequentially, this value MUST be 1.
+    //
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Wire parse extracts seq_num from first 4 bytes, proving deserialization
+    //# - MUST deserialize the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number).
+    //
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Successful multi-frame decrypt proves body bytes follow header
+    //# Once the message header is successfully parsed, the next sequential bytes
+    //# MUST be deserialized according to the [message body spec](../data-format/message-body.md).
+    //
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Successful decrypt of all frames proves bytes were consumed as available
+    //# If there could still be message body left to deserialize and decrypt,
+    //# this operation MUST either wait for more of the encrypted message bytes to become consumable,
+    //# wait for the end to the encrypted message to be indicated,
+    //# or deserialize and/or decrypt the consumable bytes.
+    assert_eq!(frames[0].seq_num, 1, "first frame sequence number must be 1 on the wire");
+    // Round-trip corroboration
+    let result = decrypt_ciphertext(&ct).await.plaintext;
+    assert_eq!(result, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_sequence_numbers_increment() {
+    // 50 bytes at frame_length=10 → 4 regular + 1 final = 5 frames.
+    let pt = vec![0xBBu8; 50];
+    let ct = encrypt_with_frame_length(&pt, 10).await;
+    let frames = parse_all_frames(&ct, 10);
+    assert_eq!(frames.len(), 5, "50 bytes / 10-byte frames = 4 regular + 1 final");
+
+    // Verify regular frames have incrementing sequence numbers on wire
+    for (i, frame) in frames[..4].iter().enumerate() {
+        assert!(!frame.is_final, "frame {i} must be regular");
+        assert_eq!(frame.seq_num, (i + 1) as u32, "frame {i}: seq_num on wire");
+        // Byte-level: seq_num bytes encode the expected value in big-endian
+        let expected_bytes = ((i + 1) as u32).to_be_bytes();
+        assert_eq!(frame.seq_num_bytes, &expected_bytes, "frame {i}: seq_num bytes");
+    }
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=On-wire seq_nums 1..5 verified byte-by-byte across 5 frames
+    //# Otherwise, this value MUST be 1 greater than the value of the sequence number
+    //# of the previous frame.
+    assert_eq!(frames[4].seq_num, 5, "final frame seq_num must be 5");
+
+    // Verify final frame has endframe marker on wire
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Final frame's first 4 bytes are 0xFFFFFFFF on wire
+    //# If the first 4 bytes have a value of 0xFFFFFFFF,
+    //# the Decrypt operation MUST treat them as the [Sequence Number End](../data-format/message-body.md#sequence-number-end)
+    //# and deserialize the following bytes according to the [final frame spec](../data-format/message-body.md#final-frame).
+    let marker = frames[4].endframe_marker_bytes.expect("final frame has marker");
+    assert_eq!(marker, &[0xFF, 0xFF, 0xFF, 0xFF]);
+
+    // Regular frames: first 4 bytes are NOT 0xFFFFFFFF
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Regular frames' first 4 bytes != 0xFFFFFFFF, treated as seq num
+    //# Otherwise, the Decrypt operation MUST treat them as the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number)
+    //# and deserialize the following bytes according to the [regular frame spec](../data-format/message-body.md#regular-frame).
+    for frame in &frames[..4] {
+        assert!(frame.endframe_marker_bytes.is_none(), "regular frame must not have endframe marker");
+    }
+
+    // Round-trip corroboration
+    let result = decrypt_ciphertext(&ct).await.plaintext;
+    assert_eq!(result, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nonframed_body_fields_deserialized_from_wire() {
+    // Parse the external V2 nonframed vector directly and verify each field.
+    let body = parse_external_nonframed_body(EXTERNAL_V2_NONFRAMED_CT, Version::V2);
+
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //= type=test
+    //= reason=External vector's IV field is 12 bytes at expected offset
+    //# - The IV MUST be the [IV](../data-format/message-body.md#nonframed-data-iv) deserialized from the message body.
+    assert_eq!(body.iv.len(), IV_LEN, "nonframed IV must be 12 bytes");
+
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //= type=test
+    //= reason=Encrypted content length field equals expected plaintext length (10240)
+    //# If this is nonframed data, this MUST be determined by using the [nonframed data encrypted content length](../data-format/message-body.md#nonframed-data-encrypted-content-length).
+    assert_eq!(
+        body.encrypted_content_length as usize,
+        EXTERNAL_V2_NONFRAMED_PT.len(),
+        "encrypted content length must equal plaintext length"
+    );
+
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=On-wire seq_num for nonframed is always 1 (checked via AAD construction)
+    //# If this is nonframed data, this value MUST be 1.
+    // The IV's last 4 bytes encode the sequence number for nonframed data.
+    let iv_seq = u32::from_be_bytes([body.iv[8], body.iv[9], body.iv[10], body.iv[11]]);
+    assert_eq!(iv_seq, 1, "nonframed IV sequence number must be 1");
+
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //= type=test
+    //= reason=External vector decrypts to known plaintext; proves all AES-GCM inputs correct
+    //# If a message has the [nonframed](../data-format/message-body.md#nonframed-data) content type,
+    //# the Decrypt operation MUST deserialize the message body according to the
+    //# [nonframed data specification](../data-format/message-body.md#nonframed-data)
+    //# and decrypt it using the [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
+    //# specified by the [algorithm suite](../framework/algorithm-suites.md), with the following inputs:
+    let result = decrypt_external_nonframed_vector(Version::V2).await;
+    assert_eq!(result, EXTERNAL_V2_NONFRAMED_PT);
+}

--- a/esdk/tests/test_decrypt_the_message_body.rs
+++ b/esdk/tests/test_decrypt_the_message_body.rs
@@ -277,20 +277,6 @@ async fn test_decrypt_first_frame_sequence_number_is_one() {
     //= type=test
     //= reason=Wire parse extracts seq_num from first 4 bytes, proving deserialization
     //# - MUST deserialize the [Sequence Number](../data-format/message-body.md#regular-frame-sequence-number).
-    //
-    //= spec/client-apis/decrypt.md#decrypt-the-message-body
-    //= type=test
-    //= reason=Successful multi-frame decrypt proves body bytes follow header
-    //# Once the message header is successfully parsed, the next sequential bytes
-    //# MUST be deserialized according to the [message body spec](../data-format/message-body.md).
-    //
-    //= spec/client-apis/decrypt.md#decrypt-the-message-body
-    //= type=test
-    //= reason=Successful decrypt of all frames proves bytes were consumed as available
-    //# If there could still be message body left to deserialize and decrypt,
-    //# this operation MUST either wait for more of the encrypted message bytes to become consumable,
-    //# wait for the end to the encrypted message to be indicated,
-    //# or deserialize and/or decrypt the consumable bytes.
     assert_eq!(frames[0].seq_num, 1, "first frame sequence number must be 1 on the wire");
     // Round-trip corroboration
     let result = decrypt_ciphertext(&ct).await.plaintext;

--- a/esdk/tests/test_decrypt_the_message_body.rs
+++ b/esdk/tests/test_decrypt_the_message_body.rs
@@ -150,12 +150,6 @@ async fn test_decrypt_no_unauthenticated_plaintext_released() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_decrypt_final_frame_held_until_signature_verification() {
-    //= spec/client-apis/decrypt.md#decrypt-the-message-body
-    //= type=test
-    //= reason=Tampered signature → Err; proves final frame plaintext was held back
-    //# Any plaintext decrypted from [nonframed data](../data-format/message-body.md#nonframed-data) or
-    //# a final frame in a streamed Decrypt operation MUST NOT be released until [signature verification](#verify-the-signature)
-    //# successfully completes.
     // Encrypt with a signing algorithm suite, then tamper with the signature.
     // Decrypt must fail, proving the final frame plaintext was held back
     // pending signature verification and never released.
@@ -176,14 +170,17 @@ async fn test_decrypt_final_frame_held_until_signature_verification() {
     let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
     let result = decrypt(&dec_input).await;
     let err = result.expect_err("tampered signature must cause decrypt failure, proving final frame was held back");
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
+    //= type=test
+    //= reason=Tampered signature → Err; final frame plaintext never reaches caller
+    //# Any plaintext decrypted from [nonframed data](../data-format/message-body.md#nonframed-data) or
+    //# a final frame in a streamed Decrypt operation MUST NOT be released until [signature verification](#verify-the-signature)
+    //# successfully completes.
     assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unframed_decrypt_fails_on_tampered_auth_tag() {
-    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
-    //= type=test
-    //# If this decryption fails, this operation MUST immediately halt and fail.
     // Tamper with the authentication tag in the external V2 nonframed vector. Decrypt must fail.
     let mut ct = EXTERNAL_V2_NONFRAMED_CT.to_vec();
     // Baseline: untampered vector decrypts successfully.
@@ -194,6 +191,10 @@ async fn test_unframed_decrypt_fails_on_tampered_auth_tag() {
     ct[last] ^= 0xFF;
     let result = try_decrypt_external_nonframed(Version::V2, &ct).await;
     let err = result.expect_err("tampered nonframed auth tag must cause immediate decryption failure");
+    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //= type=test
+    //= reason=Tampered nonframed auth tag → CryptographicError, proving AEAD halts on failure
+    //# If this decryption fails, this operation MUST immediately halt and fail.
     assert_eq!(err.kind, ErrorKind::CryptographicError, "got: {err:?}");
 }
 
@@ -356,7 +357,7 @@ async fn test_nonframed_body_fields_deserialized_from_wire() {
     //# - The IV MUST be the [IV](../data-format/message-body.md#nonframed-data-iv) deserialized from the message body.
     assert_eq!(body.iv.len(), IV_LEN, "nonframed IV must be 12 bytes");
 
-    //= spec/client-apis/decrypt.md#nonframed-message-body-decryption
+    //= spec/client-apis/decrypt.md#decrypt-the-message-body
     //= type=test
     //= reason=Encrypted content length field equals expected plaintext length (10240)
     //# If this is nonframed data, this MUST be determined by using the [nonframed data encrypted content length](../data-format/message-body.md#nonframed-data-encrypted-content-length).

--- a/esdk/tests/test_encrypted_message_format.rs
+++ b/esdk/tests/test_encrypted_message_format.rs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for decrypt.md#encrypted-message-format — Base64 detection
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use test_helpers::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_rejects_base64_encoded_input() {
+    // Construct input starting with 0x41 ('A') — the first byte of Base64-encoded
+    // version 0x01 type 0x80 (per the spec table: "01 80" → "AY..." → "41 59...")
+    let fake_b64_input: Vec<u8> = {
+        let mut v = vec![0x41, 0x59]; // 'A', 'Y'
+        v.extend_from_slice(&[0u8; 100]); // padding
+        v
+    };
+
+    let keyring = test_keyring().await;
+    let dec_input =
+        DecryptInput::with_legacy_keyring(&fake_b64_input, EncryptionContext::new(), keyring);
+    let err = decrypt(&dec_input).await.unwrap_err();
+    let msg = format!("{err}");
+    //= spec/client-apis/decrypt.md#encrypted-message-format
+    //= type=test
+    //# To make diagnosing this mistake easier, implementations SHOULD detect the first two bytes of the Base64 encoding of any supported message [versions](../data-format/message-header.md#version)
+    //# and [types](../data-format/message-header.md#type)
+    //# and fail with a more specific error message.
+    assert!(
+        msg.contains("Base64"),
+        "Error message should mention Base64, got: {msg}"
+    );
+}

--- a/esdk/tests/test_get_decryption_materials.rs
+++ b/esdk/tests/test_get_decryption_materials.rs
@@ -79,40 +79,6 @@ async fn test_pre_cmm_commitment_policy_check() {
     assert!(inner.contains("InvalidAlgorithmSuiteInfoOnDecrypt"), "expected InvalidAlgorithmSuiteInfoOnDecrypt, got: {inner}");
 }
 
-// Regression: parses header via __test_internals to extract message_id, then
-// runs the full decrypt path end-to-end to confirm derive_keys is actually
-// invoked. The "data key MUST be derived from plaintext data key" requirement
-// is covered by a source-side type=implication on the literal call site
-// (`derive_keys(message_id, dec_mat.plaintext_data_key, ...)` in decrypt.rs).
-#[tokio::test(flavor = "multi_thread")]
-async fn test_data_key_derived_from_plaintext_data_key() {
-    use aws_esdk::__test_internals::*;
-
-    let keyring = aes_keyring(0).await;
-    let pt = b"test data key derivation";
-    let ct = encrypt_with_suite(
-        pt,
-        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
-        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
-        &keyring,
-    )
-    .await;
-
-    // Parse header to confirm message_id is reachable via the public accessor;
-    // derive_keys uses message_id as HKDF info.
-    let mut cursor = std::io::Cursor::new(ct.as_slice());
-    let mut raw = Vec::new();
-    let header_body = read_header_body(&mut cursor, None, &mut raw).unwrap();
-    let message_id = header_body.message_id();
-    assert!(!message_id.is_empty(), "message_id parsed from header");
-
-    // End-to-end decrypt confirms the real derivation path works.
-    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
-    let result = decrypt(&dec_input).await.unwrap();
-    assert_eq!(result.plaintext, pt);
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn test_algorithm_suite_from_decryption_materials() {
     // Directly verify: parse the header to get the algorithm suite, then verify

--- a/esdk/tests/test_get_decryption_materials.rs
+++ b/esdk/tests/test_get_decryption_materials.rs
@@ -79,10 +79,13 @@ async fn test_pre_cmm_commitment_policy_check() {
     assert!(inner.contains("InvalidAlgorithmSuiteInfoOnDecrypt"), "expected InvalidAlgorithmSuiteInfoOnDecrypt, got: {inner}");
 }
 
+// Regression: parses header via __test_internals to extract message_id, then
+// runs the full decrypt path end-to-end to confirm derive_keys is actually
+// invoked. The "data key MUST be derived from plaintext data key" requirement
+// is covered by a source-side type=implication on the literal call site
+// (`derive_keys(message_id, dec_mat.plaintext_data_key, ...)` in decrypt.rs).
 #[tokio::test(flavor = "multi_thread")]
 async fn test_data_key_derived_from_plaintext_data_key() {
-    // Directly call derive_keys with the same inputs decrypt would use,
-    // then verify the derived key is non-empty and decrypt succeeds.
     use aws_esdk::__test_internals::*;
 
     let keyring = aes_keyring(0).await;
@@ -95,31 +98,19 @@ async fn test_data_key_derived_from_plaintext_data_key() {
     )
     .await;
 
-    // Parse header to get message_id and algorithm suite
+    // Parse header to confirm message_id is reachable via the public accessor;
+    // derive_keys uses message_id as HKDF info.
     let mut cursor = std::io::Cursor::new(ct.as_slice());
     let mut raw = Vec::new();
     let header_body = read_header_body(&mut cursor, None, &mut raw).unwrap();
-    let suite = header_body.algorithm_suite();
-
-    // Call derive_keys directly — this is the same function decrypt uses internally
-    // We use a dummy key here just to prove the function runs; the real test is that
-    // decrypt succeeds with the keyring (which provides the real PDK)
     let message_id = header_body.message_id();
     assert!(!message_id.is_empty(), "message_id parsed from header");
 
-    // Decrypt to verify the REAL derivation path works end-to-end
+    // End-to-end decrypt confirms the real derivation path works.
     let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
     dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
     let result = decrypt(&dec_input).await.unwrap();
-
-    //= spec/client-apis/decrypt.md#get-the-decryption-materials
-    //= type=test
-    //= reason=Decrypt with HKDF suite succeeds; wrong-keyring test proves wrong PDK fails
-    //# The data key used as input for all decryption described below MUST be a data key derived from the plaintext data key
-    //# included in the [decryption materials](../framework/structures.md#decryption-materials).
     assert_eq!(result.plaintext, pt);
-    // The derive_keys function is exposed via __test_internals and was called by the
-    // decrypt path; success proves derivation from the PDK in the materials worked.
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_get_decryption_materials.rs
+++ b/esdk/tests/test_get_decryption_materials.rs
@@ -16,10 +16,12 @@ use test_helpers::*;
 async fn test_decrypt_fails_with_wrong_keyring() {
     let keyring = test_keyring().await;
     let pt = b"negative test";
-    let enc_input = EncryptInput::with_legacy_keyring(pt, EncryptionContext::new(), keyring);
+    let enc_input =
+        EncryptInput::with_legacy_keyring(pt, EncryptionContext::new(), keyring.clone());
     let ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Decrypt with a different keyring (different key material) — CMM call should fail
+    // A different keyring (different namespace, different wrapping key) — its
+    // default CMM cannot unwrap the EDK encrypted by `keyring`.
     let (ns, name) = namespace_and_name(1);
     let wrong_keyring = mpl()
         .create_raw_aes_keyring()
@@ -30,26 +32,35 @@ async fn test_decrypt_fails_with_wrong_keyring() {
         .send()
         .await
         .unwrap();
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), wrong_keyring);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when CMM cannot obtain decryption materials");
+
+    let valid_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let invalid_input =
+        DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), wrong_keyring);
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Right keyring → Ok; wrong keyring → default-CMM CollectionOfErrors, proving the input keyring constructs the default CMM
+    //# If a CMM is not supplied as the input, the decrypt operation MUST construct a [default CMM](../framework/default-cmm.md)
+    //# from the input [keyring](../framework/keyring-interface.md).
+    assert!(decrypt(&valid_input).await.is_ok(), "right keyring must decrypt");
+    let err = decrypt(&invalid_input)
+        .await
+        .expect_err("wrong keyring must fail to obtain materials");
     let ErrorKind::LegacyError(legacy) = &err.kind else {
         panic!("expected LegacyError, got: {:?}", err.kind);
     };
     let inner = format!("{legacy:?}");
-    //= spec/client-apis/decrypt.md#get-the-decryption-materials
-    //= type=test
-    //= reason=Wrong keyring → default CMM can't unwrap → proves input keyring determines CMM
-    //# If a CMM is not supplied as the input, the decrypt operation MUST construct a [default CMM](../framework/default-cmm.md)
-    //# from the input [keyring](../framework/keyring-interface.md).
-    assert!(inner.contains("CollectionOfErrors"), "expected CollectionOfErrors, got: {inner}");
+    assert!(
+        inner.contains("CollectionOfErrors"),
+        "expected default-CMM CollectionOfErrors, got: {inner}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pre_cmm_commitment_policy_check() {
     let keyring = aes_keyring(0).await;
     let pt = b"test pre-cmm commitment policy";
-    // Encrypt with non-committing suite using ForbidEncryptAllowDecrypt
+    // Encrypt with a non-committing suite (allowed by ForbidEncryptAllowDecrypt).
     let ct = encrypt_with_suite(
         pt,
         EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
@@ -57,26 +68,42 @@ async fn test_pre_cmm_commitment_policy_check() {
         &keyring,
     )
     .await;
-    // Decrypt with RequireEncryptRequireDecrypt — pre-CMM check must reject non-committing suite
-    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    dec_input.commitment_policy = EsdkCommitmentPolicy::RequireEncryptRequireDecrypt;
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when parsed algorithm suite is not supported by commitment policy");
-    let ErrorKind::LegacyError(legacy) = &err.kind else {
-        panic!("expected LegacyError, got: {:?}", err.kind);
-    };
-    let inner = format!("{legacy:?}");
+
+    // Two decrypt inputs differing only in commitment_policy: the allowing
+    // policy accepts the parsed non-committing suite; the requiring policy
+    // rejects it pre-CMM.
+    let mut valid_input =
+        DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone());
+    valid_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let mut invalid_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    invalid_input.commitment_policy = EsdkCommitmentPolicy::RequireEncryptRequireDecrypt;
+
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
     //= type=test
+    //= reason=Policy that allows the parsed suite → Ok; policy that doesn't → InvalidAlgorithmSuiteInfoOnDecrypt
     //# If the parsed [algorithm suite ID](../data-format/message-header.md#algorithm-suite-id)
     //# is not supported by the [commitment policy](client.md#commitment-policy)
     //# configured in the [client](client.md) decrypt MUST yield an error.
     //
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
     //= type=test
-    //= reason=Test explicitly sets commitment_policy on input; failure proves it was passed to CMM
+    //= reason=Test sets commitment_policy on input directly; only the chosen policy reaches the pre-CMM check
     //# - Commitment Policy: This MUST be the commitment policy configured on the client.
-    assert!(inner.contains("InvalidAlgorithmSuiteInfoOnDecrypt"), "expected InvalidAlgorithmSuiteInfoOnDecrypt, got: {inner}");
+    assert!(
+        decrypt(&valid_input).await.is_ok(),
+        "policy that allows non-committing suite must decrypt"
+    );
+    let err = decrypt(&invalid_input)
+        .await
+        .expect_err("policy that requires committing must reject non-committing suite");
+    let ErrorKind::LegacyError(legacy) = &err.kind else {
+        panic!("expected LegacyError, got: {:?}", err.kind);
+    };
+    let inner = format!("{legacy:?}");
+    assert!(
+        inner.contains("InvalidAlgorithmSuiteInfoOnDecrypt"),
+        "expected InvalidAlgorithmSuiteInfoOnDecrypt, got: {inner}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_get_decryption_materials.rs
+++ b/esdk/tests/test_get_decryption_materials.rs
@@ -155,7 +155,7 @@ async fn test_commit_key_derived_and_validated() {
     let keyring = aes_keyring(0).await;
     let pt = b"test commit key derivation and equality";
     // Use committing suite
-    let ct = encrypt_with_suite(
+    let valid_ct = encrypt_with_suite(
         pt,
         EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey,
         EsdkCommitmentPolicy::RequireEncryptRequireDecrypt,
@@ -163,34 +163,42 @@ async fn test_commit_key_derived_and_validated() {
     )
     .await;
 
-    // Baseline: untampered ciphertext decrypts.
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone());
-    assert!(decrypt(&dec_input).await.is_ok(), "baseline must pass");
-
     // Tamper the Algorithm Suite Data (commit key) in the header.
     // parse_v2_header_field_offsets gives us the exact byte range.
-    let mut tampered = ct.clone();
-    let fields = parse_v2_header_field_offsets(&tampered);
-    let (_, sd_start, _sd_end) = fields.iter().find(|(n, _, _)| *n == "Algorithm Suite Data")
+    let fields = parse_v2_header_field_offsets(&valid_ct);
+    let (_, sd_start, _sd_end) = fields
+        .iter()
+        .find(|(n, _, _)| *n == "Algorithm Suite Data")
         .expect("V2 header must have Algorithm Suite Data field");
-    let original = tampered[*sd_start];
-    tampered[*sd_start] ^= 0xFF;
-    assert_ne!(tampered[*sd_start], original, "tamper must change the byte");
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[*sd_start] ^= 0xFF;
+    assert_ne!(
+        tampered_ct[*sd_start], valid_ct[*sd_start],
+        "tamper must change the byte"
+    );
 
-    let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
-    let err = decrypt(&dec_input).await.expect_err("tampered commit key must cause decrypt to fail");
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());
+    let tampered_input =
+        DecryptInput::with_legacy_keyring(&tampered_ct, EncryptionContext::new(), keyring);
+
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
     //= type=test
-    //= reason=Tampered commit key in header causes failure; proves equality check runs
+    //= reason=Untampered commit key → Ok; tampered commit key in header → ValidationError, proving the equality check runs
     //# If the [algorithm suite](../framework/algorithm-suites.md#algorithm-suites-encryption-key-derivation-settings) supports [key commitment](../framework/algorithm-suites.md#key-commitment)
     //# then the [commit key](../framework/algorithm-suites.md#commit-key) MUST be derived from the plaintext data key
     //# using the [commit key derivation](../framework/algorithm-suites.md#algorithm-suites-commit-key-derivation-settings).
     //
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
     //= type=test
-    //= reason=Tampered header commit key != derived commit key → ValidationError
+    //= reason=Header commit key must equal derived commit key; tampering breaks equality → ValidationError
     //# The derived commit key MUST equal the commit key stored in the message header.
-    assert_eq!(err.kind, ErrorKind::ValidationError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid commit key must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::ValidationError,
+        "tampered commit key must produce ValidationError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -238,33 +246,39 @@ async fn test_unsupported_esdk_algorithm_suite_yields_error() {
     let keyring = aes_keyring(0).await;
     let pt = b"unsupported esdk suite test";
 
-    // Encrypt with a valid ESDK suite
     let enc_input =
         EncryptInput::with_legacy_keyring(pt, EncryptionContext::new(), keyring.clone());
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Tamper with the algorithm suite ID bytes in the header to an invalid value.
+    // Tamper the algorithm suite ID bytes in the header to an invalid value.
     // V2 header: byte 0 = version (0x02), bytes 1-2 = algorithm suite ID.
-    // Set to 0xFF 0xFF which is not a valid ESDK suite ID.
-    ct[1] = 0xFF;
-    ct[2] = 0xFF;
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[1] = 0xFF;
+    tampered_ct[2] = 0xFF;
 
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when algorithm suite ID is not a supported ESDK suite");
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());
+    let tampered_input =
+        DecryptInput::with_legacy_keyring(&tampered_ct, EncryptionContext::new(), keyring);
+
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
     //= type=test
-    //= reason=Tampered suite ID to non-ESDK value triggers the error path
+    //= reason=Supported ESDK suite ID → Ok; tampered to non-ESDK 0xFFFF → ValidationError
     //# If this algorithm suite is not [supported for the ESDK](../framework/algorithm-suites.md#supported-algorithm-suites-enum)
     //# decrypt MUST yield an error.
     //
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
     //= type=test
-    //= reason=Tampered header suite ID causes failure, proving parsed suite is used
+    //= reason=Tampered header suite ID changes the parsed input; failure proves parsed suite is used
     //# - Algorithm Suite ID: This MUST be the parsed
     //# [algorithm suite ID](../data-format/message-header.md#algorithm-suite-id)
     //# from the message header.
-    assert_eq!(err.kind, ErrorKind::ValidationError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid suite ID must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::ValidationError,
+        "non-ESDK suite ID must produce ValidationError"
+    );
 }
 
 /// Spy CMM for decrypt: records the inputs it received from the decrypt call.
@@ -368,5 +382,4 @@ async fn test_cmm_decrypt_call_receives_header_edks_and_ec() {
     //= type=test
     //= reason=We passed spy_cmm as input; it was used
     //# The CMM used MUST be the input CMM, if supplied.
-    assert!(edk_count > 0, "CMM decrypt_materials was called (observed EDKs)");
 }

--- a/esdk/tests/test_get_decryption_materials.rs
+++ b/esdk/tests/test_get_decryption_materials.rs
@@ -1,0 +1,381 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/client-apis/decrypt.md#get-the-decryption-materials
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
+use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
+use fixtures::*;
+use test_helpers::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_decrypt_fails_with_wrong_keyring() {
+    let keyring = test_keyring().await;
+    let pt = b"negative test";
+    let enc_input = EncryptInput::with_legacy_keyring(pt, EncryptionContext::new(), keyring);
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Decrypt with a different keyring (different key material) — CMM call should fail
+    let (ns, name) = namespace_and_name(1);
+    let wrong_keyring = mpl()
+        .create_raw_aes_keyring()
+        .key_namespace(ns)
+        .key_name(name)
+        .wrapping_key(aws_smithy_types::Blob::new([1u8; 32]))
+        .wrapping_alg(aws_mpl_legacy::dafny::types::AesWrappingAlg::AlgAes256GcmIv12Tag16)
+        .send()
+        .await
+        .unwrap();
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), wrong_keyring);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when CMM cannot obtain decryption materials");
+    let ErrorKind::LegacyError(legacy) = &err.kind else {
+        panic!("expected LegacyError, got: {:?}", err.kind);
+    };
+    let inner = format!("{legacy:?}");
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Wrong keyring → default CMM can't unwrap → proves input keyring determines CMM
+    //# If a CMM is not supplied as the input, the decrypt operation MUST construct a [default CMM](../framework/default-cmm.md)
+    //# from the input [keyring](../framework/keyring-interface.md).
+    assert!(inner.contains("CollectionOfErrors"), "expected CollectionOfErrors, got: {inner}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pre_cmm_commitment_policy_check() {
+    let keyring = aes_keyring(0).await;
+    let pt = b"test pre-cmm commitment policy";
+    // Encrypt with non-committing suite using ForbidEncryptAllowDecrypt
+    let ct = encrypt_with_suite(
+        pt,
+        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
+        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
+        &keyring,
+    )
+    .await;
+    // Decrypt with RequireEncryptRequireDecrypt — pre-CMM check must reject non-committing suite
+    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    dec_input.commitment_policy = EsdkCommitmentPolicy::RequireEncryptRequireDecrypt;
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when parsed algorithm suite is not supported by commitment policy");
+    let ErrorKind::LegacyError(legacy) = &err.kind else {
+        panic!("expected LegacyError, got: {:?}", err.kind);
+    };
+    let inner = format!("{legacy:?}");
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //# If the parsed [algorithm suite ID](../data-format/message-header.md#algorithm-suite-id)
+    //# is not supported by the [commitment policy](client.md#commitment-policy)
+    //# configured in the [client](client.md) decrypt MUST yield an error.
+    //
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Test explicitly sets commitment_policy on input; failure proves it was passed to CMM
+    //# - Commitment Policy: This MUST be the commitment policy configured on the client.
+    assert!(inner.contains("InvalidAlgorithmSuiteInfoOnDecrypt"), "expected InvalidAlgorithmSuiteInfoOnDecrypt, got: {inner}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_data_key_derived_from_plaintext_data_key() {
+    // Directly call derive_keys with the same inputs decrypt would use,
+    // then verify the derived key is non-empty and decrypt succeeds.
+    use aws_esdk::__test_internals::*;
+
+    let keyring = aes_keyring(0).await;
+    let pt = b"test data key derivation";
+    let ct = encrypt_with_suite(
+        pt,
+        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
+        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
+        &keyring,
+    )
+    .await;
+
+    // Parse header to get message_id and algorithm suite
+    let mut cursor = std::io::Cursor::new(ct.as_slice());
+    let mut raw = Vec::new();
+    let header_body = read_header_body(&mut cursor, None, &mut raw).unwrap();
+    let suite = header_body.algorithm_suite();
+
+    // Call derive_keys directly — this is the same function decrypt uses internally
+    // We use a dummy key here just to prove the function runs; the real test is that
+    // decrypt succeeds with the keyring (which provides the real PDK)
+    let message_id = header_body.message_id();
+    assert!(!message_id.is_empty(), "message_id parsed from header");
+
+    // Decrypt to verify the REAL derivation path works end-to-end
+    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let result = decrypt(&dec_input).await.unwrap();
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Decrypt with HKDF suite succeeds; wrong-keyring test proves wrong PDK fails
+    //# The data key used as input for all decryption described below MUST be a data key derived from the plaintext data key
+    //# included in the [decryption materials](../framework/structures.md#decryption-materials).
+    assert_eq!(result.plaintext, pt);
+    // The derive_keys function is exposed via __test_internals and was called by the
+    // decrypt path; success proves derivation from the PDK in the materials worked.
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_algorithm_suite_from_decryption_materials() {
+    // Directly verify: parse the header to get the algorithm suite, then verify
+    // decrypt's output reports the same suite. This proves the materials' suite
+    // was used (not some hardcoded default).
+    use aws_esdk::__test_internals::*;
+
+    let keyring = aes_keyring(0).await;
+    let pt = b"test algorithm suite from materials";
+    let ct = encrypt_with_suite(
+        pt,
+        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
+        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
+        &keyring,
+    )
+    .await;
+
+    // Parse the header directly to read the algorithm suite from the wire
+    let mut cursor = std::io::Cursor::new(ct.as_slice());
+    let mut raw = Vec::new();
+    let header_body = read_header_body(&mut cursor, None, &mut raw).unwrap();
+    let wire_suite_id = header_body.algorithm_suite().id;
+
+    // Decrypt and verify the output suite matches what the header contained
+    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let result = decrypt(&dec_input).await.unwrap();
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Output suite matches wire-parsed header suite; proves materials' suite was used
+    //# The algorithm suite used as input for all decryption described below MUST be the algorithm suite
+    //# included in the [decryption materials](../framework/structures.md#decryption-materials).
+    let output_suite_id = aws_mpl_legacy::suites::AlgorithmSuiteId::Esdk(result.algorithm_suite_id);
+    assert_eq!(output_suite_id, wire_suite_id, "output suite must match header's parsed suite");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_commit_key_derived_and_validated() {
+    let keyring = aes_keyring(0).await;
+    let pt = b"test commit key derivation and equality";
+    // Use committing suite
+    let ct = encrypt_with_suite(
+        pt,
+        EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKey,
+        EsdkCommitmentPolicy::RequireEncryptRequireDecrypt,
+        &keyring,
+    )
+    .await;
+
+    // Baseline: untampered ciphertext decrypts.
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone());
+    assert!(decrypt(&dec_input).await.is_ok(), "baseline must pass");
+
+    // Tamper the Algorithm Suite Data (commit key) in the header.
+    // parse_v2_header_field_offsets gives us the exact byte range.
+    let mut tampered = ct.clone();
+    let fields = parse_v2_header_field_offsets(&tampered);
+    let (_, sd_start, _sd_end) = fields.iter().find(|(n, _, _)| *n == "Algorithm Suite Data")
+        .expect("V2 header must have Algorithm Suite Data field");
+    let original = tampered[*sd_start];
+    tampered[*sd_start] ^= 0xFF;
+    assert_ne!(tampered[*sd_start], original, "tamper must change the byte");
+
+    let dec_input = DecryptInput::with_legacy_keyring(&tampered, EncryptionContext::new(), keyring);
+    let err = decrypt(&dec_input).await.expect_err("tampered commit key must cause decrypt to fail");
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Tampered commit key in header causes failure; proves equality check runs
+    //# If the [algorithm suite](../framework/algorithm-suites.md#algorithm-suites-encryption-key-derivation-settings) supports [key commitment](../framework/algorithm-suites.md#key-commitment)
+    //# then the [commit key](../framework/algorithm-suites.md#commit-key) MUST be derived from the plaintext data key
+    //# using the [commit key derivation](../framework/algorithm-suites.md#algorithm-suites-commit-key-derivation-settings).
+    //
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Tampered header commit key != derived commit key → ValidationError
+    //# The derived commit key MUST equal the commit key stored in the message header.
+    assert_eq!(err.kind, ErrorKind::ValidationError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_kdf_algorithm_from_materials_suite() {
+    // Parse the header to verify the algorithm suite uses HKDF, then decrypt
+    // to prove that KDF algorithm was actually used for key derivation.
+    use aws_esdk::__test_internals::*;
+
+    let keyring = aes_keyring(0).await;
+    let pt = b"test kdf algorithm from materials";
+    let ct = encrypt_with_suite(
+        pt,
+        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
+        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
+        &keyring,
+    )
+    .await;
+
+    // Parse header and verify the suite's KDF is HKDF (not Identity)
+    let mut cursor = std::io::Cursor::new(ct.as_slice());
+    let mut raw = Vec::new();
+    let header_body = read_header_body(&mut cursor, None, &mut raw).unwrap();
+    let suite = header_body.algorithm_suite();
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Wire-parsed suite uses HKDF; decrypt success confirms it was used
+    //# The algorithm suite used to derive a data key from the plaintext data key MUST be
+    //# the [key derivation algorithm](../framework/algorithm-suites.md#key-derivation-algorithm) included in the
+    //# [algorithm suite](../framework/algorithm-suites.md) associated with
+    //# the returned decryption materials.
+    assert!(
+        matches!(suite.kdf, aws_mpl_legacy::suites::DerivationAlgorithm::Hkdf(_)),
+        "parsed suite must use HKDF derivation, got: {:?}", suite.kdf
+    );
+
+    // Decrypt corroborates: HKDF was actually used for key derivation
+    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    let result = decrypt(&dec_input).await.unwrap();
+    assert_eq!(result.plaintext, pt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unsupported_esdk_algorithm_suite_yields_error() {
+    let keyring = aes_keyring(0).await;
+    let pt = b"unsupported esdk suite test";
+
+    // Encrypt with a valid ESDK suite
+    let enc_input =
+        EncryptInput::with_legacy_keyring(pt, EncryptionContext::new(), keyring.clone());
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Tamper with the algorithm suite ID bytes in the header to an invalid value.
+    // V2 header: byte 0 = version (0x02), bytes 1-2 = algorithm suite ID.
+    // Set to 0xFF 0xFF which is not a valid ESDK suite ID.
+    ct[1] = 0xFF;
+    ct[2] = 0xFF;
+
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when algorithm suite ID is not a supported ESDK suite");
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Tampered suite ID to non-ESDK value triggers the error path
+    //# If this algorithm suite is not [supported for the ESDK](../framework/algorithm-suites.md#supported-algorithm-suites-enum)
+    //# decrypt MUST yield an error.
+    //
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Tampered header suite ID causes failure, proving parsed suite is used
+    //# - Algorithm Suite ID: This MUST be the parsed
+    //# [algorithm suite ID](../data-format/message-header.md#algorithm-suite-id)
+    //# from the message header.
+    assert_eq!(err.kind, ErrorKind::ValidationError, "got: {err:?}");
+}
+
+/// Spy CMM for decrypt: records the inputs it received from the decrypt call.
+struct DecryptSpyCmm {
+    inner: aws_mpl_legacy::dafny::types::cryptographic_materials_manager::CryptographicMaterialsManagerRef,
+    observed_edk_count: std::sync::Arc<std::sync::Mutex<Option<usize>>>,
+    observed_ec_keys: std::sync::Arc<std::sync::Mutex<Option<Vec<String>>>>,
+}
+
+impl aws_mpl_legacy::dafny::types::cryptographic_materials_manager::CryptographicMaterialsManager for DecryptSpyCmm {
+    fn get_encryption_materials(
+        &self,
+        input: aws_mpl_legacy::dafny::operation::get_encryption_materials::GetEncryptionMaterialsInput,
+    ) -> Result<aws_mpl_legacy::dafny::operation::get_encryption_materials::GetEncryptionMaterialsOutput, aws_mpl_legacy::dafny::types::error::Error> {
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                self.inner.get_encryption_materials()
+                    .commitment_policy(input.commitment_policy.unwrap())
+                    .encryption_context(input.encryption_context.unwrap())
+                    .max_plaintext_length(input.max_plaintext_length.unwrap())
+                    .send().await
+            })
+        })
+    }
+    fn decrypt_materials(
+        &self,
+        input: aws_mpl_legacy::dafny::operation::decrypt_materials::DecryptMaterialsInput,
+    ) -> Result<aws_mpl_legacy::dafny::operation::decrypt_materials::DecryptMaterialsOutput, aws_mpl_legacy::dafny::types::error::Error> {
+        // Record observations
+        if let Some(ref edks) = input.encrypted_data_keys {
+            *self.observed_edk_count.lock().unwrap() = Some(edks.len());
+        }
+        if let Some(ref ec) = input.encryption_context {
+            let keys: Vec<String> = ec.keys().cloned().collect();
+            *self.observed_ec_keys.lock().unwrap() = Some(keys);
+        }
+        // Delegate
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                self.inner.decrypt_materials()
+                    .algorithm_suite_id(input.algorithm_suite_id.unwrap())
+                    .commitment_policy(input.commitment_policy.unwrap())
+                    .encryption_context(input.encryption_context.unwrap())
+                    .encrypted_data_keys(input.encrypted_data_keys.unwrap())
+                    .send().await
+            })
+        })
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cmm_decrypt_call_receives_header_edks_and_ec() {
+    let keyring = test_keyring().await;
+    let mut ec = EncryptionContext::new();
+    ec.insert("spy-key".to_string(), "spy-val".to_string());
+    let pt = b"spy cmm decrypt test";
+    let enc_input = EncryptInput::with_legacy_keyring(pt, ec, keyring.clone());
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    let inner_cmm = mpl()
+        .create_default_cryptographic_materials_manager()
+        .keyring(keyring)
+        .send()
+        .await
+        .unwrap();
+    let observed_edk_count = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let observed_ec_keys = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let spy_cmm = aws_mpl_legacy::dafny::types::cryptographic_materials_manager::CryptographicMaterialsManagerRef::from(DecryptSpyCmm {
+        inner: inner_cmm,
+        observed_edk_count: observed_edk_count.clone(),
+        observed_ec_keys: observed_ec_keys.clone(),
+    });
+
+    let dec_input = DecryptInput::with_legacy_cmm(&ct, EncryptionContext::new(), spy_cmm);
+    let result = decrypt(&dec_input).await.unwrap();
+    assert_eq!(result.plaintext, pt);
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Spy CMM observes EDK count matches header (1 EDK from single keyring)
+    //# - Encrypted Data Keys: This MUST be the parsed [encrypted data keys](../data-format/message-header.md#encrypted-data-keys)
+    //# from the message header.
+    let edk_count = observed_edk_count.lock().unwrap().unwrap();
+    assert_eq!(edk_count, 1, "CMM must receive 1 EDK from header");
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Spy CMM observes EC contains the key we encrypted with
+    //# - Encryption Context: This MUST be the parsed [encryption context](../data-format/message-header.md#aad)
+    //# from the message header.
+    let ec_keys = observed_ec_keys.lock().unwrap().clone().unwrap();
+    assert!(ec_keys.contains(&"spy-key".to_string()), "CMM must receive EC from header containing 'spy-key'");
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Spy CMM was called and returned materials successfully
+    //# This operation MUST obtain this set of [decryption materials](../framework/structures.md#decryption-materials),
+    //# by calling [Decrypt Materials](../framework/cmm-interface.md#decrypt-materials) on a [CMM](../framework/cmm-interface.md).
+    //
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=We passed spy_cmm as input; it was used
+    //# The CMM used MUST be the input CMM, if supplied.
+    assert!(edk_count > 0, "CMM decrypt_materials was called (observed EDKs)");
+}

--- a/esdk/tests/test_get_decryption_materials.rs
+++ b/esdk/tests/test_get_decryption_materials.rs
@@ -215,23 +215,23 @@ async fn test_kdf_algorithm_from_materials_suite() {
     let mut raw = Vec::new();
     let header_body = read_header_body(&mut cursor, None, &mut raw).unwrap();
     let suite = header_body.algorithm_suite();
-    //= spec/client-apis/decrypt.md#get-the-decryption-materials
-    //= type=test
-    //= reason=Wire-parsed suite uses HKDF; decrypt success confirms it was used
-    //# The algorithm suite used to derive a data key from the plaintext data key MUST be
-    //# the [key derivation algorithm](../framework/algorithm-suites.md#key-derivation-algorithm) included in the
-    //# [algorithm suite](../framework/algorithm-suites.md) associated with
-    //# the returned decryption materials.
+    // Sanity check: the suite parsed from the header declares HKDF derivation.
     assert!(
         matches!(suite.kdf, aws_mpl_legacy::suites::DerivationAlgorithm::Hkdf(_)),
         "parsed suite must use HKDF derivation, got: {:?}", suite.kdf
     );
 
-    // Decrypt corroborates: HKDF was actually used for key derivation
     let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
     dec_input.commitment_policy = EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt;
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=KDF is an invisible AEAD input; a wrong KDF derives a wrong key → AES-GCM tag fails, so decrypt success proves the suite's HKDF was used
+    //# The algorithm suite used to derive a data key from the plaintext data key MUST be
+    //# the [key derivation algorithm](../framework/algorithm-suites.md#key-derivation-algorithm) included in the
+    //# [algorithm suite](../framework/algorithm-suites.md) associated with
+    //# the returned decryption materials.
     let result = decrypt(&dec_input).await.unwrap();
-    assert_eq!(result.plaintext, pt);
+    assert_eq!(result.plaintext, pt, "HKDF-derived key must decrypt the body");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -347,6 +347,16 @@ async fn test_cmm_decrypt_call_receives_header_edks_and_ec() {
 
     let dec_input = DecryptInput::with_legacy_cmm(&ct, EncryptionContext::new(), spy_cmm);
     let result = decrypt(&dec_input).await.unwrap();
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Decrypt succeeds only because the input spy CMM was called and returned valid materials
+    //# This operation MUST obtain this set of [decryption materials](../framework/structures.md#decryption-materials),
+    //# by calling [Decrypt Materials](../framework/cmm-interface.md#decrypt-materials) on a [CMM](../framework/cmm-interface.md).
+    //
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=We passed spy_cmm as the input CMM; the spy observing the call proves the input CMM was used
+    //# The CMM used MUST be the input CMM, if supplied.
     assert_eq!(result.plaintext, pt);
 
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
@@ -364,15 +374,4 @@ async fn test_cmm_decrypt_call_receives_header_edks_and_ec() {
     //# from the message header.
     let ec_keys = observed_ec_keys.lock().unwrap().clone().unwrap();
     assert!(ec_keys.contains(&"spy-key".to_string()), "CMM must receive EC from header containing 'spy-key'");
-
-    //= spec/client-apis/decrypt.md#get-the-decryption-materials
-    //= type=test
-    //= reason=Spy CMM was called and returned materials successfully
-    //# This operation MUST obtain this set of [decryption materials](../framework/structures.md#decryption-materials),
-    //# by calling [Decrypt Materials](../framework/cmm-interface.md#decrypt-materials) on a [CMM](../framework/cmm-interface.md).
-    //
-    //= spec/client-apis/decrypt.md#get-the-decryption-materials
-    //= type=test
-    //= reason=We passed spy_cmm as input; it was used
-    //# The CMM used MUST be the input CMM, if supplied.
 }

--- a/esdk/tests/test_reproduced_enc_context.rs
+++ b/esdk/tests/test_reproduced_enc_context.rs
@@ -1,0 +1,170 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/client-apis/decrypt.md#get-the-decryption-materials
+//! and spec/client-apis/decrypt.md#input,
+//! focusing on the Reproduced Encryption Context requirement.
+
+mod fixtures;
+use aws_esdk::*;
+use fixtures::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_encryption_context_on_decrypt() {
+    let kms_key = KEY_ARN;
+    let asdf = "asdf".as_bytes();
+
+    let mpl = mpl();
+    let supplier = mpl.create_default_client_supplier().send().await.unwrap();
+    let kms_client = supplier
+        .get_client()
+        .region("us-west-2")
+        .send()
+        .await
+        .unwrap();
+
+    let kms_keyring = mpl
+        .create_aws_kms_keyring()
+        .kms_key_id(kms_key)
+        .kms_client(kms_client)
+        .send()
+        .await
+        .unwrap();
+
+    let encryption_context = small_encryption_context(SmallEncryptionContextVariation::AB);
+
+    let encrypt_output = encrypt(&EncryptInput::with_legacy_keyring(
+        asdf,
+        encryption_context.clone(),
+        kms_keyring.clone(),
+    ))
+    .await
+    .unwrap();
+
+    let esdk_ciphertext = encrypt_output.ciphertext;
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //# - Reproduced Encryption Context: This MUST be the [input](#input) encryption context.
+    let decrypt_output = decrypt(&DecryptInput::with_legacy_keyring(
+        &esdk_ciphertext,
+        encryption_context,
+        kms_keyring,
+    ))
+    .await
+    .unwrap();
+
+    assert_eq!(
+        decrypt_output.plaintext, asdf,
+        "successful decrypt proves reproduced encryption context was correctly passed to CMM"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_encryption_context_on_decrypt_failure() {
+    let kms_key = KEY_ARN;
+    let asdf = "asdf".as_bytes();
+
+    let mpl = mpl();
+    let supplier = mpl.create_default_client_supplier().send().await.unwrap();
+    let kms_client = supplier
+        .get_client()
+        .region("us-west-2")
+        .send()
+        .await
+        .unwrap();
+
+    let kms_keyring = mpl
+        .create_aws_kms_keyring()
+        .kms_key_id(kms_key)
+        .kms_client(kms_client)
+        .send()
+        .await
+        .unwrap();
+
+    let encryption_context = small_encryption_context(SmallEncryptionContextVariation::A);
+    let bad_encryption_context = small_encryption_context(SmallEncryptionContextVariation::AB);
+
+    let encrypt_output = encrypt(&EncryptInput::with_legacy_keyring(
+        asdf,
+        encryption_context,
+        kms_keyring.clone(),
+    ))
+    .await
+    .unwrap();
+
+    let esdk_ciphertext = encrypt_output.ciphertext;
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //# - Reproduced Encryption Context: This MUST be the [input](#input) encryption context.
+    let decrypt_output = decrypt(&DecryptInput::with_legacy_keyring(
+        &esdk_ciphertext,
+        bad_encryption_context,
+        kms_keyring,
+    ))
+    .await;
+
+    assert!(
+        decrypt_output.is_err(),
+        "decrypt must fail when reproduced encryption context is a superset of the original"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mismatched_encryption_context_on_decrypt() {
+    let asdf = "asdf".as_bytes();
+
+    let (namespace, name) = namespace_and_name(0);
+    let mpl = mpl();
+    let raw_aes_keyring = mpl
+        .create_raw_aes_keyring()
+        .key_namespace(namespace)
+        .key_name(name)
+        .wrapping_key(aws_smithy_types::Blob::new([0; 32]))
+        .wrapping_alg(aws_mpl_legacy::dafny::types::AesWrappingAlg::AlgAes256GcmIv12Tag16)
+        .send()
+        .await
+        .unwrap();
+
+    let encryption_context = small_encryption_context(SmallEncryptionContextVariation::A);
+    let bad_encryption_context =
+        small_mismatched_encryption_context(SmallEncryptionContextVariation::A);
+
+    let encrypt_output = encrypt(&EncryptInput::with_legacy_keyring(
+        asdf,
+        encryption_context.clone(),
+        raw_aes_keyring.clone(),
+    ))
+    .await
+    .unwrap();
+
+    let esdk_ciphertext = encrypt_output.ciphertext;
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //# - Reproduced Encryption Context: This MUST be the [input](#input) encryption context.
+    let mut decrypt_input = DecryptInput::with_legacy_keyring(
+        &esdk_ciphertext,
+        bad_encryption_context,
+        raw_aes_keyring,
+    );
+    let decrypt_output = decrypt(&decrypt_input).await;
+
+    // We expect to fail because although the same key is present on the ec,
+    // the value is different.
+    assert!(
+        decrypt_output.is_err(),
+        "decrypt must fail when reproduced encryption context has mismatched values"
+    );
+
+    decrypt_input.encryption_context = encryption_context;
+    // Test that if we supply the right ec we will succeed.
+    let _ = decrypt(&decrypt_input).await.unwrap();
+
+    //= spec/client-apis/decrypt.md#input
+    //= type=test
+    //# - Decrypt operation input MUST accept an optional [Encryption Context](#encryption-context) argument.
+    decrypt_input.encryption_context = EncryptionContext::new();
+    let _ = decrypt(&decrypt_input).await.unwrap();
+}

--- a/esdk/tests/test_reproduced_enc_context.rs
+++ b/esdk/tests/test_reproduced_enc_context.rs
@@ -87,27 +87,32 @@ async fn test_encryption_context_on_decrypt_failure() {
 
     let encrypt_output = encrypt(&EncryptInput::with_legacy_keyring(
         asdf,
-        encryption_context,
+        encryption_context.clone(),
         kms_keyring.clone(),
     ))
     .await
     .unwrap();
-
     let esdk_ciphertext = encrypt_output.ciphertext;
 
-    //= spec/client-apis/decrypt.md#get-the-decryption-materials
-    //= type=test
-    //# - Reproduced Encryption Context: This MUST be the [input](#input) encryption context.
-    let decrypt_output = decrypt(&DecryptInput::with_legacy_keyring(
+    let valid_input = DecryptInput::with_legacy_keyring(
+        &esdk_ciphertext,
+        encryption_context,
+        kms_keyring.clone(),
+    );
+    let invalid_input = DecryptInput::with_legacy_keyring(
         &esdk_ciphertext,
         bad_encryption_context,
         kms_keyring,
-    ))
-    .await;
+    );
 
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Original EC → Ok; superset EC (extra key) → Err, proving the reproduced EC was used in materials/KMS lookup
+    //# - Reproduced Encryption Context: This MUST be the [input](#input) encryption context.
+    assert!(decrypt(&valid_input).await.is_ok(), "original EC must decrypt");
     assert!(
-        decrypt_output.is_err(),
-        "decrypt must fail when reproduced encryption context is a superset of the original"
+        decrypt(&invalid_input).await.is_err(),
+        "superset EC must fail (reproduced EC mismatch)"
     );
 }
 

--- a/esdk/tests/test_reproduced_enc_context.rs
+++ b/esdk/tests/test_reproduced_enc_context.rs
@@ -6,6 +6,7 @@
 //! focusing on the Reproduced Encryption Context requirement.
 
 mod fixtures;
+mod test_helpers;
 use aws_esdk::*;
 use fixtures::*;
 

--- a/esdk/tests/test_reproduced_enc_context.rs
+++ b/esdk/tests/test_reproduced_enc_context.rs
@@ -61,62 +61,6 @@ async fn test_encryption_context_on_decrypt() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_encryption_context_on_decrypt_failure() {
-    let kms_key = KEY_ARN;
-    let asdf = "asdf".as_bytes();
-
-    let mpl = mpl();
-    let supplier = mpl.create_default_client_supplier().send().await.unwrap();
-    let kms_client = supplier
-        .get_client()
-        .region("us-west-2")
-        .send()
-        .await
-        .unwrap();
-
-    let kms_keyring = mpl
-        .create_aws_kms_keyring()
-        .kms_key_id(kms_key)
-        .kms_client(kms_client)
-        .send()
-        .await
-        .unwrap();
-
-    let encryption_context = small_encryption_context(SmallEncryptionContextVariation::A);
-    let bad_encryption_context = small_encryption_context(SmallEncryptionContextVariation::AB);
-
-    let encrypt_output = encrypt(&EncryptInput::with_legacy_keyring(
-        asdf,
-        encryption_context.clone(),
-        kms_keyring.clone(),
-    ))
-    .await
-    .unwrap();
-    let esdk_ciphertext = encrypt_output.ciphertext;
-
-    let valid_input = DecryptInput::with_legacy_keyring(
-        &esdk_ciphertext,
-        encryption_context,
-        kms_keyring.clone(),
-    );
-    let invalid_input = DecryptInput::with_legacy_keyring(
-        &esdk_ciphertext,
-        bad_encryption_context,
-        kms_keyring,
-    );
-
-    //= spec/client-apis/decrypt.md#get-the-decryption-materials
-    //= type=test
-    //= reason=Original EC → Ok; superset EC (extra key) → Err, proving the reproduced EC was used in materials/KMS lookup
-    //# - Reproduced Encryption Context: This MUST be the [input](#input) encryption context.
-    assert!(decrypt(&valid_input).await.is_ok(), "original EC must decrypt");
-    assert!(
-        decrypt(&invalid_input).await.is_err(),
-        "superset EC must fail (reproduced EC mismatch)"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_mismatched_encryption_context_on_decrypt() {
     let asdf = "asdf".as_bytes();
 

--- a/esdk/tests/test_reproduced_enc_context.rs
+++ b/esdk/tests/test_reproduced_enc_context.rs
@@ -10,26 +10,20 @@ mod test_helpers;
 use aws_esdk::*;
 use fixtures::*;
 
-// Positive-path KMS round-trip with the same encryption context on encrypt
-// and decrypt.
+// Positive-path round-trip with the same encryption context on encrypt and
+// decrypt, using a local raw AES keyring (no network/credentials dependency).
 #[tokio::test(flavor = "multi_thread")]
 async fn test_encryption_context_on_decrypt() {
-    let kms_key = KEY_ARN;
     let asdf = "asdf".as_bytes();
 
+    let (namespace, name) = namespace_and_name(0);
     let mpl = mpl();
-    let supplier = mpl.create_default_client_supplier().send().await.unwrap();
-    let kms_client = supplier
-        .get_client()
-        .region("us-west-2")
-        .send()
-        .await
-        .unwrap();
-
-    let kms_keyring = mpl
-        .create_aws_kms_keyring()
-        .kms_key_id(kms_key)
-        .kms_client(kms_client)
+    let raw_aes_keyring = mpl
+        .create_raw_aes_keyring()
+        .key_namespace(namespace)
+        .key_name(name)
+        .wrapping_key(aws_smithy_types::Blob::new([0; 32]))
+        .wrapping_alg(aws_mpl_legacy::dafny::types::AesWrappingAlg::AlgAes256GcmIv12Tag16)
         .send()
         .await
         .unwrap();
@@ -39,7 +33,7 @@ async fn test_encryption_context_on_decrypt() {
     let encrypt_output = encrypt(&EncryptInput::with_legacy_keyring(
         asdf,
         encryption_context.clone(),
-        kms_keyring.clone(),
+        raw_aes_keyring.clone(),
     ))
     .await
     .unwrap();
@@ -49,7 +43,7 @@ async fn test_encryption_context_on_decrypt() {
     let decrypt_output = decrypt(&DecryptInput::with_legacy_keyring(
         &esdk_ciphertext,
         encryption_context,
-        kms_keyring,
+        raw_aes_keyring,
     ))
     .await
     .unwrap();

--- a/esdk/tests/test_reproduced_enc_context.rs
+++ b/esdk/tests/test_reproduced_enc_context.rs
@@ -9,6 +9,12 @@ mod fixtures;
 use aws_esdk::*;
 use fixtures::*;
 
+// Regression: positive-path round-trip with KMS keyring and small EC. Behavioral
+// coverage that encrypt+decrypt with the same EC succeeds end-to-end. The
+// "Reproduced Encryption Context: This MUST be the input encryption context"
+// requirement is proven by the negative-path tests below — successful
+// round-trip alone doesn't prove reproduced-EC handling because the default
+// CMM with no required keys doesn't validate the reproduced EC.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_encryption_context_on_decrypt() {
     let kms_key = KEY_ARN;
@@ -43,9 +49,6 @@ async fn test_encryption_context_on_decrypt() {
 
     let esdk_ciphertext = encrypt_output.ciphertext;
 
-    //= spec/client-apis/decrypt.md#get-the-decryption-materials
-    //= type=test
-    //# - Reproduced Encryption Context: This MUST be the [input](#input) encryption context.
     let decrypt_output = decrypt(&DecryptInput::with_legacy_keyring(
         &esdk_ciphertext,
         encryption_context,
@@ -54,10 +57,7 @@ async fn test_encryption_context_on_decrypt() {
     .await
     .unwrap();
 
-    assert_eq!(
-        decrypt_output.plaintext, asdf,
-        "successful decrypt proves reproduced encryption context was correctly passed to CMM"
-    );
+    assert_eq!(decrypt_output.plaintext, asdf);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -141,21 +141,29 @@ async fn test_mismatched_encryption_context_on_decrypt() {
 
     let esdk_ciphertext = encrypt_output.ciphertext;
 
-    //= spec/client-apis/decrypt.md#get-the-decryption-materials
-    //= type=test
-    //# - Reproduced Encryption Context: This MUST be the [input](#input) encryption context.
     let mut decrypt_input = DecryptInput::with_legacy_keyring(
         &esdk_ciphertext,
         bad_encryption_context,
         raw_aes_keyring,
     );
-    let decrypt_output = decrypt(&decrypt_input).await;
+    let err = decrypt(&decrypt_input)
+        .await
+        .expect_err("decrypt must fail when reproduced encryption context has mismatched values");
 
     // We expect to fail because although the same key is present on the ec,
-    // the value is different.
+    // the value is different. The MPL's reproduced-EC validation produces a
+    // pinned error message identifying the mechanism.
+    let ErrorKind::LegacyError(legacy) = &err.kind else {
+        panic!("expected LegacyError, got: {:?}", err.kind);
+    };
+    let inner = format!("{legacy:?}");
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //= reason=Mismatched reproduced EC value triggers MPL "does not match reproduced encryption context" error, proving the reproduced EC was used
+    //# - Reproduced Encryption Context: This MUST be the [input](#input) encryption context.
     assert!(
-        decrypt_output.is_err(),
-        "decrypt must fail when reproduced encryption context has mismatched values"
+        inner.contains("does not match reproduced encryption context"),
+        "expected reproduced-EC mismatch error, got: {inner}"
     );
 
     decrypt_input.encryption_context = encryption_context;

--- a/esdk/tests/test_reproduced_enc_context.rs
+++ b/esdk/tests/test_reproduced_enc_context.rs
@@ -9,12 +9,8 @@ mod fixtures;
 use aws_esdk::*;
 use fixtures::*;
 
-// Regression: positive-path round-trip with KMS keyring and small EC. Behavioral
-// coverage that encrypt+decrypt with the same EC succeeds end-to-end. The
-// "Reproduced Encryption Context: This MUST be the input encryption context"
-// requirement is proven by the negative-path tests below — successful
-// round-trip alone doesn't prove reproduced-EC handling because the default
-// CMM with no required keys doesn't validate the reproduced EC.
+// Positive-path KMS round-trip with the same encryption context on encrypt
+// and decrypt.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_encryption_context_on_decrypt() {
     let kms_key = KEY_ARN;

--- a/esdk/tests/test_verify_header.rs
+++ b/esdk/tests/test_verify_header.rs
@@ -30,10 +30,13 @@ async fn test_verify_header_fails_on_tampered_header() {
 
     let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
     let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when header bytes are tampered (tag verification failure)");
     //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
+    //= reason=Tampered header byte → tag verify failure halts decrypt
     //# If this tag verification fails, this operation MUST immediately halt and fail.
-        //= spec/client-apis/decrypt.md#verify-the-header
+    //
+    //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
     //= reason=Tampered header body causes tag verify failure
     //# Once a valid message header is deserialized and decryption materials are available,
@@ -51,7 +54,7 @@ async fn test_verify_header_fails_on_tampered_header() {
     //= reason=Tag verify failure proves tag from header is checked
     //# - the tag MUST be the value serialized in the message header's
     //# [authentication tag field](../data-format/message-header.md#authentication-tag)
-        let err = result.expect_err("decrypt must fail when header bytes are tampered (tag verification failure)");
+    //
     //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
     //= reason=Tampered header body would change AAD, causing tag verify failure

--- a/esdk/tests/test_verify_header.rs
+++ b/esdk/tests/test_verify_header.rs
@@ -46,25 +46,15 @@ async fn test_verify_header_fails_on_tampered_header() {
     //
     //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
-    //= reason=Tag verify failure proves the cipherkey, tag, and AAD inputs are used
-    //# - the cipherkey MUST be the derived data key
-    //
-    //= spec/client-apis/decrypt.md#verify-the-header
-    //= type=test
-    //= reason=Tag verify failure proves tag from header is checked
-    //# - the tag MUST be the value serialized in the message header's
-    //# [authentication tag field](../data-format/message-header.md#authentication-tag)
-    //
-    //= spec/client-apis/decrypt.md#verify-the-header
-    //= type=test
     //= reason=Tampered header body would change AAD, causing tag verify failure
     //# - The AAD MUST be the concatenation of the serialized [message header body](../data-format/message-header.md#header-body)
     //# and the serialization of encryption context to only authenticate.
     //
     //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
-    //= reason=Tag verify uses empty ciphertext; if non-empty, decryption would produce unexpected output
-    //# - the ciphertext MUST be an empty byte array
+    //= reason=Tag verify failure proves tag from header is checked
+    //# - the tag MUST be the value serialized in the message header's
+    //# [authentication tag field](../data-format/message-header.md#authentication-tag)
     assert_eq!(err.kind, ErrorKind::ValidationError, "got: {err:?}");
 }
 
@@ -148,6 +138,11 @@ async fn test_streamed_signed_output_not_signed_until_complete() {
     assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
 }
 
+// Regression: streaming decrypt with a signing suite returns the parsed
+// encryption context and algorithm suite ID in DecryptStreamOutput. The
+// SHOULD requirement about releasing "as soon as tag verification succeeds"
+// is unobservable from the public API (DecryptStreamOutput is returned at end
+// of operation); see decrypt.rs `type=exception` annotation for the deviation.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_streamed_release_parsed_header_after_verification() {
     let keyring = test_keyring().await;
@@ -167,13 +162,6 @@ async fn test_streamed_release_parsed_header_after_verification() {
         .await
         .unwrap();
     assert_eq!(output, plaintext);
-    //= spec/client-apis/decrypt.md#verify-the-header
-    //= type=test
-    //= reason=Streaming decrypt output includes EC and suite, proving release after verification
-    //# - A streamed Decrypt operation SHOULD release the parsed [encryption context](#encryption-context),
-    //# [algorithm suite ID](../data-format/message-header.md#algorithm-suite-id),
-    //# and [other header information](#parsed-header)
-    //# as soon as tag verification succeeds.
     assert_eq!(
         result.encryption_context.get("release-key").map(String::as_str),
         Some("release-value"),

--- a/esdk/tests/test_verify_header.rs
+++ b/esdk/tests/test_verify_header.rs
@@ -7,7 +7,6 @@ mod fixtures;
 mod test_helpers;
 
 use aws_esdk::*;
-use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
 use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
 use fixtures::*;
 use test_helpers::*;

--- a/esdk/tests/test_verify_header.rs
+++ b/esdk/tests/test_verify_header.rs
@@ -43,7 +43,7 @@ async fn test_verify_header_fails_on_tampered_header() {
     //
     //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
-    //= reason=Tampered header body would change AAD, causing tag verify failure
+    //= reason=Tampering header body changes the AAD's header-body part → tag verify fails; EC-to-only-authenticate part of AAD is covered by test_verify_header_encryption_context_to_only_authenticate
     //# - The AAD MUST be the concatenation of the serialized [message header body](../data-format/message-header.md#header-body)
     //# and the serialization of encryption context to only authenticate.
     //

--- a/esdk/tests/test_verify_header.rs
+++ b/esdk/tests/test_verify_header.rs
@@ -88,19 +88,45 @@ async fn test_verify_header_encryption_context_to_only_authenticate() {
     let enc_input = EncryptInput::with_legacy_cmm(plaintext, encryption_context, req_cmm);
     let ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Decrypt with the reproduced encryption context — proves the EC filtering is correct
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, reproduced_ec, keyring);
-    let result = decrypt(&dec_input).await.unwrap();
+    // The required-EC CMM removed keyA from the header and listed it as required;
+    // decrypt must reconstruct the EC-to-only-authenticate from the reproduced EC
+    // and fold it into the header verification AAD. The filtered EC is an
+    // authenticated input that never appears on the wire, so it can't be parsed —
+    // a successful encrypt/decrypt agreement across the two independent paths
+    // (encrypt-side required-EC CMM vs decrypt-side filtering) is the observable.
+    let valid_input = DecryptInput::with_legacy_keyring(&ct, reproduced_ec, keyring.clone());
     //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
-    //= reason=Decrypt with reproduced EC succeeds; wrong filtering would fail header auth
+    //= reason=Filtered EC-to-only-authenticate is an off-wire authenticated input; encrypt and decrypt agree only if decrypt filters/serializes it to the required keys per spec
     //# The encryption context to only authenticate MUST be the [encryption context](../framework/structures.md#encryption-context)
     //# in the [decryption materials](../framework/structures.md#decryption-materials)
     //# filtered to only contain key value pairs listed in
     //# the [decryption material's](../framework/structures.md#decryption-materials)
     //# [required encryption context keys](../framework/structures.md#required-encryption-context-keys-1)
     //# serialized according to the [encryption context serialization specification](../framework/structures.md#serialization).
-    assert_eq!(result.plaintext, plaintext);
+    assert_eq!(
+        decrypt(&valid_input).await.unwrap().plaintext,
+        plaintext,
+        "correct reproduced EC must decrypt"
+    );
+
+    // Negative (regression): a wrong value for the required key is rejected, proving
+    // the reproduced required-key value is genuinely consumed as authenticated input
+    // and not silently ignored. The required-key value is bound into the keyring's
+    // wrapping AAD, so a wrong value fails at EDK unwrap before header verification.
+    let wrong_reproduced_ec =
+        small_mismatched_encryption_context(SmallEncryptionContextVariation::A);
+    let bad_input = DecryptInput::with_legacy_keyring(&ct, wrong_reproduced_ec, keyring);
+    let err = decrypt(&bad_input)
+        .await
+        .expect_err("wrong reproduced EC value must fail decryption");
+    let ErrorKind::LegacyError(legacy) = &err.kind else {
+        panic!("expected LegacyError, got: {:?}", err.kind);
+    };
+    assert!(
+        format!("{legacy:?}").contains("unable to decrypt any encrypted data key"),
+        "wrong reproduced required-key value must be rejected, got: {legacy:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/esdk/tests/test_verify_header.rs
+++ b/esdk/tests/test_verify_header.rs
@@ -1,0 +1,183 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/client-apis/decrypt.md#verify-the-header
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
+use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
+use fixtures::*;
+use test_helpers::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_verify_header_fails_on_tampered_header() {
+    let keyring = test_keyring().await;
+    let plaintext = b"tamper header test";
+
+    let enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Tamper with a byte in the header body (byte 10 is safely within the header body)
+    // Baseline: untampered ciphertext must decrypt successfully.
+    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
+    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+
+    ct[10] ^= 0xFF;
+
+    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
+    let result = decrypt(&dec_input).await;
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //# If this tag verification fails, this operation MUST immediately halt and fail.
+        //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //= reason=Tampered header body causes tag verify failure
+    //# Once a valid message header is deserialized and decryption materials are available,
+    //# this operation MUST validate the [message header body](../data-format/message-header.md#header-body)
+    //# by using the [authenticated encryption algorithm](../framework/algorithm-suites.md#encryption-algorithm)
+    //# to decrypt with the following inputs:
+    //
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //= reason=Tag verify failure proves the cipherkey, tag, and AAD inputs are used
+    //# - the cipherkey MUST be the derived data key
+    //
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //= reason=Tag verify failure proves tag from header is checked
+    //# - the tag MUST be the value serialized in the message header's
+    //# [authentication tag field](../data-format/message-header.md#authentication-tag)
+        let err = result.expect_err("decrypt must fail when header bytes are tampered (tag verification failure)");
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //= reason=Tampered header body would change AAD, causing tag verify failure
+    //# - The AAD MUST be the concatenation of the serialized [message header body](../data-format/message-header.md#header-body)
+    //# and the serialization of encryption context to only authenticate.
+    //
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //= reason=Tag verify uses empty ciphertext; if non-empty, decryption would produce unexpected output
+    //# - the ciphertext MUST be an empty byte array
+    assert_eq!(err.kind, ErrorKind::ValidationError, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_verify_header_encryption_context_to_only_authenticate() {
+    let keyring = test_keyring().await;
+    let plaintext = b"required ec test";
+
+    // Create a required encryption context CMM that filters "keyA" out of the header
+    let encryption_context = small_encryption_context(SmallEncryptionContextVariation::AB);
+    let required_ec_keys = small_encryption_context_keys(SmallEncryptionContextVariation::A);
+    let reproduced_ec = small_encryption_context(SmallEncryptionContextVariation::A);
+
+    let default_cmm = mpl()
+        .create_default_cryptographic_materials_manager()
+        .keyring(keyring.clone())
+        .send()
+        .await
+        .unwrap();
+
+    let req_cmm = mpl()
+        .create_required_encryption_context_cmm()
+        .underlying_cmm(default_cmm)
+        .required_encryption_context_keys(required_ec_keys)
+        .send()
+        .await
+        .unwrap();
+
+    let enc_input = EncryptInput::with_legacy_cmm(plaintext, encryption_context, req_cmm);
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Decrypt with the reproduced encryption context — proves the EC filtering is correct
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, reproduced_ec, keyring);
+    let result = decrypt(&dec_input).await.unwrap();
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //= reason=Decrypt with reproduced EC succeeds; wrong filtering would fail header auth
+    //# The encryption context to only authenticate MUST be the [encryption context](../framework/structures.md#encryption-context)
+    //# in the [decryption materials](../framework/structures.md#decryption-materials)
+    //# filtered to only contain key value pairs listed in
+    //# the [decryption material's](../framework/structures.md#decryption-materials)
+    //# [required encryption context keys](../framework/structures.md#required-encryption-context-keys-1)
+    //# serialized according to the [encryption context serialization specification](../framework/structures.md#serialization).
+    assert_eq!(result.plaintext, plaintext);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_streamed_signed_output_not_signed_until_complete() {
+    // Encrypt a multi-frame message with a signing suite, then tamper with the
+    // signature (footer). decrypt_stream must return Err, proving that output
+    // released before completion cannot be considered signed.
+    let keyring = test_keyring().await;
+    let plaintext = vec![0xBBu8; 30];
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(&plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.frame_length = FrameLength::new(10).unwrap();
+    enc_input.algorithm_suite_id =
+        Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    // Tamper with the footer (signature) to cause verification failure
+    let len = ct.len();
+    // Baseline: untampered ciphertext must decrypt successfully.
+    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
+    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+
+    ct[len - 4] ^= 0xFF;
+
+    let mut cursor = std::io::Cursor::new(ct.as_slice());
+    let mut output = Vec::new();
+    let mut stream_input =
+        DecryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
+    stream_input.unsafe_release_plaintext_before_verify = true;
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //# However, if the streamed Decrypt operation is using an algorithm suite with a signature algorithm
+    //# all released output MUST NOT be considered signed data until
+    //# this operation successfully completes.
+    let result = decrypt_stream(&mut cursor, &mut output, &stream_input).await;
+    let err = result.expect_err("streaming decrypt must fail on tampered signature — output was not signed data");
+    assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_streamed_release_parsed_header_after_verification() {
+    let keyring = test_keyring().await;
+    let plaintext = b"streamed header release test";
+
+    let mut ec = EncryptionContext::new();
+    ec.insert("release-key".to_string(), "release-value".to_string());
+    let enc_input = EncryptInput::with_legacy_keyring(plaintext, ec, keyring.clone());
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    let mut cursor = std::io::Cursor::new(ct.as_slice());
+    let mut output = Vec::new();
+    let mut stream_input =
+        DecryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
+    stream_input.unsafe_release_plaintext_before_verify = true;
+    let result = decrypt_stream(&mut cursor, &mut output, &stream_input)
+        .await
+        .unwrap();
+    assert_eq!(output, plaintext);
+    //= spec/client-apis/decrypt.md#verify-the-header
+    //= type=test
+    //= reason=Streaming decrypt output includes EC and suite, proving release after verification
+    //# - A streamed Decrypt operation SHOULD release the parsed [encryption context](#encryption-context),
+    //# [algorithm suite ID](../data-format/message-header.md#algorithm-suite-id),
+    //# and [other header information](#parsed-header)
+    //# as soon as tag verification succeeds.
+    assert_eq!(
+        result.encryption_context.get("release-key").map(String::as_str),
+        Some("release-value"),
+    );
+    assert_eq!(
+        result.algorithm_suite_id,
+        EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384,
+    );
+}
+

--- a/esdk/tests/test_verify_header.rs
+++ b/esdk/tests/test_verify_header.rs
@@ -146,11 +146,8 @@ async fn test_streamed_signed_output_not_signed_until_complete() {
     );
 }
 
-// Regression: streaming decrypt with a signing suite returns the parsed
-// encryption context and algorithm suite ID in DecryptStreamOutput. The
-// SHOULD requirement about releasing "as soon as tag verification succeeds"
-// is unobservable from the public API (DecryptStreamOutput is returned at end
-// of operation); see decrypt.rs `type=exception` annotation for the deviation.
+// Streaming decrypt output contains the parsed encryption context and
+// algorithm suite ID after the operation completes successfully.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_streamed_release_parsed_header_after_verification() {
     let keyring = test_keyring().await;

--- a/esdk/tests/test_verify_header.rs
+++ b/esdk/tests/test_verify_header.rs
@@ -19,21 +19,18 @@ async fn test_verify_header_fails_on_tampered_header() {
 
     let enc_input =
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Tamper with a byte in the header body (byte 10 is safely within the header body)
-    // Baseline: untampered ciphertext must decrypt successfully.
-    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
-    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+    // Tamper with a byte in the header body (byte 10 is safely within the header body).
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[10] ^= 0xFF;
 
-    ct[10] ^= 0xFF;
+    let valid_input = DecryptInput::from_encrypt(&valid_ct, &enc_input);
+    let tampered_input = DecryptInput::from_encrypt(&tampered_ct, &enc_input);
 
-    let dec_input = DecryptInput::from_encrypt(&ct, &enc_input);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when header bytes are tampered (tag verification failure)");
     //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
-    //= reason=Tampered header byte → tag verify failure halts decrypt
+    //= reason=Untampered ct decrypts; tampered header byte → ValidationError, halting decrypt
     //# If this tag verification fails, this operation MUST immediately halt and fail.
     //
     //= spec/client-apis/decrypt.md#verify-the-header
@@ -55,7 +52,12 @@ async fn test_verify_header_fails_on_tampered_header() {
     //= reason=Tag verify failure proves tag from header is checked
     //# - the tag MUST be the value serialized in the message header's
     //# [authentication tag field](../data-format/message-header.md#authentication-tag)
-    assert_eq!(err.kind, ErrorKind::ValidationError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
+    assert_eq!(
+        decrypt(&tampered_input).await.unwrap_err().kind,
+        ErrorKind::ValidationError,
+        "tampered header byte must produce ValidationError"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -103,9 +105,9 @@ async fn test_verify_header_encryption_context_to_only_authenticate() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_streamed_signed_output_not_signed_until_complete() {
-    // Encrypt a multi-frame message with a signing suite, then tamper with the
-    // signature (footer). decrypt_stream must return Err, proving that output
-    // released before completion cannot be considered signed.
+    // Encrypt a multi-frame message with a signing suite, then tamper with
+    // the signature (footer). decrypt_stream must return Err, proving that
+    // output released before completion cannot be considered signed.
     let keyring = test_keyring().await;
     let plaintext = vec![0xBBu8; 30];
     let mut enc_input =
@@ -113,29 +115,35 @@ async fn test_streamed_signed_output_not_signed_until_complete() {
     enc_input.frame_length = FrameLength::new(10).unwrap();
     enc_input.algorithm_suite_id =
         Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    // Tamper with the footer (signature) to cause verification failure
-    let len = ct.len();
-    // Baseline: untampered ciphertext must decrypt successfully.
-    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
-    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+    let mut tampered_ct = valid_ct.clone();
+    let len = tampered_ct.len();
+    tampered_ct[len - 4] ^= 0xFF;
 
-    ct[len - 4] ^= 0xFF;
-
-    let mut cursor = std::io::Cursor::new(ct.as_slice());
-    let mut output = Vec::new();
+    let mut valid_cursor = std::io::Cursor::new(valid_ct.as_slice());
+    let mut valid_output = Vec::new();
+    let mut tampered_cursor = std::io::Cursor::new(tampered_ct.as_slice());
+    let mut tampered_output = Vec::new();
     let mut stream_input =
         DecryptStreamInput::with_legacy_keyring(EncryptionContext::new(), keyring);
     stream_input.unsafe_release_plaintext_before_verify = true;
+
     //= spec/client-apis/decrypt.md#verify-the-header
     //= type=test
+    //= reason=Untampered ct streams to Ok; tampered signature → Err, so any output released before signature verification cannot be considered signed
     //# However, if the streamed Decrypt operation is using an algorithm suite with a signature algorithm
     //# all released output MUST NOT be considered signed data until
     //# this operation successfully completes.
-    let result = decrypt_stream(&mut cursor, &mut output, &stream_input).await;
-    let err = result.expect_err("streaming decrypt must fail on tampered signature — output was not signed data");
-    assert_eq!(err.kind, ErrorKind::Esdk, "got: {err:?}");
+    assert!(
+        decrypt_stream(&mut valid_cursor, &mut valid_output, &stream_input).await.is_ok(),
+        "valid ct must stream to Ok"
+    );
+    assert_eq!(
+        decrypt_stream(&mut tampered_cursor, &mut tampered_output, &stream_input).await.unwrap_err().kind,
+        ErrorKind::Esdk,
+        "tampered signature must produce Esdk error"
+    );
 }
 
 // Regression: streaming decrypt with a signing suite returns the parsed

--- a/esdk/tests/test_verify_signature.rs
+++ b/esdk/tests/test_verify_signature.rs
@@ -1,0 +1,112 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/client-apis/decrypt.md#verify-the-signature
+
+mod fixtures;
+mod test_helpers;
+
+use aws_esdk::*;
+use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
+use test_helpers::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_verify_signature_fails_on_tampered_footer() {
+    // Tampering with the footer signature bytes and asserting that decrypt fails proves
+    // that signature verification actually runs.
+    let keyring = test_keyring().await;
+    let plaintext = b"tamper footer test";
+
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id =
+        Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
+    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    let footer_offset = find_footer_offset_only(&ct);
+    // Baseline: untampered ciphertext must decrypt successfully.
+    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
+    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+
+    ct[footer_offset + 3] ^= 0xFF;
+
+    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    let result = decrypt(&dec_input).await;
+    let err = result.expect_err("decrypt must fail when footer signature bytes are tampered");
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Tampered footer causes failure, proving the footer is verified
+    //# If the algorithm suite has a signature algorithm,
+    //# the Decrypt operation MUST verify the message footer using the specified signature algorithm.
+    //
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Tampered footer breaks ECDSA; proves correct signature algorithm is used
+    //# Once the message footer is deserialized, the Decrypt operation MUST use the
+    //# [signature algorithm](../framework/algorithm-suites.md#signature-algorithm)
+    //# from the [algorithm suite](../framework/algorithm-suites.md) in the decryption materials to
+    //# verify the encrypted message, with the following inputs:
+    //
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Tampered footer breaks ECDSA; proves correct verification key is used
+    //# - The verification key MUST be the [verification key](../framework/structures.md#verification-key)
+    //# in the decryption materials.
+    //
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Tampered footer breaks ECDSA; proves signed input is header+body concatenation
+    //# - The input to verify MUST be the concatenation of the serialization of the
+    //# [message header](../data-format/message-header.md) and [message body](../data-format/message-body.md).
+    //
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //# If this verification is not successful, this operation MUST immediately halt and fail.
+    //
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Tampered footer causes signature error, proving footer was deserialized after body
+    //# After deserializing the body, the Decrypt operation MUST deserialize the next encrypted message bytes
+    //# as the [message footer](../data-format/message-footer.md).
+    //
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Successful untampered baseline proves footer deserialization conforms to spec
+    //# The order for message footer deserialization MUST conform to the [Message Footer](../data-format/message-footer.md) specification.
+    assert_eq!(
+        err.kind,
+        ErrorKind::Esdk,
+        "signature verification failure must be an Esdk error"
+    );
+    assert!(
+        err.message.contains("Signature verification failed"),
+        "error message must indicate signature verification failure, got: {}",
+        err.message
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_footer_wait_truncated_message_fails() {
+    let keyring = test_keyring().await;
+    let plaintext = b"truncated footer test";
+
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id =
+        Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+
+    let footer_offset = find_footer_offset_only(&ct);
+    let truncated = &ct[..footer_offset + 2]; // Keep sig_len but truncate signature bytes
+
+    let dec_input = DecryptInput::with_legacy_keyring(truncated, EncryptionContext::new(), keyring);
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Truncated footer proves operation waits for bytes and fails when unavailable
+    //# If there are not enough consumable bytes to deserialize the message footer and
+    //# the caller has not yet indicated an end to the encrypted message,
+    //# the Decrypt operation MUST wait for enough bytes to become consumable or for the caller
+    //# to indicate an end to the encrypted message.
+    let err = decrypt(&dec_input).await.expect_err("decrypt must fail when footer is truncated");
+    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+}

--- a/esdk/tests/test_verify_signature.rs
+++ b/esdk/tests/test_verify_signature.rs
@@ -12,8 +12,8 @@ use test_helpers::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_verify_signature_fails_on_tampered_footer() {
-    // Tampering with the footer signature bytes and asserting that decrypt fails proves
-    // that signature verification actually runs.
+    // Tampering with the footer signature bytes and asserting that decrypt fails
+    // proves that signature verification actually runs.
     let keyring = test_keyring().await;
     let plaintext = b"tamper footer test";
 
@@ -21,27 +21,26 @@ async fn test_verify_signature_fails_on_tampered_footer() {
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
     enc_input.algorithm_suite_id =
         Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
-    let mut ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    let footer_offset = find_footer_offset_only(&ct);
-    // Baseline: untampered ciphertext must decrypt successfully.
-    let baseline = decrypt(&DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring.clone())).await;
-    assert!(baseline.is_ok(), "baseline decrypt must succeed before tamper");
+    let footer_offset = find_footer_offset_only(&valid_ct);
+    let mut tampered_ct = valid_ct.clone();
+    tampered_ct[footer_offset + 3] ^= 0xFF;
 
-    ct[footer_offset + 3] ^= 0xFF;
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());
+    let tampered_input =
+        DecryptInput::with_legacy_keyring(&tampered_ct, EncryptionContext::new(), keyring);
 
-    let dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    let result = decrypt(&dec_input).await;
-    let err = result.expect_err("decrypt must fail when footer signature bytes are tampered");
     //= spec/client-apis/decrypt.md#verify-the-signature
     //= type=test
-    //= reason=Tampered footer signature bytes → ECDSA verify fails, proving footer is verified
+    //= reason=Untampered ct decrypts; tampered footer signature byte → Esdk("Signature verification failed"), proving footer is verified
     //# If the algorithm suite has a signature algorithm,
     //# the Decrypt operation MUST verify the message footer using the specified signature algorithm.
     //
     //= spec/client-apis/decrypt.md#verify-the-signature
     //= type=test
-    //= reason=Tampered signature → Err halts decrypt with no plaintext released
+    //= reason=Untampered → Ok; tampered → Err halts decrypt with no plaintext released
     //# If this verification is not successful, this operation MUST immediately halt and fail.
     //
     //= spec/client-apis/decrypt.md#verify-the-signature
@@ -49,10 +48,14 @@ async fn test_verify_signature_fails_on_tampered_footer() {
     //= reason=Tampering at footer offset (after body) causes signature error, proving footer was deserialized after body
     //# After deserializing the body, the Decrypt operation MUST deserialize the next encrypted message bytes
     //# as the [message footer](../data-format/message-footer.md).
+    assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
+    let err = decrypt(&tampered_input)
+        .await
+        .expect_err("tampered footer must fail");
     assert_eq!(
         err.kind,
         ErrorKind::Esdk,
-        "signature verification failure must be an Esdk error"
+        "tampered footer must produce Esdk error"
     );
     assert!(
         err.message.contains("Signature verification failed"),

--- a/esdk/tests/test_verify_signature.rs
+++ b/esdk/tests/test_verify_signature.rs
@@ -35,44 +35,20 @@ async fn test_verify_signature_fails_on_tampered_footer() {
     let err = result.expect_err("decrypt must fail when footer signature bytes are tampered");
     //= spec/client-apis/decrypt.md#verify-the-signature
     //= type=test
-    //= reason=Tampered footer causes failure, proving the footer is verified
+    //= reason=Tampered footer signature bytes → ECDSA verify fails, proving footer is verified
     //# If the algorithm suite has a signature algorithm,
     //# the Decrypt operation MUST verify the message footer using the specified signature algorithm.
     //
     //= spec/client-apis/decrypt.md#verify-the-signature
     //= type=test
-    //= reason=Tampered footer breaks ECDSA; proves correct signature algorithm is used
-    //# Once the message footer is deserialized, the Decrypt operation MUST use the
-    //# [signature algorithm](../framework/algorithm-suites.md#signature-algorithm)
-    //# from the [algorithm suite](../framework/algorithm-suites.md) in the decryption materials to
-    //# verify the encrypted message, with the following inputs:
-    //
-    //= spec/client-apis/decrypt.md#verify-the-signature
-    //= type=test
-    //= reason=Tampered footer breaks ECDSA; proves correct verification key is used
-    //# - The verification key MUST be the [verification key](../framework/structures.md#verification-key)
-    //# in the decryption materials.
-    //
-    //= spec/client-apis/decrypt.md#verify-the-signature
-    //= type=test
-    //= reason=Tampered footer breaks ECDSA; proves signed input is header+body concatenation
-    //# - The input to verify MUST be the concatenation of the serialization of the
-    //# [message header](../data-format/message-header.md) and [message body](../data-format/message-body.md).
-    //
-    //= spec/client-apis/decrypt.md#verify-the-signature
-    //= type=test
+    //= reason=Tampered signature → Err halts decrypt with no plaintext released
     //# If this verification is not successful, this operation MUST immediately halt and fail.
     //
     //= spec/client-apis/decrypt.md#verify-the-signature
     //= type=test
-    //= reason=Tampered footer causes signature error, proving footer was deserialized after body
+    //= reason=Tampering at footer offset (after body) causes signature error, proving footer was deserialized after body
     //# After deserializing the body, the Decrypt operation MUST deserialize the next encrypted message bytes
     //# as the [message footer](../data-format/message-footer.md).
-    //
-    //= spec/client-apis/decrypt.md#verify-the-signature
-    //= type=test
-    //= reason=Successful untampered baseline proves footer deserialization conforms to spec
-    //# The order for message footer deserialization MUST conform to the [Message Footer](../data-format/message-footer.md) specification.
     assert_eq!(
         err.kind,
         ErrorKind::Esdk,
@@ -82,6 +58,127 @@ async fn test_verify_signature_fails_on_tampered_footer() {
         err.message.contains("Signature verification failed"),
         "error message must indicate signature verification failure, got: {}",
         err.message
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_verify_signature_inputs_directly_verified() {
+    // Independently parse the footer per the Message Footer spec
+    // ([sig_len: UInt16 BE][signature: sig_len bytes]), reconstruct the signed
+    // input as ct[..footer_offset] (header+body concatenation), and verify
+    // with the verification key from the output encryption context using
+    // ECDSA-P384. Successful direct verification with the spec-prescribed
+    // algorithm, key, and input — together with negative cases for wrong
+    // algorithm, wrong key, and wrong input — gives direct proof that
+    // decrypt's verify-the-signature step uses these same values.
+    use aws_mpl_legacy::primitives::{DigestContext, EcdsaSignatureAlgorithm, ecdsa_verify_context};
+
+    let keyring = test_keyring().await;
+    let mut enc_input = EncryptInput::with_legacy_keyring(
+        b"verify inputs direct test",
+        EncryptionContext::new(),
+        keyring,
+    );
+    enc_input.algorithm_suite_id =
+        Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
+    let output = encrypt(&enc_input).await.unwrap();
+    let ct = &output.ciphertext;
+
+    // Verification key is base64-encoded in the output encryption context.
+    let pub_key_b64 = output
+        .encryption_context
+        .get("aws-crypto-public-key")
+        .expect("signing suite must publish verification key in EC");
+    let verification_key = aws_smithy_types::base64::decode(pub_key_b64).unwrap();
+
+    // Parse the footer per Message Footer spec: [sig_len: UInt16 BE][signature: sig_len bytes].
+    let (footer_offset, sig_len) = find_footer_offset(ct);
+    let parsed_sig_len = u16::from_be_bytes([ct[footer_offset], ct[footer_offset + 1]]);
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Footer parsed independently as [sig_len UInt16 BE][signature]; subsequent ECDSA verify against this parsing succeeds, proving decrypt's parser uses the same order
+    //# The order for message footer deserialization MUST conform to the [Message Footer](../data-format/message-footer.md) specification.
+    assert_eq!(parsed_sig_len, sig_len, "sig_len at footer offset matches");
+    let signature = &ct[footer_offset + 2..footer_offset + 2 + sig_len as usize];
+    let signed_content = &ct[..footer_offset];
+
+    // Positive: verify with P-384 (the suite's signature algorithm) and the
+    // verification key from the output EC against header+body bytes.
+    let mut digest = DigestContext::new_from_ecdsa(EcdsaSignatureAlgorithm::EcdsaP384).unwrap();
+    digest.update(signed_content);
+    let valid = ecdsa_verify_context(
+        EcdsaSignatureAlgorithm::EcdsaP384,
+        &verification_key,
+        digest,
+        signature,
+    )
+    .expect("verify must not error");
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Independent ECDSA-P384 verify with materials' verification key over header+body succeeds; P-256 negative below pins the algorithm
+    //# Once the message footer is deserialized, the Decrypt operation MUST use the
+    //# [signature algorithm](../framework/algorithm-suites.md#signature-algorithm)
+    //# from the [algorithm suite](../framework/algorithm-suites.md) in the decryption materials to
+    //# verify the encrypted message, with the following inputs:
+    //
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Independent verify uses the verification key from output EC and succeeds; wrong-key negative below pins the key
+    //# - The verification key MUST be the [verification key](../framework/structures.md#verification-key)
+    //# in the decryption materials.
+    //
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Verify input is ct[..footer_offset] = header+body concatenation; wrong-input negative below pins the input
+    //# - The input to verify MUST be the concatenation of the serialization of the
+    //# [message header](../data-format/message-header.md) and [message body](../data-format/message-body.md).
+    assert!(valid, "P-384 verify with materials' key over header+body must succeed");
+
+    // Negative: wrong algorithm (P-256) must NOT verify a P-384 signature.
+    let mut digest_p256 = DigestContext::new_from_ecdsa(EcdsaSignatureAlgorithm::EcdsaP256).unwrap();
+    digest_p256.update(signed_content);
+    let valid_p256 = ecdsa_verify_context(
+        EcdsaSignatureAlgorithm::EcdsaP256,
+        &verification_key,
+        digest_p256,
+        signature,
+    );
+    assert!(
+        !matches!(valid_p256, Ok(true)),
+        "P-256 must NOT verify a P-384 signature (wrong algorithm)"
+    );
+
+    // Negative: wrong key must NOT verify.
+    let mut wrong_key = verification_key.clone();
+    let last = wrong_key.len() - 1;
+    wrong_key[last] ^= 0xFF;
+    let mut digest_wk = DigestContext::new_from_ecdsa(EcdsaSignatureAlgorithm::EcdsaP384).unwrap();
+    digest_wk.update(signed_content);
+    let valid_wk = ecdsa_verify_context(
+        EcdsaSignatureAlgorithm::EcdsaP384,
+        &wrong_key,
+        digest_wk,
+        signature,
+    );
+    assert!(
+        !matches!(valid_wk, Ok(true)),
+        "wrong verification key must NOT verify"
+    );
+
+    // Negative: wrong input (modified header byte) must NOT verify.
+    let mut wrong_input = signed_content.to_vec();
+    wrong_input[0] ^= 0xFF;
+    let mut digest_wi = DigestContext::new_from_ecdsa(EcdsaSignatureAlgorithm::EcdsaP384).unwrap();
+    digest_wi.update(&wrong_input);
+    let valid_wi = ecdsa_verify_context(
+        EcdsaSignatureAlgorithm::EcdsaP384,
+        &verification_key,
+        digest_wi,
+        signature,
+    );
+    assert!(
+        !matches!(valid_wi, Ok(true)),
+        "wrong signed input must NOT verify"
     );
 }
 

--- a/esdk/tests/test_verify_signature.rs
+++ b/esdk/tests/test_verify_signature.rs
@@ -23,9 +23,12 @@ async fn test_verify_signature_fails_on_tampered_footer() {
         Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
     let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
+    // Footer layout per the Message Footer spec: [signature length: UInt16 BE (2 bytes)][signature].
+    // Flip a byte inside the signature itself (past the 2-byte length prefix) so verification fails.
     let footer_offset = find_footer_offset_only(&valid_ct);
+    let signature_start = footer_offset + 2;
     let mut tampered_ct = valid_ct.clone();
-    tampered_ct[footer_offset + 3] ^= 0xFF;
+    tampered_ct[signature_start] ^= 0xFF;
 
     let valid_input =
         DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());

--- a/esdk/tests/test_verify_signature.rs
+++ b/esdk/tests/test_verify_signature.rs
@@ -94,10 +94,7 @@ async fn test_verify_signature_inputs_directly_verified() {
     // Parse the footer per Message Footer spec: [sig_len: UInt16 BE][signature: sig_len bytes].
     let (footer_offset, sig_len) = find_footer_offset(ct);
     let parsed_sig_len = u16::from_be_bytes([ct[footer_offset], ct[footer_offset + 1]]);
-    //= spec/client-apis/decrypt.md#verify-the-signature
-    //= type=test
-    //= reason=Footer parsed independently as [sig_len UInt16 BE][signature]; subsequent ECDSA verify against this parsing succeeds, proving decrypt's parser uses the same order
-    //# The order for message footer deserialization MUST conform to the [Message Footer](../data-format/message-footer.md) specification.
+    // Sanity-check that the helper's reading agrees with our independent re-parse.
     assert_eq!(parsed_sig_len, sig_len, "sig_len at footer offset matches");
     let signature = &ct[footer_offset + 2..footer_offset + 2 + sig_len as usize];
     let signed_content = &ct[..footer_offset];
@@ -113,6 +110,11 @@ async fn test_verify_signature_inputs_directly_verified() {
         signature,
     )
     .expect("verify must not error");
+    //= spec/client-apis/decrypt.md#verify-the-signature
+    //= type=test
+    //= reason=Footer parsed independently as [sig_len UInt16 BE][signature]; ECDSA verify against this parsing succeeds, proving decrypt's parser uses the same order
+    //# The order for message footer deserialization MUST conform to the [Message Footer](../data-format/message-footer.md) specification.
+    //
     //= spec/client-apis/decrypt.md#verify-the-signature
     //= type=test
     //= reason=Independent ECDSA-P384 verify with materials' verification key over header+body succeeds; P-256 negative below pins the algorithm

--- a/esdk/tests/test_verify_signature.rs
+++ b/esdk/tests/test_verify_signature.rs
@@ -196,19 +196,28 @@ async fn test_footer_wait_truncated_message_fails() {
         EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
     enc_input.algorithm_suite_id =
         Some(EsdkAlgorithmSuiteId::AlgAes256GcmHkdfSha512CommitKeyEcdsaP384);
-    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let valid_ct = encrypt(&enc_input).await.unwrap().ciphertext;
 
-    let footer_offset = find_footer_offset_only(&ct);
-    let truncated = &ct[..footer_offset + 2]; // Keep sig_len but truncate signature bytes
+    // Truncate the footer signature: keep sig_len but drop the signature bytes.
+    let footer_offset = find_footer_offset_only(&valid_ct);
+    let truncated_ct = valid_ct[..footer_offset + 2].to_vec();
 
-    let dec_input = DecryptInput::with_legacy_keyring(truncated, EncryptionContext::new(), keyring);
+    let valid_input =
+        DecryptInput::with_legacy_keyring(&valid_ct, EncryptionContext::new(), keyring.clone());
+    let truncated_input =
+        DecryptInput::with_legacy_keyring(&truncated_ct, EncryptionContext::new(), keyring);
+
     //= spec/client-apis/decrypt.md#verify-the-signature
     //= type=test
-    //= reason=Truncated footer proves operation waits for bytes and fails when unavailable
+    //= reason=Full ct → Ok; ct truncated mid-footer → SerializationError, EOF on the blocking read signals end-of-message
     //# If there are not enough consumable bytes to deserialize the message footer and
     //# the caller has not yet indicated an end to the encrypted message,
     //# the Decrypt operation MUST wait for enough bytes to become consumable or for the caller
     //# to indicate an end to the encrypted message.
-    let err = decrypt(&dec_input).await.expect_err("decrypt must fail when footer is truncated");
-    assert_eq!(err.kind, ErrorKind::SerializationError, "got: {err:?}");
+    assert!(decrypt(&valid_input).await.is_ok(), "full ct must decrypt");
+    assert_eq!(
+        decrypt(&truncated_input).await.unwrap_err().kind,
+        ErrorKind::SerializationError,
+        "truncated footer must produce SerializationError"
+    );
 }

--- a/esdk/tests/test_verify_signature.rs
+++ b/esdk/tests/test_verify_signature.rs
@@ -42,12 +42,6 @@ async fn test_verify_signature_fails_on_tampered_footer() {
     //= type=test
     //= reason=Untampered → Ok; tampered → Err halts decrypt with no plaintext released
     //# If this verification is not successful, this operation MUST immediately halt and fail.
-    //
-    //= spec/client-apis/decrypt.md#verify-the-signature
-    //= type=test
-    //= reason=Tampering at footer offset (after body) causes signature error, proving footer was deserialized after body
-    //# After deserializing the body, the Decrypt operation MUST deserialize the next encrypted message bytes
-    //# as the [message footer](../data-format/message-footer.md).
     assert!(decrypt(&valid_input).await.is_ok(), "valid ct must decrypt");
     let err = decrypt(&tampered_input)
         .await


### PR DESCRIPTION
Implements decrypt behavior per [client-apis/decrypt.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/update-more-data-format/client-apis/decrypt.md).

Scope:
- `esdk/src/decrypt.rs` — decrypt entry point, header parsing, decryption-materials retrieval, body decryption, signature verification, output assembly.
- Tests:
  - `esdk/tests/test_decrypt_behavior.rs` — top-level decrypt behavior.
  - `esdk/tests/test_decrypt_missing_annotations.rs` — coverage for spec requirements not tied to a sub-routine.
  - `esdk/tests/test_decrypt_output.rs` — output structure assertions.
  - `esdk/tests/test_decrypt_parse_header.rs` — header parsing step.
  - `esdk/tests/test_decrypt_the_message_body.rs` — body decryption step.
  - `esdk/tests/test_encrypted_message_format.rs` — encrypted message format validation.
  - `esdk/tests/test_get_decryption_materials.rs` — decryption-materials retrieval step.
  - `esdk/tests/test_reproduced_enc_context.rs` — reproduced encryption context handling.
  - `esdk/tests/test_verify_header.rs` — header verification step.
  - `esdk/tests/test_verify_signature.rs` — signature verification step.

The public input/output types (`DecryptInput`, `DecryptOutput`) and streaming traits are reviewed in #919. Header, body, body-AAD, and footer deserialization called from here are reviewed in their own PRs (#909, #918, #900, #898). Encrypt behavior is reviewed in #921.

---

**Note:** CI does not run on this PR. This branch is scoped for focused review and intentionally omits test helpers, scaffolding, and other supporting code. Full code — including helpers, test infrastructure, and working tests — lives on the [`aws-crypto-rust/unreviewed`](https://github.com/aws/aws-encryption-sdk/tree/aws-crypto-rust/unreviewed) branch.

If you want more context or to actually run the tests, see `aws-crypto-rust/unreviewed`.

**Related spec:**
- [client-apis/decrypt.md](https://github.com/awslabs/aws-encryption-sdk-specification/blob/update-more-data-format/client-apis/decrypt.md)
