### PR TITLE
Prevent script injection in GitHub Actions workflows

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -64,9 +64,12 @@ jobs:
 
       - name: Get release directory name
         id: release-dir
+        env:
+          PROJECT_NAME: ${{ github.event.inputs.project-name }}
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           chmod +x mpl/scripts/go-release-automation.sh
-          RELEASE_DIR_NAME=$(mpl/scripts/go-release-automation.sh get_release_dir_name "${{ github.event.inputs.project-name }}" "${{ github.event.inputs.version }}")
+          RELEASE_DIR_NAME=$(mpl/scripts/go-release-automation.sh get_release_dir_name "$PROJECT_NAME" "$VERSION")
           echo "releaseDirName=$RELEASE_DIR_NAME" >> $GITHUB_OUTPUT
 
       - name: Generate a changelog
@@ -76,13 +79,17 @@ jobs:
           args: --bump -u --prepend releases/go/${{ steps.release-dir.outputs.releaseDirName }}/CHANGELOG.md
 
       - name: Run Go release automation script
+        env:
+          PROJECT_NAME: ${{ github.event.inputs.project-name }}
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           chmod +x mpl/scripts/go-release-automation.sh
-          mpl/scripts/go-release-automation.sh run_release_script ${{ github.event.inputs.project-name }} ${{ github.event.inputs.version }}
+          mpl/scripts/go-release-automation.sh run_release_script "$PROJECT_NAME" "$VERSION"
 
       - name: print diff between development and release directory
+        env:
+          RELEASE_DIR_NAME: ${{ steps.release-dir.outputs.releaseDirName }}
+          PROJECT_NAME: ${{ github.event.inputs.project-name }}
         run: |
-          RELEASE_DIR_NAME="${{ steps.release-dir.outputs.releaseDirName }}"
-          PROJECT_NAME="${{ github.event.inputs.project-name }}"
-          DIFF_FILES=$(diff -qr $PROJECT_NAME/runtimes/go/ImplementationFromDafny-go releases/go/$RELEASE_DIR_NAME || true)
-          echo $DIFF_FILES
+          DIFF_FILES=$(diff -qr "$PROJECT_NAME/runtimes/go/ImplementationFromDafny-go" "releases/go/$RELEASE_DIR_NAME" || true)
+          echo "$DIFF_FILES"

--- a/.github/workflows/smithy-diff.yml
+++ b/.github/workflows/smithy-diff.yml
@@ -33,9 +33,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILES: ${{ steps.file-changes.outputs.FILES }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
         if: ${{env.FILES != ''}}
         run: |
           # TODO: If https://github.com/smithy-lang/smithy-dafny/issues/491 is resolved, remove comment about this issue.
-          COMMENT="@${{github.event.pull_request.user.login}} and @${{github.actor}}, I noticed you are updating the smithy model files.\nDoes this update need new or updated javadoc trait documentation?\n Are you adding constraints inside list, map or union? Do you know about this issue: https://github.com/smithy-lang/smithy-dafny/issues/491?"
-          COMMENT_URL="https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
-          curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST $COMMENT_URL -d "{\"body\":\"$COMMENT\"}"
+          COMMENT="@${PR_USER} and @${ACTOR}, I noticed you are updating the smithy model files.\nDoes this update need new or updated javadoc trait documentation?\n Are you adding constraints inside list, map or union? Do you know about this issue: https://github.com/smithy-lang/smithy-dafny/issues/491?"
+          COMMENT_URL="https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments"
+          curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST "$COMMENT_URL" -d "{\"body\":\"$COMMENT\"}"


### PR DESCRIPTION
## Summary
Fixes a **script injection in GitHub Actions workflows** finding. Untrusted, user-controlled GitHub context values were interpolated directly into inline `run:` shell scripts, allowing command injection on the runner. Each such value is now bound to an intermediate `env:` variable and referenced as a properly quoted shell variable (data, not script text) — the mitigation recommended by GitHub's hardening guide.

### Changes
- **`.github/workflows/go-release.yml`** — move `github.event.inputs.project-name` / `version` into `env:` in the `Get release directory name`, `Run Go release automation script`, and `print diff` steps; quote all shell references.
- **`.github/workflows/smithy-diff.yml`** — move `github.event.pull_request.user.login`, `github.actor`, and `github.repository` into `env:` in the comment step.

### Testing
- Verified both files parse as valid YAML.
- Confirmed no `github.event.*` / `github.actor` interpolation remains inside any `run:` block (all remaining references are within `env:` blocks).

sim: https://t.corp.amazon.com/V2263272257
