### PR TITLE
feat(native-rust): materials and key derivation

### DIFF
--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -25,7 +25,7 @@ pub struct ExpandedKeyMaterial {
 
 // Returns the HKDF-derived (output) key length defined by the algorithm suite.
 // Only HKDF suites carry this length; any other KDF reaching here is a config error.
-fn get_kdf_outlen(suite: &AlgorithmSuite) -> Result<u32, Error> {
+fn get_kdf_output_len(suite: &AlgorithmSuite) -> Result<u32, Error> {
     match suite.kdf {
         DerivationAlgorithm::Hkdf(x) => Ok(x.output_key_length),
         _ => Err(val_err(
@@ -36,7 +36,7 @@ fn get_kdf_outlen(suite: &AlgorithmSuite) -> Result<u32, Error> {
 
 // Returns the HKDF input (plaintext data key) length defined by the algorithm suite.
 // Only HKDF suites carry this length; any other KDF reaching here is a config error.
-fn get_kdf_inlen(suite: &AlgorithmSuite) -> Result<u32, Error> {
+fn get_kdf_input_len(suite: &AlgorithmSuite) -> Result<u32, Error> {
     match suite.kdf {
         DerivationAlgorithm::Hkdf(x) => Ok(x.input_key_length),
         _ => Err(val_err(
@@ -72,15 +72,15 @@ fn digest_length(alg: aws_mpl_legacy::primitives::DigestAlg) -> Result<usize, Er
     }
 }
 
-// Derives a single data key from an input plaintext data key, using "v1"-style
-// key derivation (that is, no key commitment).
-pub(crate) fn derive_key(
+// Derives the message encryption key for V1 suites: a single HKDF call, with no
+// key commitment.
+pub(crate) fn derive_key_v1(
     message_id: &[u8],
     plaintext_data_key: &[u8],
     suite: &AlgorithmSuite,
     on_net_v4_retry: bool,
 ) -> Result<ExpandedKeyMaterial, Error> {
-    // This should only be used for v1 algorithms
+    // This should only be used for V1 algorithms.
     debug_assert!(suite.message_version == 1);
     debug_assert!(valid_derivation_alg(
         &suite.kdf,
@@ -110,23 +110,14 @@ pub(crate) fn derive_key(
             let alg = hkdf.hmac;
             let salt = vec![0u8; digest_length(alg)?];
             let mut derived_key = vec![0u8; usize::try_from(hkdf.output_key_length).map_err(|_| val_err("HKDF output_key_length exceeds usize"))?];
-            if on_net_v4_retry {
-                aws_mpl_legacy::primitives::hkdf(
-                    alg,
-                    &salt,
-                    plaintext_data_key,
-                    &[message_id],
-                    &mut derived_key,
-                )?;
-            } else {
-                aws_mpl_legacy::primitives::hkdf(
-                    alg,
-                    &salt,
-                    plaintext_data_key,
-                    &[&suite.binary_id[..], message_id],
-                    &mut derived_key,
-                )?;
-            }
+
+            // The Net v4.0.0 retry path omits the suite's binary ID from the HKDF
+            // info; the standard path prefixes it.
+            let v4_info: [&[u8]; 1] = [message_id];
+            let standard_info: [&[u8]; 2] = [&suite.binary_id[..], message_id];
+            let info: &[&[u8]] = if on_net_v4_retry { &v4_info } else { &standard_info };
+
+            aws_mpl_legacy::primitives::hkdf(alg, &salt, plaintext_data_key, info, &mut derived_key)?;
 
             Ok(ExpandedKeyMaterial {
                 data_key: Zeroizing::new(derived_key),
@@ -143,19 +134,19 @@ pub(crate) fn derive_key(
 const COMMIT_LABEL: &str = "COMMITKEY";
 const KEY_LABEL: &str = "DERIVEKEY";
 
-// Derives keys from an input plaintext data key, using "v2"-style
-// key derivation (that is, including key commitment).
-pub(crate) fn expand_key_material(
+// Derives the message encryption key and key commitment value for V2 suites:
+// one HKDF-extract followed by two HKDF-expands.
+pub(crate) fn derive_key_v2(
     message_id: &[u8],
-    plaintext_key: &[u8],
+    plaintext_data_key: &[u8],
     suite: &AlgorithmSuite,
 ) -> Result<ExpandedKeyMaterial, Error> {
-    // This should only be used for v2 algorithms
+    // This should only be used for V2 algorithms.
     if suite.message_version != 2 {
-        return Err(val_err("expand_key_material requires message version 2"));
+        return Err(val_err("derive_key_v2 requires message version 2"));
     }
-    // For v2 algorithms, KDF can only be HKDF
-    if u32::from(get_encrypt_key_length(suite)) != get_kdf_outlen(suite)? {
+    // For V2 algorithms, the KDF can only be HKDF.
+    if u32::from(get_encrypt_key_length(suite)) != get_kdf_output_len(suite)? {
         return Err(val_err(
             "Encrypt key length must match KDF output key length",
         ));
@@ -163,13 +154,13 @@ pub(crate) fn expand_key_material(
     if message_id.is_empty() {
         return Err(val_err("Message ID must not be empty"));
     }
-    if plaintext_key.len() != usize::try_from(get_kdf_inlen(suite)?).map_err(|_| val_err("KDF input_key_length exceeds usize"))? {
+    if plaintext_data_key.len() != usize::try_from(get_kdf_input_len(suite)?).map_err(|_| val_err("KDF input_key_length exceeds usize"))? {
         return Err(val_err(
             "Plaintext key length must match KDF input key length",
         ));
     }
 
-    let (digest, commit_len) = match &suite.commitment {
+    let (alg, commit_len) = match &suite.commitment {
         DerivationAlgorithm::Hkdf(hkdf) => (hkdf.hmac, hkdf.output_key_length),
         DerivationAlgorithm::None => {
             return Err(val_err("None is not a valid Commitment Algorithm"));
@@ -178,7 +169,6 @@ pub(crate) fn expand_key_material(
             return Err(val_err("Unknown is not a valid Commitment Algorithm"));
         }
     };
-    let alg = digest;
     let info = [&suite.binary_id[..], KEY_LABEL.as_bytes()];
 
     // V2 key commitment derivation. A single HKDF-extract over the message ID (used
@@ -187,8 +177,8 @@ pub(crate) fn expand_key_material(
     // message encryption key (binding it to the algorithm suite), and `COMMITKEY` for
     // the commitment key. See `framework/algorithm-suites.md`.
     let pseudo_random_key =
-        aws_mpl_legacy::primitives::hkdf_extract(alg, message_id, plaintext_key);
-    let mut encrypt_key = vec![0u8; usize::try_from(get_kdf_outlen(suite)?).map_err(|_| val_err("KDF output_key_length exceeds usize"))?];
+        aws_mpl_legacy::primitives::hkdf_extract(alg, message_id, plaintext_data_key);
+    let mut encrypt_key = vec![0u8; usize::try_from(get_kdf_output_len(suite)?).map_err(|_| val_err("KDF output_key_length exceeds usize"))?];
     let mut commit_key = vec![0u8; usize::try_from(commit_len).map_err(|_| val_err("Commit key length exceeds usize"))?];
     aws_mpl_legacy::primitives::hkdf_expand(&pseudo_random_key, &info, &mut encrypt_key)?;
     aws_mpl_legacy::primitives::hkdf_expand(
@@ -203,22 +193,20 @@ pub(crate) fn expand_key_material(
     })
 }
 
-// Derives key material for encryption/decryption. Delegates out to specific methods
-// based on the input algorithm suite.
+// Derives key material for encryption/decryption. Delegates to the V1 or V2
+// routine based on the algorithm suite's message version.
 pub fn derive_keys(
     message_id: &[u8],
-    plaintext_key: &[u8],
+    plaintext_data_key: &[u8],
     suite: &AlgorithmSuite,
     on_net_v4_retry: bool,
 ) -> Result<ExpandedKeyMaterial, Error> {
     debug_assert!(!message_id.is_empty());
-    debug_assert!(usize::from(get_encrypt_key_length(suite)) == plaintext_key.len());
+    debug_assert!(usize::from(get_encrypt_key_length(suite)) == plaintext_data_key.len());
 
-    if suite.message_version == 2 {
-        expand_key_material(message_id, plaintext_key, suite)
-    } else if suite.message_version == 1 {
-        derive_key(message_id, plaintext_key, suite, on_net_v4_retry)
-    } else {
-        Err(val_err("Unknown Message Version"))
+    match suite.message_version {
+        1 => derive_key_v1(message_id, plaintext_data_key, suite, on_net_v4_retry),
+        2 => derive_key_v2(message_id, plaintext_data_key, suite),
+        _ => Err(val_err("Unknown Message Version")),
     }
 }

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -8,13 +8,13 @@ use aws_mpl_legacy::suites::AlgorithmSuite;
 use aws_mpl_legacy::suites::DerivationAlgorithm;
 use zeroize::Zeroizing;
 
-/// Convenience container to hold both a data key and an optional commitment key
-/// to support algorithm suites that provide commitment and those that do not.
+// Holds a derived data key and an optional commitment key (the latter only for
+// committing algorithm suites). This is `pub` only so `derive_keys` is reachable
+// from integration tests via `__test_internals`; it is not supported public API.
+#[doc(hidden)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExpandedKeyMaterial {
-    /// The derived data encryption key.
     pub data_key: Zeroizing<Vec<u8>>,
-    /// The derived commitment key, present only for committing algorithm suites.
     pub commitment_key: Option<Zeroizing<Vec<u8>>>,
 }
 
@@ -211,8 +211,11 @@ pub(crate) fn derive_key_v2(
     })
 }
 
-/// Derives key material for encryption/decryption. Delegates to the V1 or V2
-/// routine based on the algorithm suite's message version.
+// Derives key material for encryption/decryption. Delegates to the V1 or V2
+// routine based on the algorithm suite's message version. `pub` only so it is
+// reachable from integration tests via `__test_internals`; internal callers use
+// the crate path.
+#[doc(hidden)]
 pub fn derive_keys(
     message_id: &[u8],
     plaintext_data_key: &[u8],

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -12,6 +12,7 @@ use zeroize::Zeroizing;
 // committing algorithm suites). This is `pub` only so `derive_keys` is reachable
 // from integration tests via `__test_internals`; it is not supported public API.
 #[doc(hidden)]
+#[expect(clippy::exhaustive_structs, reason = "test-internal struct, not public API")]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExpandedKeyMaterial {
     pub data_key: Zeroizing<Vec<u8>>,
@@ -71,6 +72,7 @@ pub(crate) fn derive_key_v1(
         //= spec/client-apis/encrypt.md#get-the-encryption-materials
         //# - If the key derivation algorithm is the [identity KDF](../framework/algorithm-suites.md#identity-kdf),
         //# then the derived data key MUST be the same as the plaintext data key.
+        //
         //= spec/client-apis/decrypt.md#get-the-decryption-materials
         //# If the key derivation algorithm is the [identity KDF](../framework/algorithm-suites.md#identity-kdf),
         //# then the derived data key MUST be the same as the plaintext data key.
@@ -91,9 +93,19 @@ pub(crate) fn derive_key_v1(
         }
         //= spec/client-apis/encrypt.md#get-the-encryption-materials
         //# - If the key derivation algorithm is [HKDF](../framework/algorithm-suites.md#hkdf),
-        //# the derivation process used MUST be the process described in [HKDF Encryption Key](../transitive-requirements.md#hkdf-encryption-key).
+        //# the derivation process used MUST be the process described in [HKDF Encryption Key](./key-derivation.md#hkdf-encryption-key).
+        //
+        //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+        //# If an algorithm suite uses HKDF to derive the encryption key
+        //# the AWS Encryption SDK MUST use HKDF with the following specifics:
         DerivationAlgorithm::Hkdf(hkdf) => {
+            //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+            //# - The hash function MUST be specified by the [algorithm suite key derivation settings](#algorithm-suites-encryption-key-derivation-settings).
             let alg = hkdf.hmac;
+
+            //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+            //# - If there is no salt length defined for the [algorithm suite encryption key derivation commitment setting](#algorithm-suites-encryption-key-derivation-settings),
+            //# the the salt MUST be a byte sequence of 0 as long as the hash length in bytes.
             let salt = vec![0u8; digest_length(alg)?];
 
             let Ok(output_len) = usize::try_from(hkdf.output_key_length) else {
@@ -102,14 +114,25 @@ pub(crate) fn derive_key_v1(
                     hkdf.output_key_length
                 )));
             };
+            //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+            //# - The length of the output keying material MUST equal the [encryption key length](#encryption-key-length)
+            //# specified by the [algorithm suite encryption settings](#algorithm-suites-encryption-settings).
             let mut derived_key = vec![0u8; output_len];
 
             // The Net v4.0.0 retry path omits the suite's binary ID from the HKDF
             // info; the standard path prefixes it.
             let v4_info: [&[u8]; 1] = [message_id];
+            //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+            //# - If [key commitment](#key-commitment) for the [algorithm suite encryption key derivation setting](#algorithm-suites-encryption-key-derivation-settings) is False,
+            //# the the input info MUST be a concatenation of the [algorithm suite ID](#algorithm-suite-id)
+            //# followed by the [message ID](../data-format/message-header.md#message-id).
             let standard_info: [&[u8]; 2] = [&suite.binary_id[..], message_id];
             let info: &[&[u8]] = if on_net_v4_retry { &v4_info } else { &standard_info };
 
+            //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+            //= type=implication
+            //= reason=primitives::hkdf bundles HKDF-Extract and HKDF-Expand; the PRK input to expand is the extract output by construction of the helper
+            //# - The input pseudorandom key MUST be the output from the extract step.
             aws_mpl_legacy::primitives::hkdf(alg, &salt, plaintext_data_key, info, &mut derived_key)?;
 
             Ok(ExpandedKeyMaterial {
@@ -129,7 +152,16 @@ const KEY_LABEL: &str = "DERIVEKEY";
 
 // Derives the message encryption key and key commitment value for V2 suites:
 // one HKDF-extract followed by two HKDF-expands.
-pub(crate) fn derive_key_v2(
+//
+//= spec/client-apis/key-derivation.md#hkdf-encryption-key
+//# If an algorithm suite uses HKDF to derive the encryption key
+//# the AWS Encryption SDK MUST use HKDF with the following specifics:
+//
+//= spec/client-apis/key-derivation.md#hkdf-commit-key
+//# If an algorithm suite uses HKDF to derive the commitment key
+//# the AWS Encryption SDK MUST use HKDF with the following specifics:
+#[doc(hidden)]
+pub fn derive_key_v2(
     message_id: &[u8],
     plaintext_data_key: &[u8],
     suite: &AlgorithmSuite,
@@ -156,6 +188,13 @@ pub(crate) fn derive_key_v2(
             "KDF input_key_length {kdf_input_len} exceeds usize"
         )));
     };
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //# - The length of the input keying material MUST equal the [key derivation input length](#key-derivation-input-length)
+    //# specified by the [algorithm suite encryption key derivation settings](#algorithm-suites-encryption-key-derivation-settings).
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //# - The length of the input keying material MUST equal the [key derivation input length](#key-derivation-input-length)
+    //# specified by the algorithm suite commit key derivation setting.
     if plaintext_data_key.len() != kdf_input_len {
         return Err(val_err(format!(
             "Plaintext data key length {} does not match KDF input key length {kdf_input_len}",
@@ -163,6 +202,14 @@ pub(crate) fn derive_key_v2(
         )));
     }
 
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= reason=V2 suites share the same HKDF hash for encryption and commit derivation; suite.commitment.hkdf.hmac is the HKDF hash configured by the suite
+    //# - The hash function MUST be specified by the [algorithm suite key derivation settings](#algorithm-suites-encryption-key-derivation-settings).
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //= type=implication
+    //= reason=Hash is destructured directly from suite.commitment; both V2 committing suites (0x0478, 0x0578) carry SHA-512, so no observable runtime differential exists to falsify
+    //# - The hash function MUST be specified by the [algorithm suite commitment settings](#algorithm-suites-commit-key-derivation-settings).
     let (alg, commit_len) = match &suite.commitment {
         DerivationAlgorithm::Hkdf(hkdf) => (hkdf.hmac, hkdf.output_key_length),
         DerivationAlgorithm::None => {
@@ -174,13 +221,27 @@ pub(crate) fn derive_key_v2(
             )));
         }
     };
-    let info = [&suite.binary_id[..], KEY_LABEL.as_bytes()];
 
     // V2 key commitment derivation. A single HKDF-extract over the message ID (used
     // as the salt) and the plaintext key yields one pseudo-random key, which is then
     // expanded twice with distinct info labels: `binary_id || DERIVEKEY` for the
     // message encryption key (binding it to the algorithm suite), and `COMMITKEY` for
     // the commitment key. See `framework/algorithm-suites.md`.
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //# - If salt length is defined for the [algorithm suite encryption key derivation commitment setting](#algorithm-suites-encryption-key-derivation-settings),
+    //# the salt MUST be the [message ID](../data-format/message-header.md#message-id) with a length equal to the salt length.
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //# - The salt MUST be the [message ID](../data-format/message-header.md#message-id) with a length of 256 bits.
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //= type=implication
+    //= reason=pseudo_random_key is bound once by hkdf_extract and reused for both hkdf_expand calls — extract-once is structural
+    //# For algorithm suites that support commitment,
+    //# the AWS Encryption SDK SHOULD only perform the extract step once
+    //# and use the same output from the extract step
+    //# for both the encryption key and the commitment key.
     let pseudo_random_key =
         aws_mpl_legacy::primitives::hkdf_extract(alg, message_id, plaintext_data_key);
 
@@ -189,6 +250,9 @@ pub(crate) fn derive_key_v2(
             "KDF output_key_length {kdf_output_len} exceeds usize"
         )));
     };
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //# - The length of the output keying material MUST equal the [encryption key length](#encryption-key-length)
+    //# specified by the [algorithm suite encryption settings](#algorithm-suites-encryption-settings).
     let mut encrypt_key = vec![0u8; encrypt_key_len];
 
     let Ok(commit_len) = usize::try_from(commit_len) else {
@@ -196,9 +260,29 @@ pub(crate) fn derive_key_v2(
             "Commit key length {commit_len} exceeds usize"
         )));
     };
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //# - The length of the output keying material MUST equal the [algorithm suite data length](#algorithm-suite-data-length)
+    //# specified by the [supported algorithm suites](#supported-algorithm-suites).
     let mut commit_key = vec![0u8; commit_len];
 
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //# - If [key commitment](#key-commitment) for the [algorithm suite encryption key derivation setting](#algorithm-suites-encryption-key-derivation-settings) is True,
+    //# then the input info MUST be a concatenation of the [algorithm suite ID](#algorithm-suite-id) followed by the string `DERIVEKEY` as UTF8 encoded bytes.
+    let info = [&suite.binary_id[..], KEY_LABEL.as_bytes()];
+
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=implication
+    //= reason=pseudo_random_key holds the hkdf_extract return value above and is the only PRK input threaded into hkdf_expand here by data dependency
+    //# - The input pseudorandom key MUST be the output from the extract step.
     aws_mpl_legacy::primitives::hkdf_expand(&pseudo_random_key, &info, &mut encrypt_key)?;
+
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //= type=implication
+    //= reason=pseudo_random_key holds the hkdf_extract return value above and is the only PRK input threaded into hkdf_expand here by data dependency
+    //# - The input pseudorandom key MUST be the output from the extract step.
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //# - The input info MUST the string `COMMITKEY` as UTF8 encoded bytes by the algorithm suite commitment settings.
     aws_mpl_legacy::primitives::hkdf_expand(
         &pseudo_random_key,
         &[COMMIT_LABEL.as_bytes()],

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -1,6 +1,13 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-//! Key derivation for V1 (HKDF-extract) and V2 (HKDF-expand) algorithm suites.
+//! Key derivation for the ESDK message encryption key.
+//!
+//! The MPL produces the plaintext data key; this module derives the per-message
+//! encryption key from it (binding it to the message ID) and, for V2 suites, the
+//! key commitment value. V1 uses a single HKDF call; V2 uses one HKDF-extract
+//! followed by two HKDF-expands (encryption key and commitment key). The lengths
+//! and labels come from the algorithm suite definition in
+//! `framework/algorithm-suites.md` (outside ESDK review scope).
 
 use super::{Error, val_err};
 use crate::message::serializable_types::get_encrypt_key_length;
@@ -16,6 +23,8 @@ pub struct ExpandedKeyMaterial {
     pub commitment_key: Option<Zeroizing<Vec<u8>>>,
 }
 
+// Returns the HKDF-derived (output) key length defined by the algorithm suite.
+// Only HKDF suites carry this length; any other KDF reaching here is a config error.
 fn get_kdf_outlen(suite: &AlgorithmSuite) -> Result<u32, Error> {
     match suite.kdf {
         DerivationAlgorithm::Hkdf(x) => Ok(x.output_key_length),
@@ -25,6 +34,8 @@ fn get_kdf_outlen(suite: &AlgorithmSuite) -> Result<u32, Error> {
     }
 }
 
+// Returns the HKDF input (plaintext data key) length defined by the algorithm suite.
+// Only HKDF suites carry this length; any other KDF reaching here is a config error.
 fn get_kdf_inlen(suite: &AlgorithmSuite) -> Result<u32, Error> {
     match suite.kdf {
         DerivationAlgorithm::Hkdf(x) => Ok(x.input_key_length),
@@ -34,6 +45,10 @@ fn get_kdf_inlen(suite: &AlgorithmSuite) -> Result<u32, Error> {
     }
 }
 
+// Sanity-checks that a derivation algorithm is consistent with the suite and the
+// supplied key length. The identity KDF uses the input key verbatim, so its length
+// must already equal the suite's encryption key length. HKDF (and other) suites
+// validate their lengths at derivation time, so they pass here.
 const fn valid_derivation_alg(
     alg: &DerivationAlgorithm,
     suite: &AlgorithmSuite,
@@ -46,6 +61,8 @@ const fn valid_derivation_alg(
     }
 }
 
+// Output length in bytes of each supported hash. Used to size the all-zero HKDF
+// salt for V1 derivation (the salt length equals the hash output length, RFC 5869).
 fn digest_length(alg: aws_mpl_legacy::primitives::DigestAlg) -> Result<usize, Error> {
     match alg {
         aws_mpl_legacy::primitives::DigestAlg::Sha256 => Ok(32),
@@ -122,6 +139,8 @@ pub(crate) fn derive_key(
     }
 }
 
+// HKDF-expand info labels for V2 derivation: COMMITKEY produces the commitment
+// key, DERIVEKEY (prefixed with the suite's binary ID) produces the encryption key.
 const COMMIT_LABEL: &str = "COMMITKEY";
 const KEY_LABEL: &str = "DERIVEKEY";
 
@@ -163,6 +182,11 @@ pub(crate) fn expand_key_material(
     let alg = digest;
     let info = [&suite.binary_id[..], KEY_LABEL.as_bytes()];
 
+    // V2 key commitment derivation. A single HKDF-extract over the message ID (used
+    // as the salt) and the plaintext key yields one pseudo-random key, which is then
+    // expanded twice with distinct info labels: `binary_id || DERIVEKEY` for the
+    // message encryption key (binding it to the algorithm suite), and `COMMITKEY` for
+    // the commitment key. See `framework/algorithm-suites.md` (outside review scope).
     let pseudo_random_key =
         aws_mpl_legacy::primitives::hkdf_extract(alg, message_id, plaintext_key);
     let mut encrypt_key = vec![0u8; usize::try_from(get_kdf_outlen(suite)?).map_err(|_| val_err("KDF output_key_length exceeds usize"))?];

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -8,11 +8,13 @@ use aws_mpl_legacy::suites::AlgorithmSuite;
 use aws_mpl_legacy::suites::DerivationAlgorithm;
 use zeroize::Zeroizing;
 
-// Convenience container to hold both a data key and an optional commitment key
-// to support algorithm suites that provide commitment and those that do not
+/// Convenience container to hold both a data key and an optional commitment key
+/// to support algorithm suites that provide commitment and those that do not.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExpandedKeyMaterial {
+    /// The derived data encryption key.
     pub data_key: Zeroizing<Vec<u8>>,
+    /// The derived commitment key, present only for committing algorithm suites.
     pub commitment_key: Option<Zeroizing<Vec<u8>>>,
 }
 
@@ -21,9 +23,9 @@ pub struct ExpandedKeyMaterial {
 fn get_kdf_output_len(suite: &AlgorithmSuite) -> Result<u32, Error> {
     match suite.kdf {
         DerivationAlgorithm::Hkdf(x) => Ok(x.output_key_length),
-        _ => Err(val_err(
-            "Algorithm suite KDF must be HKDF to derive output key length",
-        )),
+        other => Err(val_err(format!(
+            "Algorithm suite KDF must be HKDF to derive output key length, got {other:?}"
+        ))),
     }
 }
 
@@ -32,25 +34,9 @@ fn get_kdf_output_len(suite: &AlgorithmSuite) -> Result<u32, Error> {
 fn get_kdf_input_len(suite: &AlgorithmSuite) -> Result<u32, Error> {
     match suite.kdf {
         DerivationAlgorithm::Hkdf(x) => Ok(x.input_key_length),
-        _ => Err(val_err(
-            "Algorithm suite KDF must be HKDF to derive input key length",
-        )),
-    }
-}
-
-// Sanity-checks that a derivation algorithm is consistent with the suite and the
-// supplied key length. The identity KDF uses the input key verbatim, so its length
-// must already equal the suite's encryption key length. HKDF (and other) suites
-// validate their lengths at derivation time, so they pass here.
-const fn valid_derivation_alg(
-    alg: &DerivationAlgorithm,
-    suite: &AlgorithmSuite,
-    key_len: usize,
-) -> bool {
-    match alg {
-        DerivationAlgorithm::Hkdf(_x) => true,
-        DerivationAlgorithm::Identity => key_len == get_encrypt_key_length(suite) as usize,
-        _ => true,
+        other => Err(val_err(format!(
+            "Algorithm suite KDF must be HKDF to derive input key length, got {other:?}"
+        ))),
     }
 }
 
@@ -61,7 +47,7 @@ fn digest_length(alg: aws_mpl_legacy::primitives::DigestAlg) -> Result<usize, Er
         aws_mpl_legacy::primitives::DigestAlg::Sha256 => Ok(32),
         aws_mpl_legacy::primitives::DigestAlg::Sha384 => Ok(48),
         aws_mpl_legacy::primitives::DigestAlg::Sha512 => Ok(64),
-        _ => Err(val_err("Unknown DigestAlg")),
+        other => Err(val_err(format!("Unknown DigestAlg {other:?}"))),
     }
 }
 
@@ -73,13 +59,9 @@ pub(crate) fn derive_key_v1(
     suite: &AlgorithmSuite,
     on_net_v4_retry: bool,
 ) -> Result<ExpandedKeyMaterial, Error> {
-    // This should only be used for V1 algorithms.
+    // `derive_keys` dispatches on the message version, so a non-V1 suite here is an
+    // internal bug rather than bad input.
     debug_assert!(suite.message_version == 1);
-    debug_assert!(valid_derivation_alg(
-        &suite.kdf,
-        suite,
-        plaintext_data_key.len()
-    ));
 
     //= spec/client-apis/encrypt.md#get-the-encryption-materials
     //# The algorithm used to derive a data key from the plaintext data key MUST be
@@ -92,17 +74,35 @@ pub(crate) fn derive_key_v1(
         //= spec/client-apis/decrypt.md#get-the-decryption-materials
         //# If the key derivation algorithm is the [identity KDF](../framework/algorithm-suites.md#identity-kdf),
         //# then the derived data key MUST be the same as the plaintext data key.
-        DerivationAlgorithm::Identity => Ok(ExpandedKeyMaterial {
-            data_key: Zeroizing::new(plaintext_data_key.to_vec()),
-            commitment_key: None,
-        }),
+        DerivationAlgorithm::Identity => {
+            // The identity KDF uses the plaintext data key verbatim, so its length
+            // must already equal the suite's encryption key length.
+            let encrypt_key_len = usize::from(get_encrypt_key_length(suite));
+            if plaintext_data_key.len() != encrypt_key_len {
+                return Err(val_err(format!(
+                    "Identity KDF plaintext data key length {} does not match the suite encryption key length {encrypt_key_len}",
+                    plaintext_data_key.len()
+                )));
+            }
+            Ok(ExpandedKeyMaterial {
+                data_key: Zeroizing::new(plaintext_data_key.to_vec()),
+                commitment_key: None,
+            })
+        }
         //= spec/client-apis/encrypt.md#get-the-encryption-materials
         //# - If the key derivation algorithm is [HKDF](../framework/algorithm-suites.md#hkdf),
         //# the derivation process used MUST be the process described in [HKDF Encryption Key](../transitive-requirements.md#hkdf-encryption-key).
         DerivationAlgorithm::Hkdf(hkdf) => {
             let alg = hkdf.hmac;
             let salt = vec![0u8; digest_length(alg)?];
-            let mut derived_key = vec![0u8; usize::try_from(hkdf.output_key_length).map_err(|_| val_err("HKDF output_key_length exceeds usize"))?];
+
+            let Ok(output_len) = usize::try_from(hkdf.output_key_length) else {
+                return Err(val_err(format!(
+                    "HKDF output_key_length {} exceeds usize",
+                    hkdf.output_key_length
+                )));
+            };
+            let mut derived_key = vec![0u8; output_len];
 
             // The Net v4.0.0 retry path omits the suite's binary ID from the HKDF
             // info; the standard path prefixes it.
@@ -134,23 +134,33 @@ pub(crate) fn derive_key_v2(
     plaintext_data_key: &[u8],
     suite: &AlgorithmSuite,
 ) -> Result<ExpandedKeyMaterial, Error> {
-    // This should only be used for V2 algorithms.
-    if suite.message_version != 2 {
-        return Err(val_err("derive_key_v2 requires message version 2"));
-    }
-    // For V2 algorithms, the KDF can only be HKDF.
-    if u32::from(get_encrypt_key_length(suite)) != get_kdf_output_len(suite)? {
-        return Err(val_err(
-            "Encrypt key length must match KDF output key length",
-        ));
+    // `derive_keys` dispatches on the message version, so a non-V2 suite here is an
+    // internal bug rather than bad input.
+    debug_assert!(suite.message_version == 2);
+
+    // For V2 algorithms the KDF can only be HKDF, and the encryption key length must
+    // match the KDF output length.
+    let kdf_output_len = get_kdf_output_len(suite)?;
+    let encrypt_key_len = u32::from(get_encrypt_key_length(suite));
+    if encrypt_key_len != kdf_output_len {
+        return Err(val_err(format!(
+            "Encryption key length {encrypt_key_len} does not match KDF output key length {kdf_output_len}"
+        )));
     }
     if message_id.is_empty() {
         return Err(val_err("Message ID must not be empty"));
     }
-    if plaintext_data_key.len() != usize::try_from(get_kdf_input_len(suite)?).map_err(|_| val_err("KDF input_key_length exceeds usize"))? {
-        return Err(val_err(
-            "Plaintext key length must match KDF input key length",
-        ));
+    let kdf_input_len = get_kdf_input_len(suite)?;
+    let Ok(kdf_input_len) = usize::try_from(kdf_input_len) else {
+        return Err(val_err(format!(
+            "KDF input_key_length {kdf_input_len} exceeds usize"
+        )));
+    };
+    if plaintext_data_key.len() != kdf_input_len {
+        return Err(val_err(format!(
+            "Plaintext data key length {} does not match KDF input key length {kdf_input_len}",
+            plaintext_data_key.len()
+        )));
     }
 
     let (alg, commit_len) = match &suite.commitment {
@@ -158,8 +168,10 @@ pub(crate) fn derive_key_v2(
         DerivationAlgorithm::None => {
             return Err(val_err("None is not a valid Commitment Algorithm"));
         }
-        _ => {
-            return Err(val_err("Unknown is not a valid Commitment Algorithm"));
+        other => {
+            return Err(val_err(format!(
+                "{other:?} is not a valid Commitment Algorithm"
+            )));
         }
     };
     let info = [&suite.binary_id[..], KEY_LABEL.as_bytes()];
@@ -171,8 +183,21 @@ pub(crate) fn derive_key_v2(
     // the commitment key. See `framework/algorithm-suites.md`.
     let pseudo_random_key =
         aws_mpl_legacy::primitives::hkdf_extract(alg, message_id, plaintext_data_key);
-    let mut encrypt_key = vec![0u8; usize::try_from(get_kdf_output_len(suite)?).map_err(|_| val_err("KDF output_key_length exceeds usize"))?];
-    let mut commit_key = vec![0u8; usize::try_from(commit_len).map_err(|_| val_err("Commit key length exceeds usize"))?];
+
+    let Ok(encrypt_key_len) = usize::try_from(kdf_output_len) else {
+        return Err(val_err(format!(
+            "KDF output_key_length {kdf_output_len} exceeds usize"
+        )));
+    };
+    let mut encrypt_key = vec![0u8; encrypt_key_len];
+
+    let Ok(commit_len) = usize::try_from(commit_len) else {
+        return Err(val_err(format!(
+            "Commit key length {commit_len} exceeds usize"
+        )));
+    };
+    let mut commit_key = vec![0u8; commit_len];
+
     aws_mpl_legacy::primitives::hkdf_expand(&pseudo_random_key, &info, &mut encrypt_key)?;
     aws_mpl_legacy::primitives::hkdf_expand(
         &pseudo_random_key,
@@ -186,8 +211,8 @@ pub(crate) fn derive_key_v2(
     })
 }
 
-// Derives key material for encryption/decryption. Delegates to the V1 or V2
-// routine based on the algorithm suite's message version.
+/// Derives key material for encryption/decryption. Delegates to the V1 or V2
+/// routine based on the algorithm suite's message version.
 pub fn derive_keys(
     message_id: &[u8],
     plaintext_data_key: &[u8],

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -7,7 +7,7 @@
 //! key commitment value. V1 uses a single HKDF call; V2 uses one HKDF-extract
 //! followed by two HKDF-expands (encryption key and commitment key). The lengths
 //! and labels come from the algorithm suite definition in
-//! `framework/algorithm-suites.md` (outside ESDK review scope).
+//! `framework/algorithm-suites.md`.
 
 use super::{Error, val_err};
 use crate::message::serializable_types::get_encrypt_key_length;
@@ -186,7 +186,7 @@ pub(crate) fn expand_key_material(
     // as the salt) and the plaintext key yields one pseudo-random key, which is then
     // expanded twice with distinct info labels: `binary_id || DERIVEKEY` for the
     // message encryption key (binding it to the algorithm suite), and `COMMITKEY` for
-    // the commitment key. See `framework/algorithm-suites.md` (outside review scope).
+    // the commitment key. See `framework/algorithm-suites.md`.
     let pseudo_random_key =
         aws_mpl_legacy::primitives::hkdf_extract(alg, message_id, plaintext_key);
     let mut encrypt_key = vec![0u8; usize::try_from(get_kdf_outlen(suite)?).map_err(|_| val_err("KDF output_key_length exceeds usize"))?];

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -1,0 +1,201 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//! Key derivation for V1 (HKDF-extract) and V2 (HKDF-expand) algorithm suites.
+
+use super::{Error, val_err};
+use crate::message::serializable_types::get_encrypt_key_length;
+use aws_mpl_legacy::suites::AlgorithmSuite;
+use aws_mpl_legacy::suites::DerivationAlgorithm;
+use zeroize::Zeroizing;
+
+// Convenience container to hold both a data key and an optional commitment key
+// to support algorithm suites that provide commitment and those that do not
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExpandedKeyMaterial {
+    pub data_key: Zeroizing<Vec<u8>>,
+    pub commitment_key: Option<Zeroizing<Vec<u8>>>,
+}
+
+fn get_kdf_outlen(suite: &AlgorithmSuite) -> Result<u32, Error> {
+    match suite.kdf {
+        DerivationAlgorithm::Hkdf(x) => Ok(x.output_key_length),
+        _ => Err(val_err(
+            "Algorithm suite KDF must be HKDF to derive output key length",
+        )),
+    }
+}
+
+fn get_kdf_inlen(suite: &AlgorithmSuite) -> Result<u32, Error> {
+    match suite.kdf {
+        DerivationAlgorithm::Hkdf(x) => Ok(x.input_key_length),
+        _ => Err(val_err(
+            "Algorithm suite KDF must be HKDF to derive input key length",
+        )),
+    }
+}
+
+const fn valid_derivation_alg(
+    alg: &DerivationAlgorithm,
+    suite: &AlgorithmSuite,
+    key_len: usize,
+) -> bool {
+    match alg {
+        DerivationAlgorithm::Hkdf(_x) => true,
+        DerivationAlgorithm::Identity => key_len == get_encrypt_key_length(suite) as usize,
+        _ => true,
+    }
+}
+
+fn digest_length(alg: aws_mpl_legacy::primitives::DigestAlg) -> Result<usize, Error> {
+    match alg {
+        aws_mpl_legacy::primitives::DigestAlg::Sha256 => Ok(32),
+        aws_mpl_legacy::primitives::DigestAlg::Sha384 => Ok(48),
+        aws_mpl_legacy::primitives::DigestAlg::Sha512 => Ok(64),
+        _ => Err(val_err("Unknown DigestAlg")),
+    }
+}
+
+// Derives a single data key from an input plaintext data key, using "v1"-style
+// key derivation (that is, no key commitment).
+pub(crate) fn derive_key(
+    message_id: &[u8],
+    plaintext_data_key: &[u8],
+    suite: &AlgorithmSuite,
+    // TODO Post-#619: Refactor, breaking Net v4.0.0 logic out into independent method
+    on_net_v4_retry: bool,
+) -> Result<ExpandedKeyMaterial, Error> {
+    // This should only be used for v1 algorithms
+    debug_assert!(suite.message_version == 1);
+    debug_assert!(valid_derivation_alg(
+        &suite.kdf,
+        suite,
+        plaintext_data_key.len()
+    ));
+
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //# The algorithm used to derive a data key from the plaintext data key MUST be
+    //# the [key derivation algorithm](../framework/algorithm-suites.md#key-derivation-algorithm) included in the
+    //# [algorithm suite](../framework/algorithm-suites.md) defined above.
+    match &suite.kdf {
+        //= spec/client-apis/encrypt.md#get-the-encryption-materials
+        //# - If the key derivation algorithm is the [identity KDF](../framework/algorithm-suites.md#identity-kdf),
+        //# then the derived data key MUST be the same as the plaintext data key.
+        //= spec/client-apis/decrypt.md#get-the-decryption-materials
+        //# If the key derivation algorithm is the [identity KDF](../framework/algorithm-suites.md#identity-kdf),
+        //# then the derived data key MUST be the same as the plaintext data key.
+        DerivationAlgorithm::Identity => Ok(ExpandedKeyMaterial {
+            data_key: Zeroizing::new(plaintext_data_key.to_vec()),
+            commitment_key: None,
+        }),
+        //= spec/client-apis/encrypt.md#get-the-encryption-materials
+        //# - If the key derivation algorithm is [HKDF](../framework/algorithm-suites.md#hkdf),
+        //# the derivation process used MUST be the process described in [HKDF Encryption Key](../transitive-requirements.md#hkdf-encryption-key).
+        DerivationAlgorithm::Hkdf(hkdf) => {
+            let alg = hkdf.hmac;
+            let salt = vec![0u8; digest_length(alg)?];
+            let mut derived_key = vec![0u8; usize::try_from(hkdf.output_key_length).map_err(|_| val_err("HKDF output_key_length exceeds usize"))?];
+            if on_net_v4_retry {
+                aws_mpl_legacy::primitives::hkdf(
+                    alg,
+                    &salt,
+                    plaintext_data_key,
+                    &[message_id],
+                    &mut derived_key,
+                )?;
+            } else {
+                aws_mpl_legacy::primitives::hkdf(
+                    alg,
+                    &salt,
+                    plaintext_data_key,
+                    &[&suite.binary_id[..], message_id],
+                    &mut derived_key,
+                )?;
+            }
+
+            Ok(ExpandedKeyMaterial {
+                data_key: Zeroizing::new(derived_key),
+                commitment_key: None,
+            })
+        }
+        DerivationAlgorithm::None => Err(val_err("None is not a valid Key Derivation Function")),
+        _ => Err(val_err("Unknown is not a valid Key Derivation Function")),
+    }
+}
+
+const COMMIT_LABEL: &str = "COMMITKEY";
+const KEY_LABEL: &str = "DERIVEKEY";
+
+// Derives keys from an input plaintext data key, using "v2"-style
+// key derivation (that is, including key commitment).
+pub(crate) fn expand_key_material(
+    message_id: &[u8],
+    plaintext_key: &[u8],
+    suite: &AlgorithmSuite,
+) -> Result<ExpandedKeyMaterial, Error> {
+    // This should only be used for v2 algorithms
+    if suite.message_version != 2 {
+        return Err(val_err("expand_key_material requires message version 2"));
+    }
+    // For v2 algorithms, KDF can only be HKDF
+    if u32::from(get_encrypt_key_length(suite)) != get_kdf_outlen(suite)? {
+        return Err(val_err(
+            "Encrypt key length must match KDF output key length",
+        ));
+    }
+    if message_id.is_empty() {
+        return Err(val_err("Message ID must not be empty"));
+    }
+    if plaintext_key.len() != usize::try_from(get_kdf_inlen(suite)?).map_err(|_| val_err("KDF input_key_length exceeds usize"))? {
+        return Err(val_err(
+            "Plaintext key length must match KDF input key length",
+        ));
+    }
+
+    let (digest, commit_len) = match &suite.commitment {
+        DerivationAlgorithm::Hkdf(hkdf) => (hkdf.hmac, hkdf.output_key_length),
+        DerivationAlgorithm::None => {
+            return Err(val_err("None is not a valid Commitment Algorithm"));
+        }
+        _ => {
+            return Err(val_err("Unknown is not a valid Commitment Algorithm"));
+        }
+    };
+    let alg = digest;
+    let info = [&suite.binary_id[..], KEY_LABEL.as_bytes()];
+
+    let pseudo_random_key =
+        aws_mpl_legacy::primitives::hkdf_extract(alg, message_id, plaintext_key);
+    let mut encrypt_key = vec![0u8; usize::try_from(get_kdf_outlen(suite)?).map_err(|_| val_err("KDF output_key_length exceeds usize"))?];
+    let mut commit_key = vec![0u8; usize::try_from(commit_len).map_err(|_| val_err("Commit key length exceeds usize"))?];
+    aws_mpl_legacy::primitives::hkdf_expand(&pseudo_random_key, &info, &mut encrypt_key)?;
+    aws_mpl_legacy::primitives::hkdf_expand(
+        &pseudo_random_key,
+        &[COMMIT_LABEL.as_bytes()],
+        &mut commit_key,
+    )?;
+
+    Ok(ExpandedKeyMaterial {
+        data_key: Zeroizing::new(encrypt_key),
+        commitment_key: Some(Zeroizing::new(commit_key)),
+    })
+}
+
+// Derives key material for encryption/decryption. Delegates out to specific methods
+// based on the input algorithm suite.
+pub fn derive_keys(
+    message_id: &[u8],
+    plaintext_key: &[u8],
+    suite: &AlgorithmSuite,
+    on_net_v4_retry: bool,
+) -> Result<ExpandedKeyMaterial, Error> {
+    debug_assert!(!message_id.is_empty());
+    debug_assert!(usize::from(get_encrypt_key_length(suite)) == plaintext_key.len());
+
+    if suite.message_version == 2 {
+        expand_key_material(message_id, plaintext_key, suite)
+    } else if suite.message_version == 1 {
+        derive_key(message_id, plaintext_key, suite, on_net_v4_retry)
+    } else {
+        Err(val_err("Unknown Message Version"))
+    }
+}

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -1,13 +1,6 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //! Key derivation for the ESDK message encryption key.
-//!
-//! The MPL produces the plaintext data key; this module derives the per-message
-//! encryption key from it (binding it to the message ID) and, for V2 suites, the
-//! key commitment value. V1 uses a single HKDF call; V2 uses one HKDF-extract
-//! followed by two HKDF-expands (encryption key and commitment key). The lengths
-//! and labels come from the algorithm suite definition in
-//! `framework/algorithm-suites.md`.
 
 use super::{Error, val_err};
 use crate::message::serializable_types::get_encrypt_key_length;

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -78,7 +78,6 @@ pub(crate) fn derive_key(
     message_id: &[u8],
     plaintext_data_key: &[u8],
     suite: &AlgorithmSuite,
-    // TODO Post-#619: Refactor, breaking Net v4.0.0 logic out into independent method
     on_net_v4_retry: bool,
 ) -> Result<ExpandedKeyMaterial, Error> {
     // This should only be used for v1 algorithms

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -118,7 +118,7 @@ pub(crate) fn derive_key_v1(
             //= spec/client-apis/key-derivation.md#hkdf-encryption-key
             //# - The length of the output keying material MUST equal the [encryption key length](#encryption-key-length)
             //# specified by the [algorithm suite encryption settings](#algorithm-suites-encryption-settings).
-            let mut derived_key = vec![0u8; output_len];
+            let mut derived_key = Zeroizing::new(vec![0u8; output_len]);
 
             // The .NET v4.0.0 retry path omits the suite's binary ID from the HKDF
             // info; the standard path prefixes it.
@@ -134,10 +134,10 @@ pub(crate) fn derive_key_v1(
             //= type=implication
             //= reason=primitives::hkdf bundles HKDF-Extract and HKDF-Expand; the PRK input to expand is the extract output by construction of the helper
             //# - The input pseudorandom key MUST be the output from the extract step.
-            aws_mpl_legacy::primitives::hkdf(alg, &salt, plaintext_data_key, info, &mut derived_key)?;
+            aws_mpl_legacy::primitives::hkdf(alg, &salt, plaintext_data_key, info, &mut derived_key[..])?;
 
             Ok(ExpandedKeyMaterial {
-                data_key: Zeroizing::new(derived_key),
+                data_key: derived_key,
                 commitment_key: None,
             })
         }
@@ -257,7 +257,7 @@ pub fn derive_key_v2(
     //= spec/client-apis/key-derivation.md#hkdf-encryption-key
     //# - The length of the output keying material MUST equal the [encryption key length](#encryption-key-length)
     //# specified by the [algorithm suite encryption settings](#algorithm-suites-encryption-settings).
-    let mut encrypt_key = vec![0u8; encrypt_key_len];
+    let mut encrypt_key = Zeroizing::new(vec![0u8; encrypt_key_len]);
 
     let Ok(commit_len) = usize::try_from(commit_len) else {
         return Err(val_err(format!(
@@ -267,7 +267,7 @@ pub fn derive_key_v2(
     //= spec/client-apis/key-derivation.md#hkdf-commit-key
     //# - The length of the output keying material MUST equal the [algorithm suite data length](#algorithm-suite-data-length)
     //# specified by the [supported algorithm suites](#supported-algorithm-suites).
-    let mut commit_key = vec![0u8; commit_len];
+    let mut commit_key = Zeroizing::new(vec![0u8; commit_len]);
 
     //= spec/client-apis/key-derivation.md#hkdf-encryption-key
     //# - If [key commitment](#key-commitment) for the [algorithm suite encryption key derivation setting](#algorithm-suites-encryption-key-derivation-settings) is True,
@@ -278,7 +278,7 @@ pub fn derive_key_v2(
     //= type=implication
     //= reason=pseudo_random_key holds the hkdf_extract return value above and is the only PRK input threaded into hkdf_expand here by data dependency
     //# - The input pseudorandom key MUST be the output from the extract step.
-    aws_mpl_legacy::primitives::hkdf_expand(&pseudo_random_key, &info, &mut encrypt_key)?;
+    aws_mpl_legacy::primitives::hkdf_expand(&pseudo_random_key, &info, &mut encrypt_key[..])?;
 
     //= spec/client-apis/key-derivation.md#hkdf-commit-key
     //= type=implication
@@ -290,12 +290,12 @@ pub fn derive_key_v2(
     aws_mpl_legacy::primitives::hkdf_expand(
         &pseudo_random_key,
         &[COMMIT_LABEL.as_bytes()],
-        &mut commit_key,
+        &mut commit_key[..],
     )?;
 
     Ok(ExpandedKeyMaterial {
-        data_key: Zeroizing::new(encrypt_key),
-        commitment_key: Some(Zeroizing::new(commit_key)),
+        data_key: encrypt_key,
+        commitment_key: Some(commit_key),
     })
 }
 
@@ -316,6 +316,9 @@ pub fn derive_keys(
     match suite.message_version {
         1 => derive_key_v1(message_id, plaintext_data_key, suite, on_net_v4_retry),
         2 => derive_key_v2(message_id, plaintext_data_key, suite),
-        _ => Err(val_err("Unknown Message Version")),
+        _ => Err(val_err(format!(
+            "Unknown Message Version {}",
+            suite.message_version
+        ))),
     }
 }

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -120,7 +120,7 @@ pub(crate) fn derive_key_v1(
             //# specified by the [algorithm suite encryption settings](#algorithm-suites-encryption-settings).
             let mut derived_key = vec![0u8; output_len];
 
-            // The Net v4.0.0 retry path omits the suite's binary ID from the HKDF
+            // The .NET v4.0.0 retry path omits the suite's binary ID from the HKDF
             // info; the standard path prefixes it.
             let v4_info: [&[u8]; 1] = [message_id];
             //= spec/client-apis/key-derivation.md#hkdf-encryption-key

--- a/esdk/src/key_derivation.rs
+++ b/esdk/src/key_derivation.rs
@@ -3,6 +3,7 @@
 //! Key derivation for the ESDK message encryption key.
 
 use super::{Error, val_err};
+use crate::message::header_types::MESSAGE_ID_LEN_V2;
 use crate::message::serializable_types::get_encrypt_key_length;
 use aws_mpl_legacy::suites::AlgorithmSuite;
 use aws_mpl_legacy::suites::DerivationAlgorithm;
@@ -179,8 +180,11 @@ pub fn derive_key_v2(
             "Encryption key length {encrypt_key_len} does not match KDF output key length {kdf_output_len}"
         )));
     }
-    if message_id.is_empty() {
-        return Err(val_err("Message ID must not be empty"));
+    if message_id.len() != MESSAGE_ID_LEN_V2 {
+        return Err(val_err(format!(
+            "V2 message ID (HKDF salt) must be {MESSAGE_ID_LEN_V2} bytes, got {}",
+            message_id.len()
+        )));
     }
     let kdf_input_len = get_kdf_input_len(suite)?;
     let Ok(kdf_input_len) = usize::try_from(kdf_input_len) else {

--- a/esdk/src/materials.rs
+++ b/esdk/src/materials.rs
@@ -1,0 +1,370 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//! Cryptographic materials management — CMM creation and materials retrieval.
+
+use crate::error::{Error, val_err};
+use crate::legacy_compat::{
+    convert_alg, convert_commit, convert_edks, from_legacy_dm, from_legacy_em,
+};
+use crate::message::header_types::HeaderBody;
+use crate::message::serializable_types::{
+    from_canonical_pairs, is_esdk_encrypted_data_keys, is_esdk_encryption_context,
+};
+use crate::types::{EncryptionContext, MaterialSource, mpl};
+use aws_mpl_legacy::DecryptionMaterials;
+use aws_mpl_legacy::EncryptionMaterials;
+use aws_mpl_legacy::cmm::DecryptMaterialsInput;
+use aws_mpl_legacy::cmm::GetEncryptionMaterialsInput;
+
+pub(crate) enum Cmm {
+    Legacy(
+        aws_mpl_legacy::dafny::types::cryptographic_materials_manager::CryptographicMaterialsManagerRef,
+    ),
+    Modern(aws_mpl_legacy::cmm::CryptographicMaterialsManagerRef),
+}
+
+#[allow(clippy::unused_async)]
+pub(crate) async fn create_cmm_from_input(
+    input_source: Option<MaterialSource>,
+) -> Result<Cmm, Error> {
+    match input_source.ok_or_else(|| val_err("A Materials Source must be provided"))? {
+        MaterialSource::LegacyCmm(cmm) => Ok(Cmm::Legacy(cmm)),
+        MaterialSource::LegacyKeyring(keyring) => {
+            let mpl = mpl();
+            let cmm = mpl
+                .create_default_cryptographic_materials_manager()
+                .keyring(keyring)
+                .send()
+                .await?;
+            Ok(Cmm::Legacy(cmm))
+        }
+        MaterialSource::Cmm(cmm) => Ok(Cmm::Modern(cmm)),
+        MaterialSource::Keyring(keyring) => {
+            //= spec/client-apis/encrypt.md#get-the-encryption-materials
+            //# If instead the caller supplied a [keyring](../framework/keyring-interface.md),
+            //# this behavior MUST use a [default CMM](../framework/default-cmm.md)
+            //# constructed using the caller-supplied keyring as input.
+            //
+            //= spec/client-apis/decrypt.md#keyring
+            //# If the Keyring is provided as the input, the client MUST construct a [default CMM](../framework/default-cmm.md) that uses this keyring,
+            //# to obtain the [decryption materials](../framework/structures.md#decryption-materials) that is required for decryption.
+            //
+            //= spec/client-apis/decrypt.md#keyring
+            //= reason=The default CMM constructed here will obtain decryption materials when decrypt_materials is called on it
+            //# This default CMM constructed from the keyring MUST obtain the decryption materials required for decryption.
+            let cmm = aws_mpl_legacy::cmm::create_default_cryptographic_materials_manager(keyring)?;
+            Ok(Cmm::Modern(cmm))
+        }
+    }
+}
+
+pub(crate) async fn get_decryption_materials(
+    cmm: Cmm,
+    algorithm_suite_id: aws_mpl_legacy::suites::AlgorithmSuiteId,
+    header_body: &HeaderBody,
+    reproduced_encryption_context: &EncryptionContext,
+    commitment_policy: aws_mpl_legacy::commitment::EsdkCommitmentPolicy,
+) -> Result<DecryptionMaterials, Error> {
+    let materials = match cmm {
+        Cmm::Legacy(cmm) => {
+            get_legacy_decryption_materials(
+                cmm,
+                algorithm_suite_id,
+                header_body,
+                reproduced_encryption_context,
+                commitment_policy,
+            )
+            .await?
+        }
+        Cmm::Modern(cmm) => {
+            get_modern_decryption_materials(
+                cmm,
+                algorithm_suite_id,
+                header_body,
+                reproduced_encryption_context,
+                commitment_policy,
+            )
+            .await?
+        }
+    };
+    if !is_esdk_encryption_context(&materials.encryption_context) {
+        return Err(val_err(
+            "CMM failed to return serializable encryption materials",
+        ));
+    }
+    Ok(materials)
+}
+
+pub(crate) async fn get_encryption_materials(
+    cmm: Cmm,
+    algorithm_suite_id: Option<aws_mpl_legacy::suites::AlgorithmSuiteId>,
+    encryption_context: EncryptionContext,
+    max_plaintext_length: Option<usize>,
+    commitment_policy: aws_mpl_legacy::commitment::EsdkCommitmentPolicy,
+) -> Result<EncryptionMaterials, Error> {
+    let materials = match cmm {
+        Cmm::Legacy(cmm) => {
+            get_legacy_encryption_materials(
+                cmm,
+                algorithm_suite_id,
+                encryption_context,
+                max_plaintext_length,
+                commitment_policy,
+            )
+            .await?
+        }
+        Cmm::Modern(cmm) => {
+            get_modern_encryption_materials(
+                cmm,
+                algorithm_suite_id,
+                encryption_context,
+                max_plaintext_length,
+                commitment_policy,
+            )
+            .await?
+        }
+    };
+    if !is_esdk_encryption_context(&materials.encryption_context) {
+        return Err(val_err(
+            "CMM failed to return serializable encryption materials",
+        ));
+    }
+    if !is_esdk_encrypted_data_keys(&materials.encrypted_data_keys) {
+        return Err(val_err(
+            "CMM failed to return serializable encrypted data keys",
+        ));
+    }
+    Ok(materials)
+}
+
+pub(crate) async fn get_modern_decryption_materials(
+    cmm: aws_mpl_legacy::cmm::CryptographicMaterialsManagerRef,
+    algorithm_suite_id: aws_mpl_legacy::suites::AlgorithmSuiteId,
+    header_body: &HeaderBody,
+    reproduced_encryption_context: &EncryptionContext,
+    commitment_policy: aws_mpl_legacy::commitment::EsdkCommitmentPolicy,
+) -> Result<DecryptionMaterials, Error> {
+    let encryption_context = from_canonical_pairs(header_body.encryption_context().clone());
+    let mut input = DecryptMaterialsInput::default();
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# The call to the CMM's [Decrypt Materials](../framework/cmm-interface.md#decrypt-materials) operation
+    //# MUST be constructed as follows:
+    //
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# - Algorithm Suite ID: This MUST be the parsed
+    //# [algorithm suite ID](../data-format/message-header.md#algorithm-suite-id)
+    //# from the message header.
+    input.algorithm_suite_id = algorithm_suite_id;
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# - Commitment Policy: This MUST be the commitment policy configured on the client.
+    input.commitment_policy = aws_mpl_legacy::commitment::CommitmentPolicy::Esdk(commitment_policy);
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# - Encrypted Data Keys: This MUST be the parsed [encrypted data keys](../data-format/message-header.md#encrypted-data-keys)
+    //# from the message header.
+    input.encrypted_data_keys = header_body.encrypted_data_keys().into();
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# - Encryption Context: This MUST be the parsed [encryption context](../data-format/message-header.md#aad)
+    //# from the message header.
+    input.encryption_context = encryption_context;
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# - Reproduced Encryption Context: This MUST be the [input](#input) encryption context.
+    input
+        .reproduced_encryption_context
+        .clone_from(reproduced_encryption_context);
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# This operation MUST obtain this set of [decryption materials](../framework/structures.md#decryption-materials),
+    //# by calling [Decrypt Materials](../framework/cmm-interface.md#decrypt-materials) on a [CMM](../framework/cmm-interface.md).
+    //
+    //= spec/client-apis/decrypt.md#cryptographic-materials-manager
+    //# This CMM MUST obtain the [decryption materials](../framework/structures.md#decryption-materials) required for decryption.
+    let materials = cmm.decrypt_materials(&input).await?;
+
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //# If the algorithm suite is not supported by the [commitment policy](client.md#commitment-policy)
+    //# configured in the [client](client.md) decrypt MUST yield an error.
+    aws_mpl_legacy::commitment::validate_commitment_policy_on_decrypt(
+        aws_mpl_legacy::commitment::ValidateCommitmentPolicyOnDecryptInput::new(
+            materials.algorithm_suite.id,
+            aws_mpl_legacy::commitment::CommitmentPolicy::Esdk(commitment_policy),
+        ),
+    )?;
+
+    aws_mpl_legacy::materials::decryption_materials_with_plaintext_data_key(&materials)?;
+    Ok(materials)
+}
+
+pub(crate) async fn get_legacy_decryption_materials(
+    cmm: aws_mpl_legacy::dafny::types::cryptographic_materials_manager::CryptographicMaterialsManagerRef,
+    algorithm_suite_id: aws_mpl_legacy::suites::AlgorithmSuiteId,
+    header_body: &HeaderBody,
+    reproduced_encryption_context: &EncryptionContext,
+    commitment_policy: aws_mpl_legacy::commitment::EsdkCommitmentPolicy,
+) -> Result<DecryptionMaterials, Error> {
+    let encryption_context = from_canonical_pairs(header_body.encryption_context().clone());
+
+    let output = cmm
+        .decrypt_materials()
+
+        .algorithm_suite_id(convert_alg(algorithm_suite_id)?)
+
+        .commitment_policy(convert_commit(commitment_policy)?)
+
+        .encrypted_data_keys(convert_edks(header_body.encrypted_data_keys())?)
+
+        .encryption_context(encryption_context)
+
+        .reproduced_encryption_context(reproduced_encryption_context.clone())
+        .send()
+        .await?;
+
+    let materials = output
+        .decryption_materials
+        .ok_or_else(|| val_err("Legacy CMM did not return decryption materials"))?;
+    let return_materials = materials.clone();
+    let mpl = mpl();
+
+    mpl.validate_commitment_policy_on_decrypt()
+        .algorithm(
+            materials
+                .algorithm_suite
+                .as_ref()
+                .ok_or_else(|| val_err("Legacy decryption materials missing algorithm suite"))?
+                .id()
+                .as_ref()
+                .ok_or_else(|| val_err("Legacy decryption materials algorithm suite missing id"))?
+                .clone(),
+        )
+        .commitment_policy(convert_commit(commitment_policy)?)
+        .send()
+        .await?;
+
+    mpl.decryption_materials_with_plaintext_data_key()
+        .set_algorithm_suite(materials.algorithm_suite.clone())
+        .set_encryption_context(materials.encryption_context)
+        .set_plaintext_data_key(materials.plaintext_data_key)
+        .set_required_encryption_context_keys(materials.required_encryption_context_keys)
+        .set_symmetric_signing_key(materials.symmetric_signing_key)
+        .set_verification_key(materials.verification_key)
+        .send()
+        .await?;
+    from_legacy_dm(return_materials)
+}
+
+pub(crate) async fn get_modern_encryption_materials(
+    cmm: aws_mpl_legacy::cmm::CryptographicMaterialsManagerRef,
+    algorithm_suite_id: Option<aws_mpl_legacy::suites::AlgorithmSuiteId>,
+    encryption_context: EncryptionContext,
+    max_plaintext_length: Option<usize>,
+    commitment_policy: aws_mpl_legacy::commitment::EsdkCommitmentPolicy,
+) -> Result<EncryptionMaterials, Error> {
+    let mut input = GetEncryptionMaterialsInput::default();
+
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //= reason=algorithm_suite_id is Option; None means the field is not set on the input
+    //# If no Algorithm Suite is provided, this field MUST NOT be included.
+    input.algorithm_suite_id = algorithm_suite_id;
+
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //# - Commitment Policy: This MUST be the [commitment policy](client.md#commitment-policy)
+    //# configured in the [client](client.md) exposing this encrypt function.
+    input.commitment_policy = aws_mpl_legacy::commitment::CommitmentPolicy::Esdk(commitment_policy);
+
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //# - Encryption Context: If provided, this MUST be the [input encryption context](#encryption-context).
+    //
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //= reason=Encryption context is empty by default
+    //# Otherwise, this MUST be an empty encryption context.
+    input.encryption_context = encryption_context;
+
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //# - Max Plaintext Length: If the [input plaintext](#plaintext) has known length,
+    //# this length MUST be used.
+    //
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //# If the input [plaintext](#plaintext) has unknown length and a [Plaintext Length Bound](#plaintext-length-bound)
+    //# was provided, this MUST be the [Plaintext Length Bound](#plaintext-length-bound).
+    //
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //= reason=max_plaintext_length is Option; None means the field is not set on the input
+    //# If no Plaintext Length Bound is provided, this field MUST NOT be included.
+    input.max_plaintext_length = max_plaintext_length;
+    let materials = cmm.get_encryption_materials(&input).await?;
+
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //# If this [algorithm suite](../framework/algorithm-suites.md) is not supported by the [commitment policy](client.md#commitment-policy)
+    //# configured in the [client](client.md) encrypt MUST yield an error.
+    aws_mpl_legacy::commitment::validate_commitment_policy_on_encrypt(
+        &aws_mpl_legacy::commitment::ValidateCommitmentPolicyOnEncryptInput::new(
+            materials.algorithm_suite.id,
+            aws_mpl_legacy::commitment::CommitmentPolicy::Esdk(commitment_policy),
+        ),
+    )?;
+
+    aws_mpl_legacy::materials::encryption_materials_has_plaintext_data_key(&materials)?;
+    Ok(materials)
+}
+
+pub(crate) async fn get_legacy_encryption_materials(
+    cmm: aws_mpl_legacy::dafny::types::cryptographic_materials_manager::CryptographicMaterialsManagerRef,
+    algorithm_suite_id: Option<aws_mpl_legacy::suites::AlgorithmSuiteId>,
+    encryption_context: EncryptionContext,
+    max_plaintext_length: Option<usize>,
+    commitment_policy: aws_mpl_legacy::commitment::EsdkCommitmentPolicy,
+) -> Result<EncryptionMaterials, Error> {
+    let mpl = mpl();
+    let max_plaintext_length_i64 = max_plaintext_length
+        .map(i64::try_from)
+        .transpose()
+        .map_err(|_| val_err("max_plaintext_length too large for i64"))?;
+    let output = cmm
+        .get_encryption_materials()
+
+        .encryption_context(encryption_context)
+        .commitment_policy(convert_commit(commitment_policy)?)
+
+        .set_algorithm_suite_id(algorithm_suite_id.map(convert_alg).transpose()?)
+
+        .set_max_plaintext_length(max_plaintext_length_i64)
+        .send()
+        .await?;
+
+    let materials = output
+        .encryption_materials
+        .ok_or_else(|| val_err("Legacy CMM did not return encryption materials"))?;
+    let return_materials = materials.clone();
+
+    mpl.validate_commitment_policy_on_encrypt()
+        .algorithm(
+            materials
+                .algorithm_suite
+                .as_ref()
+                .ok_or_else(|| val_err("Legacy encryption materials missing algorithm suite"))?
+                .id
+                .as_ref()
+                .ok_or_else(|| val_err("Legacy encryption materials algorithm suite missing id"))?
+                .clone(),
+        )
+        .commitment_policy(convert_commit(commitment_policy)?)
+        .send()
+        .await?;
+
+    mpl.encryption_materials_has_plaintext_data_key()
+        .set_algorithm_suite(materials.algorithm_suite.clone())
+        .set_encryption_context(materials.encryption_context)
+        .set_encrypted_data_keys(materials.encrypted_data_keys)
+        .set_required_encryption_context_keys(materials.required_encryption_context_keys)
+        .set_plaintext_data_key(materials.plaintext_data_key)
+        .set_signing_key(materials.signing_key)
+        .set_symmetric_signing_keys(materials.symmetric_signing_keys)
+        .send()
+        .await?;
+
+    from_legacy_em(return_materials)
+}

--- a/esdk/src/materials.rs
+++ b/esdk/src/materials.rs
@@ -48,10 +48,6 @@ pub(crate) async fn create_cmm_from_input(
             //= spec/client-apis/decrypt.md#keyring
             //# If the Keyring is provided as the input, the client MUST construct a [default CMM](../framework/default-cmm.md) that uses this keyring,
             //# to obtain the [decryption materials](../framework/structures.md#decryption-materials) that is required for decryption.
-            //
-            //= spec/client-apis/decrypt.md#keyring
-            //= reason=The default CMM constructed here will obtain decryption materials when decrypt_materials is called on it
-            //# This default CMM constructed from the keyring MUST obtain the decryption materials required for decryption.
             let cmm = aws_mpl_legacy::cmm::create_default_cryptographic_materials_manager(keyring)?;
             Ok(Cmm::Modern(cmm))
         }
@@ -183,6 +179,9 @@ pub(crate) async fn get_modern_decryption_materials(
     //
     //= spec/client-apis/decrypt.md#cryptographic-materials-manager
     //# This CMM MUST obtain the [decryption materials](../framework/structures.md#decryption-materials) required for decryption.
+    //
+    //= spec/client-apis/decrypt.md#keyring
+    //# This default CMM constructed from the keyring MUST obtain the decryption materials required for decryption.
     let materials = cmm.decrypt_materials(&input).await?;
 
     //= spec/client-apis/decrypt.md#get-the-decryption-materials

--- a/esdk/src/materials.rs
+++ b/esdk/src/materials.rs
@@ -210,15 +210,10 @@ pub(crate) async fn get_legacy_decryption_materials(
 
     let output = cmm
         .decrypt_materials()
-
         .algorithm_suite_id(convert_alg(algorithm_suite_id)?)
-
         .commitment_policy(convert_commit(commitment_policy)?)
-
         .encrypted_data_keys(convert_edks(header_body.encrypted_data_keys())?)
-
         .encryption_context(encryption_context)
-
         .reproduced_encryption_context(reproduced_encryption_context.clone())
         .send()
         .await?;
@@ -325,12 +320,9 @@ pub(crate) async fn get_legacy_encryption_materials(
         .map_err(|_| val_err("max_plaintext_length too large for i64"))?;
     let output = cmm
         .get_encryption_materials()
-
         .encryption_context(encryption_context)
         .commitment_policy(convert_commit(commitment_policy)?)
-
         .set_algorithm_suite_id(algorithm_suite_id.map(convert_alg).transpose()?)
-
         .set_max_plaintext_length(max_plaintext_length_i64)
         .send()
         .await?;

--- a/esdk/src/materials.rs
+++ b/esdk/src/materials.rs
@@ -85,7 +85,7 @@ pub(crate) async fn get_decryption_materials(
     };
     if !is_esdk_encryption_context(&materials.encryption_context) {
         return Err(val_err(
-            "CMM failed to return serializable encryption materials",
+            "CMM failed to return serializable decryption materials",
         ));
     }
     Ok(materials)

--- a/esdk/tests/test_key_derivation.rs
+++ b/esdk/tests/test_key_derivation.rs
@@ -9,6 +9,9 @@
 //! requirements: a wrong-but-consistent KDF on both sides still round-trips, so
 //! it shows neither which KDF was selected nor what the KDF produced.
 
+mod fixtures;
+mod test_helpers;
+
 use aws_esdk::__test_internals::derive_keys;
 use aws_mpl_legacy::suites::{get_algorithm_suite_info, AlgorithmSuite};
 
@@ -71,8 +74,23 @@ fn test_kdf_algorithm_is_selected_from_suite() {
     assert_ne!(hkdf.data_key.as_slice(), pdk.as_slice());
 }
 
-// HKDF derivation is deterministic, full-length, transforms the input key, and is
-// bound to the message id (the message id is mixed into the derivation).
+// Expected V1 HKDF-SHA256 derived key for the inputs in the test below, computed
+// independently with OpenSSL (RFC 5869 HKDF) so this is a known-answer test rather
+// than a self-consistency check:
+//
+//   openssl kdf -keylen 32 -binary -kdfopt digest:SHA256 \
+//     -kdfopt hexkey:000102...1f                       (sample_key: bytes 0..31) \
+//     -kdfopt hexsalt:<32 zero bytes>                  (salt = hash length, all zero) \
+//     -kdfopt hexinfo:0178<0x01 * 16>                  (suite binary id || message id) \
+//     HKDF
+const EXPECTED_HKDF_SHA256_DERIVED_KEY: [u8; 32] = [
+    0x46, 0x91, 0x38, 0xc3, 0x42, 0xa4, 0xb0, 0xc7, 0x48, 0x76, 0x02, 0xf7, 0xdc, 0x96, 0x7d, 0xe5,
+    0x44, 0xb5, 0x0a, 0xb2, 0xba, 0xda, 0x90, 0xdc, 0x32, 0xa8, 0x03, 0xa5, 0xaf, 0x7c, 0xdb, 0x35,
+];
+
+// The end-to-end interop test vectors (PR M3) exercise this same derivation against
+// known-good ciphertexts from other implementations; this unit test pins the V1 HKDF
+// process directly against an independent HKDF computation.
 #[test]
 fn test_hkdf_derivation_process() {
     let suite = suite(HKDF_SHA256_AES_256);
@@ -86,23 +104,17 @@ fn test_hkdf_derivation_process() {
 
     //= spec/client-apis/encrypt.md#get-the-encryption-materials
     //= type=test
-    //= reason=Deterministic, full-length output that transforms the input key and varies with the message id evidences the HKDF process
+    //= reason=Derived key matches an independent OpenSSL HKDF-SHA256 computation over the same salt, ikm, and info
     //# - If the key derivation algorithm is [HKDF](../framework/algorithm-suites.md#hkdf),
     //# the derivation process used MUST be the process described in [HKDF Encryption Key](../transitive-requirements.md#hkdf-encryption-key).
+    assert_eq!(a1.data_key.as_slice(), &EXPECTED_HKDF_SHA256_DERIVED_KEY);
+
+    // Supporting regression checks: derivation is deterministic, is bound to the
+    // message id, and produces no commitment key for V1 suites.
     assert_eq!(
-        a1.data_key.as_slice(),
         a2.data_key.as_slice(),
-        "HKDF derivation must be deterministic"
-    );
-    assert_eq!(
-        a1.data_key.len(),
-        AES_256_KEY_LEN,
-        "derived key must be the suite's key length"
-    );
-    assert_ne!(
         a1.data_key.as_slice(),
-        pdk.as_slice(),
-        "HKDF must transform the plaintext data key"
+        "HKDF derivation must be deterministic"
     );
     assert_ne!(
         a1.data_key.as_slice(),

--- a/esdk/tests/test_key_derivation.rs
+++ b/esdk/tests/test_key_derivation.rs
@@ -2,19 +2,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tests for spec/client-apis/encrypt.md#get-the-encryption-materials
+//! and spec/client-apis/key-derivation.md.
 
 mod fixtures;
 mod test_helpers;
 
-use aws_esdk::__test_internals::derive_keys;
+use aws_esdk::ErrorKind;
+use aws_esdk::__test_internals::{derive_key_v2, derive_keys};
+use aws_mpl_legacy::primitives::{hkdf_expand, hkdf_extract};
 use aws_mpl_legacy::suites::{get_algorithm_suite_info, AlgorithmSuite};
 
 // AES-256 data key length, required by the `derive_keys` length precondition.
 const AES_256_KEY_LEN: usize = 32;
 
+// V1 message ID length is 128 bits; V2 is 256 bits.
+const V2_MESSAGE_ID_LEN: usize = 32;
+
 // AES-256 algorithm suite binary IDs (data-format wire values).
 const NO_KDF_AES_256: [u8; 2] = [0x00, 0x78];
 const HKDF_SHA256_AES_256: [u8; 2] = [0x01, 0x78];
+// V1 AES-256 with HKDF-SHA-384 + ECDSA-P-384. Differs from HKDF_SHA256_AES_256
+// only in the HKDF hash, so it lets us test that the suite's hash function
+// (not a hard-coded one) actually drives derivation.
+const HKDF_SHA384_AES_256_SIG: [u8; 2] = [0x03, 0x78];
+const HKDF_SHA512_COMMIT_AES_256: [u8; 2] = [0x04, 0x78];
+
+// V2 HKDF-Expand info labels — must match the constants in src/key_derivation.rs.
+const KEY_LABEL: &[u8] = b"DERIVEKEY";
+const COMMIT_LABEL: &[u8] = b"COMMITKEY";
 
 fn suite(binary_id: [u8; 2]) -> &'static AlgorithmSuite {
     get_algorithm_suite_info(binary_id).expect("known algorithm suite id")
@@ -52,14 +67,19 @@ fn test_identity_kdf_derived_key_equals_plaintext_key() {
 }
 
 // The KDF that runs is the one named by the algorithm suite: the identity suite
-// returns the key verbatim, the HKDF suite transforms it.
+// returns the key verbatim, the HKDF suite transforms it. A second HKDF suite
+// that differs only in hash function (SHA-256 vs SHA-384) makes the hash-selection
+// requirement falsifiable — a hard-coded SHA-256 implementation would produce
+// identical bytes for both HKDF suites.
 #[test]
 fn test_kdf_algorithm_is_selected_from_suite() {
     let pdk = sample_key();
     let message_id = [7u8; 16];
 
     let identity = derive_keys(&message_id, &pdk, suite(NO_KDF_AES_256), false).unwrap();
-    let hkdf = derive_keys(&message_id, &pdk, suite(HKDF_SHA256_AES_256), false).unwrap();
+    let hkdf_sha256 = derive_keys(&message_id, &pdk, suite(HKDF_SHA256_AES_256), false).unwrap();
+    let hkdf_sha384 =
+        derive_keys(&message_id, &pdk, suite(HKDF_SHA384_AES_256_SIG), false).unwrap();
 
     //= spec/client-apis/encrypt.md#get-the-encryption-materials
     //= type=test
@@ -68,24 +88,38 @@ fn test_kdf_algorithm_is_selected_from_suite() {
     //# the [key derivation algorithm](../framework/algorithm-suites.md#key-derivation-algorithm) included in the
     //# [algorithm suite](../framework/algorithm-suites.md) defined above.
     assert_eq!(identity.data_key.as_slice(), pdk.as_slice());
-    assert_ne!(hkdf.data_key.as_slice(), pdk.as_slice());
+    assert_ne!(hkdf_sha256.data_key.as_slice(), pdk.as_slice());
+
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //= reason=Two HKDF suites that differ only in hash (SHA-256 vs SHA-384) over the same pdk and message id produce different derived keys; a hard-coded hash would yield identical bytes
+    //# - The hash function MUST be specified by the [algorithm suite key derivation settings](#algorithm-suites-encryption-key-derivation-settings).
+    assert_ne!(hkdf_sha256.data_key.as_slice(), hkdf_sha384.data_key.as_slice());
 }
 
 // Expected V1 HKDF-SHA256 derived key for the inputs in the test below, computed
 // independently with OpenSSL (RFC 5869 HKDF) so this is a known-answer test rather
-// than a self-consistency check:
+// than a self-consistency check.
 //
-//   openssl kdf -keylen 32 -binary -kdfopt digest:SHA256 \
-//     -kdfopt hexkey:000102...1f                       (sample_key: bytes 0..31) \
-//     -kdfopt hexsalt:<32 zero bytes>                  (salt = hash length, all zero) \
-//     -kdfopt hexinfo:0178<0x01 * 16>                  (suite binary id || message id) \
-//     HKDF
+// Reproduce (copy-pasteable, OpenSSL 3.0+):
+//
+//   openssl kdf -keylen 32 -binary \
+//     -kdfopt digest:SHA256 \
+//     -kdfopt hexkey:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f \
+//     -kdfopt hexsalt:0000000000000000000000000000000000000000000000000000000000000000 \
+//     -kdfopt hexinfo:017801010101010101010101010101010101 \
+//     HKDF | xxd -p -c 64
+//
+//   where:
+//     hexkey  = sample_key()       = bytes 0x00..0x1f
+//     hexsalt = 32 zero bytes       = salt defaults to hash length, all zero
+//     hexinfo = 0178 || 0x01 * 16   = suite binary id || message_id ([1u8; 16])
 const EXPECTED_HKDF_SHA256_DERIVED_KEY: [u8; 32] = [
     0x46, 0x91, 0x38, 0xc3, 0x42, 0xa4, 0xb0, 0xc7, 0x48, 0x76, 0x02, 0xf7, 0xdc, 0x96, 0x7d, 0xe5,
     0x44, 0xb5, 0x0a, 0xb2, 0xba, 0xda, 0x90, 0xdc, 0x32, 0xa8, 0x03, 0xa5, 0xaf, 0x7c, 0xdb, 0x35,
 ];
 
-// The end-to-end interop test vectors (PR M3) exercise this same derivation against
+// The end-to-end interop test vectors exercise this same derivation against
 // known-good ciphertexts from other implementations; this unit test pins the V1 HKDF
 // process directly against an independent HKDF computation.
 #[test]
@@ -103,8 +137,27 @@ fn test_hkdf_derivation_process() {
     //= type=test
     //= reason=Derived key matches an independent OpenSSL HKDF-SHA256 computation over the same salt, ikm, and info
     //# - If the key derivation algorithm is [HKDF](../framework/algorithm-suites.md#hkdf),
-    //# the derivation process used MUST be the process described in [HKDF Encryption Key](../transitive-requirements.md#hkdf-encryption-key).
+    //# the derivation process used MUST be the process described in [HKDF Encryption Key](./key-derivation.md#hkdf-encryption-key).
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //= reason=The expected vector was computed with all-zero salt of hash length, no other salt would produce these bytes
+    //# - If there is no salt length defined for the [algorithm suite encryption key derivation commitment setting](#algorithm-suites-encryption-key-derivation-settings),
+    //# the the salt MUST be a byte sequence of 0 as long as the hash length in bytes.
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //= reason=The expected vector was computed with info = 0x0178 || 0x01*16 (binary_id || message_id); no other info would produce these bytes
+    //# - If [key commitment](#key-commitment) for the [algorithm suite encryption key derivation setting](#algorithm-suites-encryption-key-derivation-settings) is False,
+    //# the the input info MUST be a concatenation of the [algorithm suite ID](#algorithm-suite-id)
+    //# followed by the [message ID](../data-format/message-header.md#message-id).
     assert_eq!(a1.data_key.as_slice(), &EXPECTED_HKDF_SHA256_DERIVED_KEY);
+
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //# - The length of the output keying material MUST equal the [encryption key length](#encryption-key-length)
+    //# specified by the [algorithm suite encryption settings](#algorithm-suites-encryption-settings).
+    assert_eq!(a1.data_key.len(), AES_256_KEY_LEN);
 
     // Supporting regression checks: derivation is deterministic, is bound to the
     // message id, and produces no commitment key for V1 suites.
@@ -119,4 +172,205 @@ fn test_hkdf_derivation_process() {
         "HKDF must bind the derived key to the message id"
     );
     assert!(a1.commitment_key.is_none(), "V1 HKDF suites have no commitment key");
+}
+
+// V2 HKDF (suite 0x0478, AES-256-GCM-HKDF-SHA-512-COMMIT-KEY): the encryption key
+// MUST be HKDF-Expand(HKDF-Extract(salt=message_id, ikm=pdk), info=binary_id||"DERIVEKEY", L=32).
+// We compute the same chain with the underlying primitives directly and compare —
+// any drift in salt, ikm, info, or output length would cause a mismatch.
+#[test]
+fn test_v2_hkdf_derivation_process() {
+    let alg_suite = suite(HKDF_SHA512_COMMIT_AES_256);
+    let pdk = sample_key();
+    let message_id = [0x42u8; V2_MESSAGE_ID_LEN];
+
+    let derived = derive_keys(&message_id, &pdk, alg_suite, false).unwrap();
+
+    // Compute the expected encryption key using the same primitives the SDK uses.
+    let prk = hkdf_extract(alg_suite.kdf_digest(), &message_id, &pdk);
+    let info = [&alg_suite.binary_id[..], KEY_LABEL];
+    let mut expected_encrypt_key = vec![0u8; AES_256_KEY_LEN];
+    hkdf_expand(&prk, &info, &mut expected_encrypt_key).expect("hkdf_expand");
+
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //= reason=Re-running HKDF-Extract+Expand with salt=message_id and info=binary_id||DERIVEKEY produces the same encryption key, proving the V2 path follows the spec
+    //# If an algorithm suite uses HKDF to derive the encryption key
+    //# the AWS Encryption SDK MUST use HKDF with the following specifics:
+    assert_eq!(derived.data_key.as_slice(), expected_encrypt_key.as_slice());
+
+    let other_message_id = [0x99u8; V2_MESSAGE_ID_LEN];
+    let other_prk = hkdf_extract(alg_suite.kdf_digest(), &other_message_id, &pdk);
+    let mut wrong_salt_key = vec![0u8; AES_256_KEY_LEN];
+    hkdf_expand(&other_prk, &info, &mut wrong_salt_key).expect("hkdf_expand");
+    // Wrong-salt differential: regression-only coverage. The duvet citation for
+    // "salt MUST be the message ID" lives on the cross-message-id test below
+    // (`test_message_id_binds_derived_keys_v2`), which proves the same property
+    // through the public API rather than by re-running the underlying primitive.
+    assert_ne!(derived.data_key.as_slice(), wrong_salt_key.as_slice());
+
+    let wrong_info = [&alg_suite.binary_id[..], b"WRONGLABEL"];
+    let mut wrong_info_key = vec![0u8; AES_256_KEY_LEN];
+    hkdf_expand(&prk, &wrong_info, &mut wrong_info_key).expect("hkdf_expand");
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //= reason=The preceding assert_eq! pins info=binary_id||DERIVEKEY against an independent HKDF; this assert_ne! falsifies any other info label
+    //# - If [key commitment](#key-commitment) for the [algorithm suite encryption key derivation setting](#algorithm-suites-encryption-key-derivation-settings) is True,
+    //# then the input info MUST be a concatenation of the [algorithm suite ID](#algorithm-suite-id) followed by the string `DERIVEKEY` as UTF8 encoded bytes.
+    assert_ne!(derived.data_key.as_slice(), wrong_info_key.as_slice());
+
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //# - The length of the output keying material MUST equal the [encryption key length](#encryption-key-length)
+    //# specified by the [algorithm suite encryption settings](#algorithm-suites-encryption-settings).
+    assert_eq!(derived.data_key.len(), AES_256_KEY_LEN);
+}
+
+// V2 HKDF commit key derivation (suite 0x0478): the commit key MUST be
+// HKDF-Expand(HKDF-Extract(salt=message_id, ikm=pdk), info="COMMITKEY", L=32).
+// Using the SAME PRK as the encryption key proves the "extract once, expand twice"
+// property holds and that the commit-side info is exactly "COMMITKEY".
+#[test]
+fn test_v2_hkdf_commit_key_derivation_process() {
+    let alg_suite = suite(HKDF_SHA512_COMMIT_AES_256);
+    let pdk = sample_key();
+    let message_id = [0x42u8; V2_MESSAGE_ID_LEN];
+
+    let derived = derive_keys(&message_id, &pdk, alg_suite, false).unwrap();
+    let commit_key = derived
+        .commitment_key
+        .as_ref()
+        .expect("V2 committing suite produces a commitment key");
+
+    // Compute the expected commit key using the same primitives the SDK uses.
+    let prk = hkdf_extract(alg_suite.kdf_digest(), &message_id, &pdk);
+    let mut expected_commit_key = vec![0u8; AES_256_KEY_LEN];
+    hkdf_expand(&prk, &[COMMIT_LABEL], &mut expected_commit_key).expect("hkdf_expand");
+
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //= type=test
+    //= reason=Re-running HKDF-Extract+Expand with salt=message_id and info=COMMITKEY produces the same commit key, proving the commit derivation follows the spec
+    //# If an algorithm suite uses HKDF to derive the commitment key
+    //# the AWS Encryption SDK MUST use HKDF with the following specifics:
+    assert_eq!(commit_key.as_slice(), expected_commit_key.as_slice());
+
+    let mut wrong_info_commit_key = vec![0u8; AES_256_KEY_LEN];
+    hkdf_expand(&prk, &[b"WRONGLABEL"], &mut wrong_info_commit_key).expect("hkdf_expand");
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //= type=test
+    //= reason=The preceding assert_eq! pins info=COMMITKEY against an independent HKDF; this assert_ne! falsifies any other commit-key info label
+    //# - The input info MUST the string `COMMITKEY` as UTF8 encoded bytes by the algorithm suite commitment settings.
+    assert_ne!(commit_key.as_slice(), wrong_info_commit_key.as_slice());
+
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //= type=test
+    //# - The length of the output keying material MUST equal the [algorithm suite data length](#algorithm-suite-data-length)
+    //# specified by the [supported algorithm suites](#supported-algorithm-suites).
+    assert_eq!(commit_key.len(), AES_256_KEY_LEN);
+}
+
+// The V2 IKM-length precondition rejects a plaintext data key whose length differs
+// from the suite's KDF input length. Covers encryption-key R1.4 and commit-key R2.4
+// (both share the same length check at runtime). Calls `derive_key_v2` directly so
+// the wrapper's debug_assert (which guards the same invariant in debug builds) does
+// not preempt the runtime length check we are exercising.
+#[test]
+fn test_kdf_input_length_validation() {
+    let alg_suite = suite(HKDF_SHA512_COMMIT_AES_256);
+    let message_id = [0x42u8; V2_MESSAGE_ID_LEN];
+
+    // Suite expects 32-byte PDK; pass 31 bytes.
+    let too_short_pdk = vec![0u8; AES_256_KEY_LEN - 1];
+    let result = derive_key_v2(&message_id, &too_short_pdk, alg_suite);
+
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //# - The length of the input keying material MUST equal the [key derivation input length](#key-derivation-input-length)
+    //# specified by the [algorithm suite encryption key derivation settings](#algorithm-suites-encryption-key-derivation-settings).
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //= type=test
+    //# - The length of the input keying material MUST equal the [key derivation input length](#key-derivation-input-length)
+    //# specified by the algorithm suite commit key derivation setting.
+    let err = result.expect_err("wrong-length PDK must be rejected");
+    assert_eq!(
+        err.kind,
+        ErrorKind::ValidationError,
+        "wrong-length PDK must yield ErrorKind::ValidationError, got: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("does not match KDF input key length"),
+        "error must name the KDF input length mismatch, got: {err}"
+    );
+}
+
+// Companion to the test above. The spec is strict equality, so both sides of the
+// boundary must be rejected — a length check that only fires on `<` (or only on
+// `>`) would silently accept the other side. The duvet citation for the equality
+// requirement lives on the under-length test above; this test is regression-only
+// coverage of the over-length boundary.
+#[test]
+fn test_kdf_input_length_validation_too_long() {
+    let alg_suite = suite(HKDF_SHA512_COMMIT_AES_256);
+    let message_id = [0x42u8; V2_MESSAGE_ID_LEN];
+
+    // Suite expects 32-byte PDK; pass 33 bytes.
+    let too_long_pdk = vec![0u8; AES_256_KEY_LEN + 1];
+    let result = derive_key_v2(&message_id, &too_long_pdk, alg_suite);
+
+    let err = result.expect_err("over-length PDK must be rejected");
+    assert_eq!(
+        err.kind,
+        ErrorKind::ValidationError,
+        "over-length PDK must yield ErrorKind::ValidationError, got: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("does not match KDF input key length"),
+        "error must name the KDF input length mismatch, got: {err}"
+    );
+}
+
+// The message ID is mixed into the V2 derivation as the HKDF salt, so changing
+// only the message ID (with all other inputs held equal) must yield a different
+// encryption key AND a different commitment key. Falsifies any path that ignores
+// the message ID at extract time.
+#[test]
+fn test_message_id_binds_derived_keys_v2() {
+    let alg_suite = suite(HKDF_SHA512_COMMIT_AES_256);
+    let pdk = sample_key();
+    let message_id_a = [0x01u8; V2_MESSAGE_ID_LEN];
+    let message_id_b = [0x02u8; V2_MESSAGE_ID_LEN];
+
+    let a = derive_keys(&message_id_a, &pdk, alg_suite, false).unwrap();
+    let b = derive_keys(&message_id_b, &pdk, alg_suite, false).unwrap();
+
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //= reason=Holding pdk and suite constant, swapping the message ID changes the encryption key — proves message ID is the salt
+    //# - If salt length is defined for the [algorithm suite encryption key derivation commitment setting](#algorithm-suites-encryption-key-derivation-settings),
+    //# the salt MUST be the [message ID](../data-format/message-header.md#message-id) with a length equal to the salt length.
+    assert_ne!(a.data_key.as_slice(), b.data_key.as_slice());
+
+    let a_commit = a.commitment_key.as_ref().unwrap();
+    let b_commit = b.commitment_key.as_ref().unwrap();
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //= type=test
+    //= reason=Holding pdk and suite constant, swapping the 32-byte message ID changes the commit key — proves message ID is the 256-bit salt
+    //# - The salt MUST be the [message ID](../data-format/message-header.md#message-id) with a length of 256 bits.
+    assert_ne!(a_commit.as_slice(), b_commit.as_slice());
+}
+
+// Helper: the kdf hash on the V2 suites equals the commitment hash by construction.
+// We rely on this to compute expected vectors via the underlying primitive directly.
+trait KdfDigestExt {
+    fn kdf_digest(&self) -> aws_mpl_legacy::primitives::DigestAlg;
+}
+
+impl KdfDigestExt for AlgorithmSuite {
+    fn kdf_digest(&self) -> aws_mpl_legacy::primitives::DigestAlg {
+        match self.kdf {
+            aws_mpl_legacy::suites::DerivationAlgorithm::Hkdf(h) => h.hmac,
+            other => panic!("expected HKDF-based suite, got {other:?}"),
+        }
+    }
 }

--- a/esdk/tests/test_key_derivation.rs
+++ b/esdk/tests/test_key_derivation.rs
@@ -3,89 +3,109 @@
 
 //! Tests for spec/client-apis/encrypt.md#get-the-encryption-materials
 //! Key derivation requirements.
+//!
+//! These call `derive_keys` directly (via `__test_internals`) and assert on the
+//! derived key bytes. An encrypt/decrypt round-trip cannot prove these
+//! requirements: a wrong-but-consistent KDF on both sides still round-trips, so
+//! it shows neither which KDF was selected nor what the KDF produced.
 
-mod test_helpers;
+use aws_esdk::__test_internals::derive_keys;
+use aws_mpl_legacy::suites::{get_algorithm_suite_info, AlgorithmSuite};
 
-use aws_esdk::*;
-use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
-use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
-use test_helpers::*;
+// AES-256 data key length, required by the `derive_keys` length precondition.
+const AES_256_KEY_LEN: usize = 32;
 
-/// Encrypt then decrypt with a specific algorithm suite and commitment policy.
-async fn round_trip_with_suite(
-    plaintext: &[u8],
-    suite: EsdkAlgorithmSuiteId,
-    policy: EsdkCommitmentPolicy,
-) -> Vec<u8> {
-    let keyring = test_keyring().await;
-    let mut enc_input =
-        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
-    enc_input.algorithm_suite_id = Some(suite);
-    enc_input.commitment_policy = policy;
-    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
-    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
-    dec_input.commitment_policy = policy;
-    decrypt(&dec_input).await.unwrap().plaintext
+// AES-256 algorithm suite binary IDs (data-format wire values).
+const NO_KDF_AES_256: [u8; 2] = [0x00, 0x78];
+const HKDF_SHA256_AES_256: [u8; 2] = [0x01, 0x78];
+
+fn suite(binary_id: [u8; 2]) -> &'static AlgorithmSuite {
+    get_algorithm_suite_info(binary_id).expect("known algorithm suite id")
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_key_derivation_uses_suite_kdf() {
-    //= spec/client-apis/encrypt.md#get-the-encryption-materials
-    //= type=test
-    //# The algorithm used to derive a data key from the plaintext data key MUST be
-    //# the [key derivation algorithm](../framework/algorithm-suites.md#key-derivation-algorithm) included in the
-    //# [algorithm suite](../framework/algorithm-suites.md) defined above.
-    let pt = b"test kdf selection from suite";
-    let result = round_trip_with_suite(
-        pt,
-        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
-        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
-    )
-    .await;
-    assert_eq!(
-        result, pt,
-        "round-trip proves the correct KDF from the algorithm suite was used"
-    );
+// A deterministic 32-byte plaintext data key.
+fn sample_key() -> Vec<u8> {
+    (0u8..32).collect()
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_identity_kdf_derived_key_equals_plaintext_key() {
+// Identity KDF returns the plaintext data key unchanged (and no commitment key).
+#[test]
+fn test_identity_kdf_derived_key_equals_plaintext_key() {
+    let pdk = sample_key();
+    let message_id = [0u8; 16];
+
+    let derived = derive_keys(&message_id, &pdk, suite(NO_KDF_AES_256), false).unwrap();
+
     //= spec/client-apis/encrypt.md#get-the-encryption-materials
     //= type=test
     //# - If the key derivation algorithm is the [identity KDF](../framework/algorithm-suites.md#identity-kdf),
     //# then the derived data key MUST be the same as the plaintext data key.
+    //
     //= spec/client-apis/decrypt.md#get-the-decryption-materials
     //= type=test
     //# If the key derivation algorithm is the [identity KDF](../framework/algorithm-suites.md#identity-kdf),
     //# then the derived data key MUST be the same as the plaintext data key.
-    let pt = b"test identity kdf";
-    let result = round_trip_with_suite(
-        pt,
-        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16NoKdf,
-        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
-    )
-    .await;
-    assert_eq!(
-        result, pt,
-        "round-trip with identity KDF proves derived key equals plaintext key"
-    );
+    assert_eq!(derived.data_key.as_slice(), pdk.as_slice());
+    assert!(derived.commitment_key.is_none());
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_hkdf_derivation_process() {
+// The KDF that runs is the one named by the algorithm suite: the identity suite
+// returns the key verbatim, the HKDF suite transforms it.
+#[test]
+fn test_kdf_algorithm_is_selected_from_suite() {
+    let pdk = sample_key();
+    let message_id = [7u8; 16];
+
+    let identity = derive_keys(&message_id, &pdk, suite(NO_KDF_AES_256), false).unwrap();
+    let hkdf = derive_keys(&message_id, &pdk, suite(HKDF_SHA256_AES_256), false).unwrap();
+
     //= spec/client-apis/encrypt.md#get-the-encryption-materials
     //= type=test
+    //= reason=Identity suite returns the key verbatim while the HKDF suite transforms it, proving the KDF follows the suite
+    //# The algorithm used to derive a data key from the plaintext data key MUST be
+    //# the [key derivation algorithm](../framework/algorithm-suites.md#key-derivation-algorithm) included in the
+    //# [algorithm suite](../framework/algorithm-suites.md) defined above.
+    assert_eq!(identity.data_key.as_slice(), pdk.as_slice());
+    assert_ne!(hkdf.data_key.as_slice(), pdk.as_slice());
+}
+
+// HKDF derivation is deterministic, full-length, transforms the input key, and is
+// bound to the message id (the message id is mixed into the derivation).
+#[test]
+fn test_hkdf_derivation_process() {
+    let suite = suite(HKDF_SHA256_AES_256);
+    let pdk = sample_key();
+    let message_id_a = [1u8; 16];
+    let message_id_b = [2u8; 16];
+
+    let a1 = derive_keys(&message_id_a, &pdk, suite, false).unwrap();
+    let a2 = derive_keys(&message_id_a, &pdk, suite, false).unwrap();
+    let b = derive_keys(&message_id_b, &pdk, suite, false).unwrap();
+
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //= type=test
+    //= reason=Deterministic, full-length output that transforms the input key and varies with the message id evidences the HKDF process
     //# - If the key derivation algorithm is [HKDF](../framework/algorithm-suites.md#hkdf),
     //# the derivation process used MUST be the process described in [HKDF Encryption Key](../transitive-requirements.md#hkdf-encryption-key).
-    let pt = b"test hkdf derivation";
-    let result = round_trip_with_suite(
-        pt,
-        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
-        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
-    )
-    .await;
     assert_eq!(
-        result, pt,
-        "round-trip with HKDF suite proves correct HKDF derivation process"
+        a1.data_key.as_slice(),
+        a2.data_key.as_slice(),
+        "HKDF derivation must be deterministic"
     );
+    assert_eq!(
+        a1.data_key.len(),
+        AES_256_KEY_LEN,
+        "derived key must be the suite's key length"
+    );
+    assert_ne!(
+        a1.data_key.as_slice(),
+        pdk.as_slice(),
+        "HKDF must transform the plaintext data key"
+    );
+    assert_ne!(
+        a1.data_key.as_slice(),
+        b.data_key.as_slice(),
+        "HKDF must bind the derived key to the message id"
+    );
+    assert!(a1.commitment_key.is_none(), "V1 HKDF suites have no commitment key");
 }

--- a/esdk/tests/test_key_derivation.rs
+++ b/esdk/tests/test_key_derivation.rs
@@ -67,10 +67,12 @@ fn test_identity_kdf_derived_key_equals_plaintext_key() {
 }
 
 // The KDF that runs is the one named by the algorithm suite: the identity suite
-// returns the key verbatim, the HKDF suite transforms it. A second HKDF suite
-// that differs only in hash function (SHA-256 vs SHA-384) makes the hash-selection
-// requirement falsifiable — a hard-coded SHA-256 implementation would produce
-// identical bytes for both HKDF suites.
+// returns the key verbatim, the HKDF suite transforms it. The second HKDF suite
+// (SHA-384) is a supporting regression check that a *different* HKDF suite yields
+// different bytes; it does NOT isolate the hash function, because the two suites
+// also differ in their binary ID, which is mixed into the HKDF info. The
+// hash-function-from-suite requirement is proven falsifiably by the independent
+// SHA-256 known-answer vector in `test_hkdf_derivation_process`.
 #[test]
 fn test_kdf_algorithm_is_selected_from_suite() {
     let pdk = sample_key();
@@ -90,10 +92,10 @@ fn test_kdf_algorithm_is_selected_from_suite() {
     assert_eq!(identity.data_key.as_slice(), pdk.as_slice());
     assert_ne!(hkdf_sha256.data_key.as_slice(), pdk.as_slice());
 
-    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
-    //= type=test
-    //= reason=Two HKDF suites that differ only in hash (SHA-256 vs SHA-384) over the same pdk and message id produce different derived keys; a hard-coded hash would yield identical bytes
-    //# - The hash function MUST be specified by the [algorithm suite key derivation settings](#algorithm-suites-encryption-key-derivation-settings).
+    // Supporting regression check: a different HKDF suite produces different bytes.
+    // This does not isolate the hash function (the suites also differ in binary ID,
+    // which is part of the HKDF info); the hash-from-suite requirement is proven by
+    // the known-answer vector in `test_hkdf_derivation_process`.
     assert_ne!(hkdf_sha256.data_key.as_slice(), hkdf_sha384.data_key.as_slice());
 }
 
@@ -138,6 +140,11 @@ fn test_hkdf_derivation_process() {
     //= reason=Derived key matches an independent OpenSSL HKDF-SHA256 computation over the same salt, ikm, and info
     //# - If the key derivation algorithm is [HKDF](../framework/algorithm-suites.md#hkdf),
     //# the derivation process used MUST be the process described in [HKDF Encryption Key](./key-derivation.md#hkdf-encryption-key).
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //= reason=The expected vector was computed with HKDF-SHA-256; no other hash would produce these bytes, proving the hash is taken from the suite
+    //# - The hash function MUST be specified by the [algorithm suite key derivation settings](#algorithm-suites-encryption-key-derivation-settings).
     //
     //= spec/client-apis/key-derivation.md#hkdf-encryption-key
     //= type=test
@@ -214,7 +221,7 @@ fn test_v2_hkdf_derivation_process() {
     hkdf_expand(&prk, &wrong_info, &mut wrong_info_key).expect("hkdf_expand");
     //= spec/client-apis/key-derivation.md#hkdf-encryption-key
     //= type=test
-    //= reason=The preceding assert_eq! pins info=binary_id||DERIVEKEY against an independent HKDF; this assert_ne! falsifies any other info label
+    //= reason=The preceding assert_eq! pins info=binary_id||DERIVEKEY against a recomputation with the underlying HKDF primitive; this assert_ne! falsifies any other info label
     //# - If [key commitment](#key-commitment) for the [algorithm suite encryption key derivation setting](#algorithm-suites-encryption-key-derivation-settings) is True,
     //# then the input info MUST be a concatenation of the [algorithm suite ID](#algorithm-suite-id) followed by the string `DERIVEKEY` as UTF8 encoded bytes.
     assert_ne!(derived.data_key.as_slice(), wrong_info_key.as_slice());
@@ -258,7 +265,7 @@ fn test_v2_hkdf_commit_key_derivation_process() {
     hkdf_expand(&prk, &[b"WRONGLABEL"], &mut wrong_info_commit_key).expect("hkdf_expand");
     //= spec/client-apis/key-derivation.md#hkdf-commit-key
     //= type=test
-    //= reason=The preceding assert_eq! pins info=COMMITKEY against an independent HKDF; this assert_ne! falsifies any other commit-key info label
+    //= reason=The preceding assert_eq! pins info=COMMITKEY against a recomputation with the underlying HKDF primitive; this assert_ne! falsifies any other commit-key info label
     //# - The input info MUST the string `COMMITKEY` as UTF8 encoded bytes by the algorithm suite commitment settings.
     assert_ne!(commit_key.as_slice(), wrong_info_commit_key.as_slice());
 
@@ -346,7 +353,7 @@ fn test_message_id_binds_derived_keys_v2() {
 
     //= spec/client-apis/key-derivation.md#hkdf-encryption-key
     //= type=test
-    //= reason=Holding pdk and suite constant, swapping the message ID changes the encryption key — proves message ID is the salt
+    //= reason=Swapping only the message ID changes the encryption key — proves the message ID is an input to derivation (its salt role is shown by the recomputation test above)
     //# - If salt length is defined for the [algorithm suite encryption key derivation commitment setting](#algorithm-suites-encryption-key-derivation-settings),
     //# the salt MUST be the [message ID](../data-format/message-header.md#message-id) with a length equal to the salt length.
     assert_ne!(a.data_key.as_slice(), b.data_key.as_slice());
@@ -355,7 +362,7 @@ fn test_message_id_binds_derived_keys_v2() {
     let b_commit = b.commitment_key.as_ref().unwrap();
     //= spec/client-apis/key-derivation.md#hkdf-commit-key
     //= type=test
-    //= reason=Holding pdk and suite constant, swapping the 32-byte message ID changes the commit key — proves message ID is the 256-bit salt
+    //= reason=Swapping only the 32-byte message ID changes the commit key — proves the message ID is an input to commit derivation
     //# - The salt MUST be the [message ID](../data-format/message-header.md#message-id) with a length of 256 bits.
     assert_ne!(a_commit.as_slice(), b_commit.as_slice());
 }

--- a/esdk/tests/test_key_derivation.rs
+++ b/esdk/tests/test_key_derivation.rs
@@ -23,9 +23,11 @@ fn suite(binary_id: [u8; 2]) -> &'static AlgorithmSuite {
     get_algorithm_suite_info(binary_id).expect("known algorithm suite id")
 }
 
-// A deterministic 32-byte plaintext data key.
+// A deterministic plaintext data key of the AES-256 key length.
 fn sample_key() -> Vec<u8> {
-    (0u8..32).collect()
+    (0..AES_256_KEY_LEN)
+        .map(|i| u8::try_from(i).expect("index fits in u8"))
+        .collect()
 }
 
 // Identity KDF returns the plaintext data key unchanged (and no commitment key).

--- a/esdk/tests/test_key_derivation.rs
+++ b/esdk/tests/test_key_derivation.rs
@@ -1,0 +1,91 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for spec/client-apis/encrypt.md#get-the-encryption-materials
+//! Key derivation requirements.
+
+mod test_helpers;
+
+use aws_esdk::*;
+use aws_mpl_legacy::commitment::EsdkCommitmentPolicy;
+use aws_mpl_legacy::suites::EsdkAlgorithmSuiteId;
+use test_helpers::*;
+
+/// Encrypt then decrypt with a specific algorithm suite and commitment policy.
+async fn round_trip_with_suite(
+    plaintext: &[u8],
+    suite: EsdkAlgorithmSuiteId,
+    policy: EsdkCommitmentPolicy,
+) -> Vec<u8> {
+    let keyring = test_keyring().await;
+    let mut enc_input =
+        EncryptInput::with_legacy_keyring(plaintext, EncryptionContext::new(), keyring.clone());
+    enc_input.algorithm_suite_id = Some(suite);
+    enc_input.commitment_policy = policy;
+    let ct = encrypt(&enc_input).await.unwrap().ciphertext;
+    let mut dec_input = DecryptInput::with_legacy_keyring(&ct, EncryptionContext::new(), keyring);
+    dec_input.commitment_policy = policy;
+    decrypt(&dec_input).await.unwrap().plaintext
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_key_derivation_uses_suite_kdf() {
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //= type=test
+    //# The algorithm used to derive a data key from the plaintext data key MUST be
+    //# the [key derivation algorithm](../framework/algorithm-suites.md#key-derivation-algorithm) included in the
+    //# [algorithm suite](../framework/algorithm-suites.md) defined above.
+    let pt = b"test kdf selection from suite";
+    let result = round_trip_with_suite(
+        pt,
+        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
+        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
+    )
+    .await;
+    assert_eq!(
+        result, pt,
+        "round-trip proves the correct KDF from the algorithm suite was used"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_identity_kdf_derived_key_equals_plaintext_key() {
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //= type=test
+    //# - If the key derivation algorithm is the [identity KDF](../framework/algorithm-suites.md#identity-kdf),
+    //# then the derived data key MUST be the same as the plaintext data key.
+    //= spec/client-apis/decrypt.md#get-the-decryption-materials
+    //= type=test
+    //# If the key derivation algorithm is the [identity KDF](../framework/algorithm-suites.md#identity-kdf),
+    //# then the derived data key MUST be the same as the plaintext data key.
+    let pt = b"test identity kdf";
+    let result = round_trip_with_suite(
+        pt,
+        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16NoKdf,
+        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
+    )
+    .await;
+    assert_eq!(
+        result, pt,
+        "round-trip with identity KDF proves derived key equals plaintext key"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_hkdf_derivation_process() {
+    //= spec/client-apis/encrypt.md#get-the-encryption-materials
+    //= type=test
+    //# - If the key derivation algorithm is [HKDF](../framework/algorithm-suites.md#hkdf),
+    //# the derivation process used MUST be the process described in [HKDF Encryption Key](../transitive-requirements.md#hkdf-encryption-key).
+    let pt = b"test hkdf derivation";
+    let result = round_trip_with_suite(
+        pt,
+        EsdkAlgorithmSuiteId::AlgAes256GcmIv12Tag16HkdfSha256,
+        EsdkCommitmentPolicy::ForbidEncryptAllowDecrypt,
+    )
+    .await;
+    assert_eq!(
+        result, pt,
+        "round-trip with HKDF suite proves correct HKDF derivation process"
+    );
+}

--- a/esdk/tests/test_key_derivation.rs
+++ b/esdk/tests/test_key_derivation.rs
@@ -2,12 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tests for spec/client-apis/encrypt.md#get-the-encryption-materials
-//! Key derivation requirements.
-//!
-//! These call `derive_keys` directly (via `__test_internals`) and assert on the
-//! derived key bytes. An encrypt/decrypt round-trip cannot prove these
-//! requirements: a wrong-but-consistent KDF on both sides still round-trips, so
-//! it shows neither which KDF was selected nor what the KDF produced.
 
 mod fixtures;
 mod test_helpers;
@@ -32,6 +26,9 @@ fn sample_key() -> Vec<u8> {
         .map(|i| u8::try_from(i).expect("index fits in u8"))
         .collect()
 }
+
+// These call `derive_keys` directly so the assertions observe the derived bytes; a
+// round-trip can't prove which KDF ran or what it produced (both sides would agree).
 
 // Identity KDF returns the plaintext data key unchanged (and no commitment key).
 #[test]

--- a/esdk/tests/test_key_derivation.rs
+++ b/esdk/tests/test_key_derivation.rs
@@ -337,6 +337,41 @@ fn test_kdf_input_length_validation_too_long() {
     );
 }
 
+// A V2 message ID that is not exactly 256 bits (32 bytes) must be rejected: it is
+// used verbatim as the HKDF salt, so a wrong length would otherwise HKDF-extract
+// cleanly and silently derive the wrong keys. Calls `derive_key_v2` directly so the
+// wrapper's debug_assert does not preempt the runtime check.
+#[test]
+fn test_v2_message_id_length_validation() {
+    let alg_suite = suite(HKDF_SHA512_COMMIT_AES_256);
+    let pdk = sample_key();
+
+    // Suite expects a 32-byte (256-bit) message ID; pass 31 bytes.
+    let short_message_id = [0x42u8; V2_MESSAGE_ID_LEN - 1];
+    let result = derive_key_v2(&short_message_id, &pdk, alg_suite);
+
+    //= spec/client-apis/key-derivation.md#hkdf-encryption-key
+    //= type=test
+    //= reason=A message ID that is not the suite salt length is rejected, enforcing the salt-length requirement
+    //# - If salt length is defined for the [algorithm suite encryption key derivation commitment setting](#algorithm-suites-encryption-key-derivation-settings),
+    //# the salt MUST be the [message ID](../data-format/message-header.md#message-id) with a length equal to the salt length.
+    //
+    //= spec/client-apis/key-derivation.md#hkdf-commit-key
+    //= type=test
+    //= reason=A message ID that is not 256 bits is rejected, enforcing the commit-key salt length
+    //# - The salt MUST be the [message ID](../data-format/message-header.md#message-id) with a length of 256 bits.
+    let err = result.expect_err("wrong-length V2 message ID must be rejected");
+    assert_eq!(
+        err.kind,
+        ErrorKind::ValidationError,
+        "wrong-length message ID must yield ErrorKind::ValidationError, got: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("message ID"),
+        "error must name the message ID length problem, got: {err}"
+    );
+}
+
 // The message ID is mixed into the V2 derivation as the HKDF salt, so changing
 // only the message ID (with all other inputs held equal) must yield a different
 // encryption key AND a different commitment key. Falsifies any path that ignores


### PR DESCRIPTION
Adds the shared materials structures and key derivation logic for the native Rust ESDK implementation. These are used by both encrypt and decrypt; their primary specs live in `framework/` (algorithm suites, structures), which is outside the ESDK review scope, so they are grouped here as miscellaneous PR M1.

## Scope

Source:
- `esdk/src/materials.rs`
- `esdk/src/key_derivation.rs`

Tests:
- `esdk/tests/test_key_derivation.rs`

## Notes

CI does not run on this PR. This branch is scoped for focused review and intentionally omits test helpers, scaffolding, and other supporting code. Full code with helpers and working tests lives on the [`aws-crypto-rust/unreviewed`](https://github.com/aws/aws-encryption-sdk/tree/aws-crypto-rust/unreviewed) branch.

## Spec

- [`framework/algorithm-suites.md`](https://github.com/awslabs/aws-encryption-sdk-specification/blob/update-more-data-format/framework/algorithm-suites.md) (key derivation)
- [`framework/structures.md`](https://github.com/awslabs/aws-encryption-sdk-specification/blob/update-more-data-format/framework/structures.md) (materials)