### PR TITLE
fix(CI): surface ESDK Java perf benchmark failures and tolerate shared config keys

### DIFF
--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/performance-benchmarks.yml"
+      # TEMP (DO NOT MERGE): run on PRs touching benchmark sources to validate
+      # the CloudWatch dashboard updates. Revert before merging.
+      - "esdk-performance-testing/**"
   schedule:
     - cron: "00 09 * * *"
 

--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     paths:
       - ".github/workflows/performance-benchmarks.yml"
-      # TEMP (DO NOT MERGE): run on PRs touching benchmark sources to validate
-      # the CloudWatch dashboard updates. Revert before merging.
-      - "esdk-performance-testing/**"
   schedule:
     - cron: "00 09 * * *"
 

--- a/esdk-performance-testing/benchmarks/java/src/main/java/com/amazon/esdk/benchmark/Program.java
+++ b/esdk-performance-testing/benchmarks/java/src/main/java/com/amazon/esdk/benchmark/Program.java
@@ -30,7 +30,9 @@ public final class Program {
       );
       printSummary(results, options.outputPath());
     } catch (final Exception ex) {
-      System.out.println("Benchmark failed: " + ex.getMessage());
+      System.err.println("Benchmark failed: " + ex.getMessage());
+      ex.printStackTrace();
+      System.exit(1);
     }
   }
 

--- a/esdk-performance-testing/benchmarks/java/src/main/java/com/amazon/esdk/benchmark/model/Config.java
+++ b/esdk-performance-testing/benchmarks/java/src/main/java/com/amazon/esdk/benchmark/model/Config.java
@@ -3,6 +3,7 @@
 
 package com.amazon.esdk.benchmark.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -13,6 +14,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// Other languages share this config file and add keys Java doesn't model.
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class Config {
 
   private static final Logger logger = LoggerFactory.getLogger(Config.class);


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Make the Java performance benchmark fail loudly (stack trace + non-zero exit) instead of swallowing exceptions, and let its config loader ignore unknown keys in the shared `test-scenarios.yaml`.

*Squash/merge commit message, if applicable:*

fix: surface ESDK Java perf benchmark failures and tolerate shared config keys

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.