### PR TITLE
ci(rust): publish to crates.io via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -13,9 +13,14 @@
 # BEFORE the PR is merged, so a failed publish or failed smoke test
 # leaves the unmerged PR for cleanup.
 #
-# Authenticates to crates.io with a long-lived API token issued under the
-# Crypto Tools CI bot account, stored in the CARGO_REGISTRY_TOKEN repo
-# secret and gated by the `crates-io-publish` GitHub environment.
+# Authenticates to crates.io via Trusted Publishing (OIDC): the
+# `rust-lang/crates-io-auth-action` step exchanges the workflow's GitHub
+# OIDC token for a short-lived crates.io token (automatically revoked
+# when the job ends), gated by the `crates-io-publish` GitHub
+# environment. No long-lived crates.io API token is stored in the repo.
+# crates.io must be configured with a Trusted Publisher for this crate
+# pointing at this repo, the `rust-release.yml` workflow, and the
+# `crates-io-publish` environment.
 name: Rust Release
 
 on:
@@ -79,11 +84,15 @@ jobs:
         working-directory: releases/rust/esdk
         run: cargo publish --dry-run
 
+      - name: Authenticate to crates.io (Trusted Publishing / OIDC)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Cargo publish
         shell: bash
         working-directory: releases/rust/esdk
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish
 
       - name: Configure AWS Credentials for test_published.sh

--- a/AwsEncryptionSDK/runtimes/rust/Cargo.toml
+++ b/AwsEncryptionSDK/runtimes/rust/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [dependencies]
 aws-config = "1.8.12"
 aws-lc-rs = {version = "1.17.0"}
-aws-lc-sys = { version = "0.41", optional = true }
+aws-lc-sys = { version = "0.42", optional = true }
 aws-lc-fips-sys = { version = "0.13.1", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Switch the Rust release workflow's `cargo publish` step from the long-lived `CARGO_REGISTRY_TOKEN` secret to crates.io Trusted Publishing (OIDC) via `rust-lang/crates-io-auth-action`.

Prerequisite: a crates.io Trusted Publisher must be configured for `aws-esdk` (this repo + `rust-release.yml` + `crates-io-publish` environment) before the next release; the `CARGO_REGISTRY_TOKEN` repo secret can be removed once an OIDC release is validated.

_Squash/merge commit message, if applicable:_ `ci(rust): publish to crates.io via Trusted Publishing (OIDC)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.